### PR TITLE
Fix Dockerfile to handle missing go.sum

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,9 @@ FROM mcr.microsoft.com/devcontainers/go:1.23
 
 # Pre-download Go modules for faster startup
 WORKDIR /tmp/go-cache
-COPY backend/go.mod backend/go.sum ./
-RUN go mod download
+COPY backend/go.mod ./
+COPY backend/go.sum* ./
+RUN go mod download || true
 
 # Reset working directory
 WORKDIR /workspaces


### PR DESCRIPTION
Use wildcard pattern for go.sum COPY to make it optional since go.sum may not exist in the repo initially. Added fallback for go mod download in case of incomplete dependency resolution.