### PR TITLE
Implement share token enforcement for unlisted views

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -47,7 +47,7 @@ func main() {
 	hooks.RegisterAIHooks(app, aiService, cryptoService)
 	hooks.RegisterShareHooks(app, shareService, cryptoService)
 	hooks.RegisterPasswordHooks(app, cryptoService)
-	hooks.RegisterViewHooks(app, cryptoService)
+	hooks.RegisterViewHooks(app, cryptoService, shareService)
 	hooks.RegisterSeedHook(app)
 
 	// Note: Trusted proxy headers are handled by Caddy in the Docker setup.

--- a/backend/migrations/add_token_prefix.go
+++ b/backend/migrations/add_token_prefix.go
@@ -1,0 +1,49 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		// Add token_prefix field to share_tokens for O(1) lookup
+		collection, err := app.FindCollectionByNameOrId("share_tokens")
+		if err != nil {
+			return err
+		}
+
+		// Check if field already exists
+		if collection.Fields.GetByName("token_prefix") != nil {
+			return nil
+		}
+
+		// Add token_prefix field (first 12 chars of raw token for indexed lookup)
+		collection.Fields.Add(&core.TextField{
+			Name:     "token_prefix",
+			Max:      16,
+			Required: false, // Not required for backwards compatibility with existing tokens
+		})
+
+		// Add composite index for efficient lookup: prefix + is_active
+		collection.Indexes = append(collection.Indexes,
+			"CREATE INDEX idx_share_tokens_prefix_active ON share_tokens(token_prefix, is_active) WHERE token_prefix != ''",
+		)
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		// Rollback: remove token_prefix field
+		collection, err := app.FindCollectionByNameOrId("share_tokens")
+		if err != nil {
+			return err
+		}
+
+		field := collection.Fields.GetByName("token_prefix")
+		if field != nil {
+			collection.Fields.RemoveById(field.GetId())
+		}
+
+		// Note: Index will be removed automatically when field is removed
+		return app.Save(collection)
+	})
+}

--- a/backend/services/share.go
+++ b/backend/services/share.go
@@ -4,6 +4,10 @@ import (
 	"time"
 )
 
+// TokenPrefixLength is the number of characters to store for indexed lookup
+// 12 chars of base64 = ~72 bits of entropy, sufficient for narrowing to 1-2 candidates
+const TokenPrefixLength = 12
+
 // ShareService handles share token operations
 type ShareService struct {
 	crypto *CryptoService
@@ -52,4 +56,13 @@ func (s *ShareService) CanUseToken(useCount int, maxUses *int) bool {
 		return true // Unlimited uses
 	}
 	return useCount < *maxUses
+}
+
+// TokenPrefix extracts the prefix from a raw token for indexed lookup
+// This is stored unencrypted for O(1) database queries
+func (s *ShareService) TokenPrefix(token string) string {
+	if len(token) < TokenPrefixLength {
+		return token
+	}
+	return token[:TokenPrefixLength]
 }

--- a/backend/services/share_test.go
+++ b/backend/services/share_test.go
@@ -5,8 +5,40 @@ import (
 	"time"
 )
 
+func TestTokenPrefixLength(t *testing.T) {
+	if TokenPrefixLength != 12 {
+		t.Fatalf("Expected TokenPrefixLength to be 12, got %d", TokenPrefixLength)
+	}
+}
+
+func TestTokenPrefix(t *testing.T) {
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
+
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+	}{
+		{"normal token", "abcdefghijklmnopqrstuvwxyz", "abcdefghijkl"},
+		{"exact length", "abcdefghijkl", "abcdefghijkl"},
+		{"short token", "short", "short"},
+		{"empty token", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix := share.TokenPrefix(tt.token)
+			if prefix != tt.expected {
+				t.Errorf("TokenPrefix(%q) = %q, want %q", tt.token, prefix, tt.expected)
+			}
+		})
+	}
+}
+
 func TestShareTokenGeneration(t *testing.T) {
-	share := NewShareService()
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
 
 	token1, err := share.GenerateToken()
 	if err != nil {
@@ -30,30 +62,73 @@ func TestShareTokenGeneration(t *testing.T) {
 }
 
 func TestShareTokenHashValidation(t *testing.T) {
-	share := NewShareService()
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
 
 	token, _ := share.GenerateToken()
-	hash := share.HashToken(token)
+	hash := share.HMACToken(token)
 
 	// Same token should validate
-	if !share.ValidateTokenHash(token, hash) {
-		t.Error("ValidateTokenHash() should return true for matching token")
+	if !share.ValidateTokenHMAC(token, hash) {
+		t.Error("ValidateTokenHMAC() should return true for matching token")
 	}
 
 	// Different token should not validate
 	otherToken, _ := share.GenerateToken()
-	if share.ValidateTokenHash(otherToken, hash) {
-		t.Error("ValidateTokenHash() should return false for different token")
+	if share.ValidateTokenHMAC(otherToken, hash) {
+		t.Error("ValidateTokenHMAC() should return false for different token")
 	}
 
 	// Wrong hash should not validate
-	if share.ValidateTokenHash(token, "wrong-hash") {
-		t.Error("ValidateTokenHash() should return false for wrong hash")
+	if share.ValidateTokenHMAC(token, "wrong-hash") {
+		t.Error("ValidateTokenHMAC() should return false for wrong hash")
+	}
+}
+
+func TestHMACWithDifferentKeys(t *testing.T) {
+	crypto1 := NewCryptoService("first-encryption-key-32-chars!!")
+	crypto2 := NewCryptoService("second-encryption-key-32-chars!")
+	share1 := NewShareService(crypto1)
+	share2 := NewShareService(crypto2)
+
+	token := "same-token"
+	hash1 := share1.HMACToken(token)
+	hash2 := share2.HMACToken(token)
+
+	// Same token with different keys should produce different hashes
+	if hash1 == hash2 {
+		t.Error("Same token with different keys should produce different hashes")
+	}
+
+	// Cross-validation should fail
+	if share2.ValidateTokenHMAC(token, hash1) {
+		t.Error("Token hashed with different key should not validate")
+	}
+}
+
+func TestTokenPrefixConsistency(t *testing.T) {
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
+
+	// Generate a token and extract prefix
+	token, _ := share.GenerateToken()
+	prefix := share.TokenPrefix(token)
+
+	// Prefix should be the first 12 chars of the token
+	if token[:TokenPrefixLength] != prefix {
+		t.Error("Prefix should be first 12 chars of token")
+	}
+
+	// Multiple calls should return same prefix
+	prefix2 := share.TokenPrefix(token)
+	if prefix != prefix2 {
+		t.Error("TokenPrefix should be deterministic")
 	}
 }
 
 func TestTokenExpiration(t *testing.T) {
-	share := NewShareService()
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
 
 	// No expiration
 	if share.IsTokenExpired(nil) {
@@ -74,7 +149,8 @@ func TestTokenExpiration(t *testing.T) {
 }
 
 func TestTokenUsageLimit(t *testing.T) {
-	share := NewShareService()
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
 
 	// No limit
 	if !share.CanUseToken(100, nil) {
@@ -101,5 +177,67 @@ func TestTokenUsageLimit(t *testing.T) {
 	// Over limit
 	if share.CanUseToken(10, &limit) {
 		t.Error("CanUseToken(10, 5) should return false")
+	}
+}
+
+func TestHMACConstantTimeComparison(t *testing.T) {
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
+
+	token := "test-token-12345"
+	hash := share.HMACToken(token)
+
+	// Test that validation uses constant-time comparison by verifying behavior
+	// (actual timing verification would require more complex testing)
+
+	// Correct token should validate
+	if !share.ValidateTokenHMAC(token, hash) {
+		t.Error("Correct token should validate")
+	}
+
+	// Completely wrong token should not validate
+	if share.ValidateTokenHMAC("completely-different", hash) {
+		t.Error("Wrong token should not validate")
+	}
+
+	// Token with only first char different should not validate
+	wrongFirst := "Xest-token-12345"
+	if share.ValidateTokenHMAC(wrongFirst, hash) {
+		t.Error("Token with different first char should not validate")
+	}
+
+	// Token with only last char different should not validate
+	wrongLast := "test-token-12346"
+	if share.ValidateTokenHMAC(wrongLast, hash) {
+		t.Error("Token with different last char should not validate")
+	}
+}
+
+func TestTokenPrefixWithRealToken(t *testing.T) {
+	crypto := NewCryptoService("test-encryption-key-32-chars-ok!")
+	share := NewShareService(crypto)
+
+	// Generate a real token
+	token, err := share.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+
+	prefix := share.TokenPrefix(token)
+
+	// Prefix length should be exactly TokenPrefixLength
+	if len(prefix) != TokenPrefixLength {
+		t.Errorf("Prefix length = %d, want %d", len(prefix), TokenPrefixLength)
+	}
+
+	// Prefix should be a substring of the token
+	if token[:TokenPrefixLength] != prefix {
+		t.Error("Prefix should match first TokenPrefixLength chars of token")
+	}
+
+	// HMAC should still work correctly with the full token
+	hash := share.HMACToken(token)
+	if !share.ValidateTokenHMAC(token, hash) {
+		t.Error("Full token HMAC validation should work")
 	}
 }


### PR DESCRIPTION
- Add token_prefix field for O(1) indexed lookup (instead of O(n) scan)
- Store first 12 chars of token as prefix for efficient database queries
- Enforce share tokens server-side for visibility=unlisted views
- Accept tokens via Authorization header, X-Share-Token header, or query param
- Add comprehensive share token tests
- Update SECURITY.md with share token architecture and flow
- Maintain backwards compatibility with legacy tokens (no prefix)