### PR TITLE
Fix Codespaces setup: remove corrupted go.sum, use go mod tidy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "me.yaml",
+  "name": "Me.yaml",
   "image": "mcr.microsoft.com/devcontainers/go:1.22",
 
   "features": {
@@ -26,7 +26,7 @@
   "forwardPorts": [5173, 8090],
   "portsAttributes": {
     "5173": {
-      "label": "me.yaml (Frontend)",
+      "label": "Me.yaml (Frontend)",
       "onAutoForward": "openBrowser"
     },
     "8090": {
@@ -35,7 +35,7 @@
     }
   },
 
-  "postCreateCommand": "cd frontend && npm install && cd ../backend && go mod download",
+  "postCreateCommand": "cd frontend && npm install && cd ../backend && go mod tidy",
   "postStartCommand": "chmod +x scripts/start-dev.sh && scripts/start-dev.sh",
 
   "remoteUser": "vscode"

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,4 +1,0 @@
-github.com/pocketbase/pocketbase v0.23.4 h1:Example==
-github.com/pocketbase/pocketbase v0.23.4/go.mod h1:Example==
-golang.org/x/crypto v0.28.0 h1:Example==
-golang.org/x/crypto v0.28.0/go.mod h1:Example==


### PR DESCRIPTION
- Remove go.sum with placeholder checksums (will be regenerated)
- Change postCreateCommand to use 'go mod tidy' instead of 'go mod download'
- Fix branding in devcontainer.json (Me.yaml)