### PR TITLE
Fix PocketBase v0.23.4 API breaking changes

### DIFF
--- a/backend/hooks/ai.go
+++ b/backend/hooks/ai.go
@@ -8,6 +8,7 @@ import (
 	"ownprofile/services"
 
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -62,7 +63,7 @@ func RegisterAIHooks(app *pocketbase.PocketBase, ai *services.AIService, crypto 
 			return e.JSON(http.StatusOK, map[string]interface{}{
 				"success": true,
 			})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		// Enrich project content with AI
 		se.Router.POST("/api/ai/enrich", func(e *core.RequestEvent) error {
@@ -127,7 +128,7 @@ func RegisterAIHooks(app *pocketbase.PocketBase, ai *services.AIService, crypto 
 			}
 
 			return e.JSON(http.StatusOK, result)
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		return se.Next()
 	})

--- a/backend/hooks/auth.go
+++ b/backend/hooks/auth.go
@@ -67,14 +67,3 @@ type AdminDeniedError struct {
 func (e *AdminDeniedError) Error() string {
 	return e.Message
 }
-
-// RequireAuth returns a middleware that requires authentication
-func RequireAuth(app *pocketbase.PocketBase) func(e *core.RequestEvent) error {
-	return func(e *core.RequestEvent) error {
-		info, _ := e.RequestInfo()
-		if info != nil && info.Auth != nil {
-			e.Auth = info.Auth
-		}
-		return e.Next()
-	}
-}

--- a/backend/hooks/github.go
+++ b/backend/hooks/github.go
@@ -9,6 +9,7 @@ import (
 	"ownprofile/services"
 
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -44,7 +45,7 @@ func RegisterGitHubHooks(app *pocketbase.PocketBase, github *services.GitHubServ
 			}
 
 			return e.JSON(http.StatusOK, metadata)
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		// Import a GitHub repo as a project
 		se.Router.POST("/api/github/import", func(e *core.RequestEvent) error {
@@ -195,7 +196,7 @@ func RegisterGitHubHooks(app *pocketbase.PocketBase, github *services.GitHubServ
 				"ai_enriched": aiResult != nil,
 				"metadata":    metadata,
 			})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		// Refresh an existing source
 		se.Router.POST("/api/github/refresh/{id}", func(e *core.RequestEvent) error {
@@ -281,7 +282,7 @@ func RegisterGitHubHooks(app *pocketbase.PocketBase, github *services.GitHubServ
 				"diff":        diff,
 				"proposed":    proposedData,
 			})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		return se.Next()
 	})

--- a/backend/hooks/password.go
+++ b/backend/hooks/password.go
@@ -7,6 +7,7 @@ import (
 	"ownprofile/services"
 
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -93,7 +94,7 @@ func RegisterPasswordHooks(app *pocketbase.PocketBase, crypto *services.CryptoSe
 			}
 
 			return e.JSON(http.StatusOK, map[string]string{"status": "password set"})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		return se.Next()
 	})

--- a/backend/hooks/share.go
+++ b/backend/hooks/share.go
@@ -7,6 +7,7 @@ import (
 	"ownprofile/services"
 
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -162,7 +163,7 @@ func RegisterShareHooks(app *pocketbase.PocketBase, share *services.ShareService
 				"token": rawToken, // Only returned once!
 				"name":  req.Name,
 			})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		// Revoke a share token
 		se.Router.POST("/api/share/revoke/{id}", func(e *core.RequestEvent) error {
@@ -182,7 +183,7 @@ func RegisterShareHooks(app *pocketbase.PocketBase, share *services.ShareService
 			}
 
 			return e.JSON(http.StatusOK, map[string]string{"status": "revoked"})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		return se.Next()
 	})

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -268,7 +269,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase) {
 				"project_id": project.Id,
 				"status":     "applied",
 			})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		// Reject import proposal
 		se.Router.POST("/api/proposals/{id}/reject", func(e *core.RequestEvent) error {
@@ -286,7 +287,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase) {
 			app.Save(proposal)
 
 			return e.JSON(http.StatusOK, map[string]string{"status": "rejected"})
-		}).Bind(RequireAuth(app))
+		}).Bind(apis.RequireAuth())
 
 		return se.Next()
 	})


### PR DESCRIPTION
Update all hooks to use apis.RequireAuth() instead of custom RequireAuth(app). PocketBase v0.23 changed the middleware binding API - RequireAuth() now returns a *hook.Handler directly rather than a function.

Changes:
- Replace RequireAuth(app) with apis.RequireAuth() in all hook files
- Add github.com/pocketbase/pocketbase/apis import where needed
- Remove obsolete RequireAuth helper function from auth.go