### PR TITLE
Fix Go module cache permissions for vscode user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,5 +6,8 @@ COPY backend/go.mod ./
 COPY backend/go.sum* ./
 RUN go mod download || true
 
+# Fix permissions so vscode user can use the module cache
+RUN chmod -R 777 /go/pkg/mod/cache || true
+
 # Reset working directory
 WORKDIR /workspaces


### PR DESCRIPTION
The module cache created during docker build was owned by root, preventing the vscode user from writing to it during postCreateCommand.