### PR TITLE
Implement JWT-based password-protected view access

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -47,7 +47,7 @@ func main() {
 	hooks.RegisterAIHooks(app, aiService, cryptoService)
 	hooks.RegisterShareHooks(app, shareService, cryptoService)
 	hooks.RegisterPasswordHooks(app, cryptoService)
-	hooks.RegisterViewHooks(app)
+	hooks.RegisterViewHooks(app, cryptoService)
 	hooks.RegisterSeedHook(app)
 
 	// Note: Trusted proxy headers are handled by Caddy in the Docker setup.

--- a/backend/services/crypto.go
+++ b/backend/services/crypto.go
@@ -10,24 +10,41 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// JWT constants
+const (
+	JWTIssuer   = "me.yaml"
+	JWTAudience = "view-access"
+)
+
+// ViewAccessClaims represents the JWT claims for password-protected view access
+type ViewAccessClaims struct {
+	ViewID string `json:"vid"`
+	jwt.RegisteredClaims
+}
 
 // CryptoService handles encryption/decryption of sensitive data
 type CryptoService struct {
 	key     []byte
 	hmacKey []byte
+	jwtKey  []byte
 }
 
 // NewCryptoService creates a new crypto service with the given key
 func NewCryptoService(key string) *CryptoService {
-	// Derive separate keys for encryption and HMAC
+	// Derive separate keys for encryption, HMAC, and JWT signing
 	encKey := sha256.Sum256([]byte(key + ":encryption"))
 	hmacKey := sha256.Sum256([]byte(key + ":hmac"))
+	jwtKey := sha256.Sum256([]byte(key + ":jwt"))
 	return &CryptoService{
 		key:     encKey[:],
 		hmacKey: hmacKey[:],
+		jwtKey:  jwtKey[:],
 	}
 }
 
@@ -127,4 +144,84 @@ func (c *CryptoService) HMACToken(token string) string {
 func (c *CryptoService) ValidateTokenHMAC(token, storedHMAC string) bool {
 	expectedHMAC := c.HMACToken(token)
 	return subtle.ConstantTimeCompare([]byte(expectedHMAC), []byte(storedHMAC)) == 1
+}
+
+// GenerateViewAccessJWT creates a signed JWT for password-protected view access
+// Returns the token string and expiration time
+func (c *CryptoService) GenerateViewAccessJWT(viewID string, duration time.Duration) (string, time.Time, error) {
+	// Generate random JWT ID for audit/future revocation
+	jtiBytes := make([]byte, 16)
+	if _, err := rand.Read(jtiBytes); err != nil {
+		return "", time.Time{}, err
+	}
+	jti := base64.URLEncoding.EncodeToString(jtiBytes)
+
+	now := time.Now()
+	expiresAt := now.Add(duration)
+
+	claims := ViewAccessClaims{
+		ViewID: viewID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    JWTIssuer,
+			Audience:  jwt.ClaimStrings{JWTAudience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			ID:        jti,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, err := token.SignedString(c.jwtKey)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	return signedToken, expiresAt, nil
+}
+
+// ValidateViewAccessJWT validates a JWT and returns the view ID if valid
+// Returns an error if the token is invalid, expired, or tampered with
+func (c *CryptoService) ValidateViewAccessJWT(tokenString string) (string, error) {
+	if tokenString == "" {
+		return "", errors.New("token required")
+	}
+
+	token, err := jwt.ParseWithClaims(tokenString, &ViewAccessClaims{}, func(token *jwt.Token) (interface{}, error) {
+		// Validate signing method
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("invalid signing method")
+		}
+		return c.jwtKey, nil
+	})
+
+	if err != nil {
+		return "", errors.New("invalid token")
+	}
+
+	claims, ok := token.Claims.(*ViewAccessClaims)
+	if !ok || !token.Valid {
+		return "", errors.New("invalid token")
+	}
+
+	// Validate issuer
+	if claims.Issuer != JWTIssuer {
+		return "", errors.New("invalid issuer")
+	}
+
+	// Validate audience
+	if !claims.VerifyAudience(JWTAudience, true) {
+		return "", errors.New("invalid audience")
+	}
+
+	// Validate expiry (already checked by jwt library, but explicit)
+	if claims.ExpiresAt == nil || claims.ExpiresAt.Before(time.Now()) {
+		return "", errors.New("token expired")
+	}
+
+	// Validate view ID exists
+	if claims.ViewID == "" {
+		return "", errors.New("missing view ID")
+	}
+
+	return claims.ViewID, nil
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,154 @@
+# Me.yaml Security
+
+This document describes security features, authentication flows, and known limitations.
+
+## Encryption
+
+### Master Encryption Key
+
+All sensitive data is encrypted using AES-256-GCM. The encryption key is derived from the `ENCRYPTION_KEY` environment variable.
+
+**Requirements:**
+- Minimum 32 characters (256 bits)
+- Generate with: `openssl rand -hex 32`
+- Application **will not start** without a valid key
+
+**What's encrypted:**
+- AI provider API keys (`ai_providers.api_key_encrypted`)
+- GitHub tokens (`settings.github_token`)
+
+**Key derivation:**
+The master key is stretched into separate keys for different purposes:
+- Encryption key: `SHA256(master + ":encryption")`
+- HMAC key: `SHA256(master + ":hmac")`
+- JWT signing key: `SHA256(master + ":jwt")`
+
+## Authentication
+
+### Admin Authentication
+
+Admin users authenticate via:
+1. **OAuth2** (Google, GitHub) - preferred
+2. **Password** - fallback
+
+Access is controlled by the `ADMIN_EMAILS` environment variable (comma-separated list).
+
+### View Access Levels
+
+| Visibility | Access Control |
+|------------|----------------|
+| `public` | Anyone |
+| `unlisted` | Anyone with the link (share tokens planned) |
+| `password` | Anyone with the correct password → receives JWT |
+| `private` | Admin only |
+
+## Password-Protected Views
+
+Password-protected views use signed JWTs for access control.
+
+### Flow
+
+```
+1. Client: POST /api/view/{slug}/access
+   Response: { "requires_password": true, "id": "..." }
+
+2. Client: POST /api/password/check
+   Body: { "view_id": "...", "password": "..." }
+   Response: { "access_token": "<JWT>", "expires_in": 3600 }
+
+3. Client: GET /api/view/{slug}/data
+   Header: Authorization: Bearer <JWT>
+   Response: { view data }
+```
+
+### JWT Structure
+
+**Algorithm:** HS256
+
+**Claims:**
+| Claim | Description |
+|-------|-------------|
+| `vid` | View ID |
+| `iss` | Issuer: `me.yaml` |
+| `aud` | Audience: `view-access` |
+| `iat` | Issued at timestamp |
+| `exp` | Expiration timestamp |
+| `jti` | Unique token ID (for audit) |
+
+**Lifetime:** 1 hour
+
+### Token Transport
+
+Tokens can be sent via:
+1. `Authorization: Bearer <token>` (preferred)
+2. `X-Password-Token: <token>` (legacy/UI convenience)
+
+### Security Properties
+
+- Tokens are signed with HMAC-SHA256
+- Signature validation is required
+- Expiry is enforced
+- Issuer and audience are validated
+- View ID in token must match requested view
+- Tokens cannot be used for a different view than issued
+
+### Limitations
+
+- **No revocation:** Tokens are valid until expiry
+- **No refresh:** Client must re-authenticate after expiry
+- **Stateless:** Server doesn't track issued tokens
+
+## Share Tokens
+
+Share tokens provide access to unlisted views.
+
+### Storage
+
+Share tokens are stored as HMAC-SHA256 hashes:
+- Raw token is returned to user once
+- Server stores only the HMAC
+- Constant-time comparison prevents timing attacks
+
+### Properties
+
+- Cryptographically random (32 bytes)
+- Optional expiration date
+- Optional usage limit
+- Can be revoked by admin
+
+## API Security
+
+### Rate Limiting
+
+*(Planned - not yet implemented)*
+
+### CORS
+
+No explicit CORS configuration - all endpoints are same-origin behind the Caddy reverse proxy.
+
+### Security Headers
+
+*(Planned - to be added via Caddyfile)*
+
+## File Access
+
+Files are served via PocketBase at `/api/files/{collectionId}/{recordId}/{filename}`.
+
+**Current state:** Files follow the collection's access rules.
+
+**Planned:** Signed URLs with expiration for private files.
+
+## Development vs Production
+
+| Aspect | Development | Production |
+|--------|-------------|------------|
+| Encryption key | Dev-only key in docker-compose.dev.yml | **Required** via `ENCRYPTION_KEY` |
+| PocketBase Admin | Enabled at `/_/` | Disabled by default (`ADMIN_ENABLED=false`) |
+| Seed data | Created automatically | Not created |
+| Debug logging | Enabled | Disabled |
+
+## Reporting Security Issues
+
+If you discover a security vulnerability, please report it responsibly by opening a private issue or contacting the maintainers directly.
+
+Do not open public issues for security vulnerabilities.


### PR DESCRIPTION
Security implementation for password-protected views:

- Add JWT generation/validation to CryptoService (HS256, 1hr expiry)
- JWT claims: vid, iss=me.yaml, aud=view-access, iat, exp, jti
- Update /api/password/check to return signed JWT
- Update /api/view/{slug}/data to validate JWT for password views
- Accept tokens via Authorization: Bearer or X-Password-Token header
- Add comprehensive tests for JWT validation scenarios
- Add docs/SECURITY.md documenting the security model

Test coverage:
- Valid token → 200
- No token → 401
- Malformed token → 401
- Tampered token → 401
- Expired token → 401
- Wrong view ID → 401
- Wrong signing key → 401