### PR TITLE
Add go mod tidy to postCreateCommand for complete go.sum

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,7 @@
     }
   },
 
-  "postCreateCommand": "chmod +x scripts/*.sh",
+  "postCreateCommand": "chmod +x scripts/*.sh && cd backend && go mod tidy",
   "postStartCommand": "./scripts/start-dev.sh",
 
   "remoteUser": "vscode"


### PR DESCRIPTION
The go.sum file in the repo only contains .mod hashes, not the full dependency tree. Adding `go mod tidy` to postCreateCommand ensures:
1. All dependencies are downloaded on first container creation
2. Complete go.sum is generated for subsequent builds
3. postStartCommand can then build without missing module errors

This runs only once on container creation, not on every restart.