### PR TITLE
Create Me.yaml self-hosted profile system

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,10 @@
     }
   },
 
+  "containerEnv": {
+    "ENCRYPTION_KEY": "devcontainer-only-key-do-not-use-in-production!!"
+  },
+
   "mounts": [
     "source=meyaml-node-modules,target=${containerWorkspaceFolder}/frontend/node_modules,type=volume",
     "source=meyaml-go-cache,target=/go/pkg/mod,type=volume"

--- a/backend/hooks/seed.go
+++ b/backend/hooks/seed.go
@@ -36,9 +36,9 @@ func seedDemoData(app *pocketbase.PocketBase) error {
 	log.Println("Seeding demo data...")
 
 	// Create PocketBase superuser for /_/ admin access (dev mode only)
-	superusers := app.SuperusersCollection()
-	if superusers != nil {
-		superuserCount, _ := app.CountRecords(superusers.Name)
+	superusers, err := app.FindCollectionByNameOrId(core.CollectionNameSuperusers)
+	if err == nil && superusers != nil {
+		superuserCount, _ := app.CountRecords(core.CollectionNameSuperusers)
 		if superuserCount == 0 {
 			su := core.NewRecord(superusers)
 			su.SetEmail("admin@localhost.dev")

--- a/backend/main.go
+++ b/backend/main.go
@@ -20,8 +20,13 @@ func main() {
 	// Initialize services
 	encryptionKey := os.Getenv("ENCRYPTION_KEY")
 	if encryptionKey == "" {
-		log.Println("WARNING: ENCRYPTION_KEY not set. API tokens will not be encrypted properly.")
-		encryptionKey = "default-dev-key-change-in-prod!!" // 32 bytes for dev
+		log.Fatal("FATAL: ENCRYPTION_KEY environment variable is required.\n" +
+			"This key is used to encrypt sensitive data (API tokens, credentials).\n" +
+			"Generate one with: openssl rand -hex 32")
+	}
+	if len(encryptionKey) < 32 {
+		log.Fatal("FATAL: ENCRYPTION_KEY must be at least 32 characters.\n" +
+			"Generate one with: openssl rand -hex 32")
 	}
 
 	cryptoService := services.NewCryptoService(encryptionKey)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,9 @@ services:
       - "8090:8090"
     environment:
       - DATA_DIR=/app/pb_data
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-dev-only-key-change-in-production}
+      # DEV ONLY: This key is for local development. Never use in production.
+      # Production requires a unique key: openssl rand -hex 32
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-dev-only-key-do-not-use-in-production!!}
       - SEED_DATA=true
       - LOG_LEVEL=debug
     command: /app/scripts/dev-backend.sh


### PR DESCRIPTION
- Remove dangerous dev fallback for ENCRYPTION_KEY
- Application now fails hard if key is missing or <32 chars
- Dev environments get key via docker-compose.dev.yml and devcontainer.json
- Fix PocketBase v0.23 API: SuperusersCollection() → FindCollectionByNameOrId()

This prevents production deployments from accidentally running with the known dev key, which would make all encrypted secrets (API tokens, credentials) vulnerable.