### PR TITLE
Use go mod tidy instead of go mod download in dev script

### DIFF
--- a/scripts/dev-backend.sh
+++ b/scripts/dev-backend.sh
@@ -61,16 +61,18 @@ needs_download() {
 echo "[backend] Checking Go modules..."
 
 if reason=$(needs_download); then
-    echo "[backend] Downloading modules ($reason)..."
+    echo "[backend] Updating modules ($reason)..."
     cd "$BACKEND_DIR"
-    go mod download
+    # Use go mod tidy to ensure go.sum is complete (not just go mod download)
+    # This fixes "missing go.sum entry" errors when go.sum is incomplete
+    go mod tidy
     cd "$PROJECT_ROOT"
 
-    # Save hash after successful download
+    # Save hash after successful update
     get_gomod_hash > "$HASH_FILE"
-    echo "[backend] Modules downloaded and hash cached"
+    echo "[backend] Modules updated and hash cached"
 else
-    echo "[backend] Modules up to date (skipping go mod download)"
+    echo "[backend] Modules up to date (skipping go mod tidy)"
 fi
 
 # Check if air is available


### PR DESCRIPTION
go mod download only downloads modules but doesn't update go.sum with missing entries. Using go mod tidy ensures go.sum is complete, fixing "missing go.sum entry" build errors.

This runs on first startup or when go.mod/go.sum changes, with hash-based caching to skip on subsequent restarts.