### PR TITLE
Implement per-IP rate limiting (Step 6A)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,4 +5,5 @@ go 1.23
 require (
 	github.com/pocketbase/pocketbase v0.23.4
 	golang.org/x/crypto v0.29.0
+	golang.org/x/time v0.8.0
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,4 @@
 github.com/pocketbase/pocketbase v0.23.4/go.mod h1:9GFdDL2BNlVWM/csEhVUMylPrY+QJCTqpXu7Wa7TxSQ=
 golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=
+golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
+golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/backend/hooks/ratelimit.go
+++ b/backend/hooks/ratelimit.go
@@ -1,0 +1,48 @@
+package hooks
+
+import (
+	"fmt"
+	"net/http"
+
+	"ownprofile/services"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// RateLimitMiddleware creates a rate-limiting wrapper for endpoint handlers
+// tier: "strict", "moderate", or "normal"
+func RateLimitMiddleware(rl *services.RateLimitService, tier string) func(func(*core.RequestEvent) error) func(*core.RequestEvent) error {
+	return func(handler func(*core.RequestEvent) error) func(*core.RequestEvent) error {
+		return func(e *core.RequestEvent) error {
+			allowed, retryAfter := rl.Allow(e.Request, tier)
+
+			if !allowed {
+				// Set standard rate limit headers
+				e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+				e.Response.Header().Set("X-RateLimit-Limit", tierToLimit(tier))
+				e.Response.Header().Set("X-RateLimit-Remaining", "0")
+
+				// Return uniform 429 response (non-leaky)
+				return e.JSON(http.StatusTooManyRequests, map[string]string{
+					"error": "too many requests",
+				})
+			}
+
+			return handler(e)
+		}
+	}
+}
+
+// tierToLimit returns a human-readable limit description
+func tierToLimit(tier string) string {
+	switch tier {
+	case "strict":
+		return "5/min"
+	case "moderate":
+		return "10/min"
+	case "normal":
+		return "60/min"
+	default:
+		return "60/min"
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -33,6 +33,7 @@ func main() {
 	githubService := services.NewGitHubService()
 	aiService := services.NewAIService(cryptoService)
 	shareService := services.NewShareService(cryptoService)
+	rateLimitService := services.NewRateLimitService()
 
 	// Register migrations
 	migratecmd.MustRegister(app, app.RootCmd, migratecmd.Config{
@@ -45,9 +46,9 @@ func main() {
 	hooks.RegisterAdminAuth(app)
 	hooks.RegisterGitHubHooks(app, githubService, aiService, cryptoService)
 	hooks.RegisterAIHooks(app, aiService, cryptoService)
-	hooks.RegisterShareHooks(app, shareService, cryptoService)
-	hooks.RegisterPasswordHooks(app, cryptoService)
-	hooks.RegisterViewHooks(app, cryptoService, shareService)
+	hooks.RegisterShareHooks(app, shareService, cryptoService, rateLimitService)
+	hooks.RegisterPasswordHooks(app, cryptoService, rateLimitService)
+	hooks.RegisterViewHooks(app, cryptoService, shareService, rateLimitService)
 	hooks.RegisterSeedHook(app)
 
 	// Note: Trusted proxy headers are handled by Caddy in the Docker setup.

--- a/backend/services/ratelimit.go
+++ b/backend/services/ratelimit.go
@@ -1,0 +1,220 @@
+package services
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// RateLimitTier defines rate limit parameters for a category of endpoints
+type RateLimitTier struct {
+	Rate  rate.Limit // Requests per second
+	Burst int        // Maximum burst size
+}
+
+// Predefined tiers for different endpoint types
+var (
+	// TierStrict: Password/token validation - very restrictive
+	// 5 requests per minute = 0.083/sec, burst of 3
+	TierStrict = RateLimitTier{Rate: rate.Limit(5.0 / 60.0), Burst: 3}
+
+	// TierModerate: Token validation, sensitive operations
+	// 10 requests per minute = 0.167/sec, burst of 5
+	TierModerate = RateLimitTier{Rate: rate.Limit(10.0 / 60.0), Burst: 5}
+
+	// TierNormal: General public endpoints
+	// 60 requests per minute = 1/sec, burst of 10
+	TierNormal = RateLimitTier{Rate: rate.Limit(1.0), Burst: 10}
+)
+
+// RateLimitService provides per-IP rate limiting using token bucket algorithm
+type RateLimitService struct {
+	// Per-tier limiters: tier name -> IP -> limiter
+	limiters map[string]map[string]*rate.Limiter
+	mu       sync.RWMutex
+
+	// Tier configurations
+	tiers map[string]RateLimitTier
+
+	// Cleanup interval and TTL
+	cleanupInterval time.Duration
+	limiterTTL      time.Duration
+
+	// Last access times for cleanup
+	lastAccess   map[string]map[string]time.Time
+	lastAccessMu sync.RWMutex
+
+	// Proxy trust settings
+	trustProxy bool
+}
+
+// NewRateLimitService creates a new rate limiting service
+func NewRateLimitService() *RateLimitService {
+	trustProxy := os.Getenv("TRUST_PROXY") == "true"
+
+	svc := &RateLimitService{
+		limiters: make(map[string]map[string]*rate.Limiter),
+		tiers: map[string]RateLimitTier{
+			"strict":   TierStrict,
+			"moderate": TierModerate,
+			"normal":   TierNormal,
+		},
+		cleanupInterval: 5 * time.Minute,
+		limiterTTL:      10 * time.Minute,
+		lastAccess:      make(map[string]map[string]time.Time),
+		trustProxy:      trustProxy,
+	}
+
+	// Initialize limiter maps for each tier
+	for tier := range svc.tiers {
+		svc.limiters[tier] = make(map[string]*rate.Limiter)
+		svc.lastAccess[tier] = make(map[string]time.Time)
+	}
+
+	// Start background cleanup
+	go svc.cleanupLoop()
+
+	return svc
+}
+
+// Allow checks if a request should be allowed for the given tier
+// Returns (allowed, retryAfter) where retryAfter is seconds until next allowed request
+func (s *RateLimitService) Allow(r *http.Request, tier string) (bool, int) {
+	ip := s.getClientIP(r)
+	limiter := s.getLimiter(ip, tier)
+
+	if limiter.Allow() {
+		return true, 0
+	}
+
+	// Calculate retry-after (time until next token available)
+	reservation := limiter.Reserve()
+	delay := reservation.Delay()
+	reservation.Cancel() // Don't actually consume the token
+
+	retryAfter := int(delay.Seconds()) + 1 // Round up
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+
+	return false, retryAfter
+}
+
+// getLimiter returns or creates a limiter for the given IP and tier
+func (s *RateLimitService) getLimiter(ip, tier string) *rate.Limiter {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tierConfig, ok := s.tiers[tier]
+	if !ok {
+		tierConfig = TierNormal
+	}
+
+	if _, exists := s.limiters[tier]; !exists {
+		s.limiters[tier] = make(map[string]*rate.Limiter)
+		s.lastAccess[tier] = make(map[string]time.Time)
+	}
+
+	limiter, exists := s.limiters[tier][ip]
+	if !exists {
+		limiter = rate.NewLimiter(tierConfig.Rate, tierConfig.Burst)
+		s.limiters[tier][ip] = limiter
+	}
+
+	// Update last access time
+	s.lastAccessMu.Lock()
+	s.lastAccess[tier][ip] = time.Now()
+	s.lastAccessMu.Unlock()
+
+	return limiter
+}
+
+// getClientIP extracts the client IP address from the request
+// Respects TRUST_PROXY setting for X-Forwarded-For and CF-Connecting-IP
+func (s *RateLimitService) getClientIP(r *http.Request) string {
+	if s.trustProxy {
+		// Priority 1: Cloudflare's CF-Connecting-IP (most reliable when using Cloudflare)
+		if cfIP := r.Header.Get("CF-Connecting-IP"); cfIP != "" {
+			return cfIP
+		}
+
+		// Priority 2: X-Real-IP (set by some proxies like nginx)
+		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+			return realIP
+		}
+
+		// Priority 3: X-Forwarded-For (take the first/leftmost IP, which is the original client)
+		// WARNING: This can be spoofed if not behind a trusted proxy
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			// X-Forwarded-For format: "client, proxy1, proxy2"
+			// The leftmost IP is the original client
+			ips := strings.Split(xff, ",")
+			if len(ips) > 0 {
+				clientIP := strings.TrimSpace(ips[0])
+				if clientIP != "" {
+					return clientIP
+				}
+			}
+		}
+	}
+
+	// Fallback: Use RemoteAddr (direct connection IP)
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr might not have a port
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// cleanupLoop periodically removes stale limiters
+func (s *RateLimitService) cleanupLoop() {
+	ticker := time.NewTicker(s.cleanupInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		s.cleanup()
+	}
+}
+
+// cleanup removes limiters that haven't been accessed recently
+func (s *RateLimitService) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.lastAccessMu.Lock()
+	defer s.lastAccessMu.Unlock()
+
+	cutoff := time.Now().Add(-s.limiterTTL)
+
+	for tier, accessTimes := range s.lastAccess {
+		for ip, lastAccess := range accessTimes {
+			if lastAccess.Before(cutoff) {
+				delete(s.limiters[tier], ip)
+				delete(s.lastAccess[tier], ip)
+			}
+		}
+	}
+}
+
+// TrustProxy returns whether proxy headers are trusted
+func (s *RateLimitService) TrustProxy() bool {
+	return s.trustProxy
+}
+
+// Stats returns current limiter statistics (for debugging/monitoring)
+func (s *RateLimitService) Stats() map[string]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	stats := make(map[string]int)
+	for tier, limiters := range s.limiters {
+		stats[tier] = len(limiters)
+	}
+	return stats
+}

--- a/backend/services/ratelimit_test.go
+++ b/backend/services/ratelimit_test.go
@@ -1,0 +1,208 @@
+package services
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRateLimitService_Allow(t *testing.T) {
+	svc := NewRateLimitService()
+
+	// Create a mock request
+	req := httptest.NewRequest("POST", "/api/password/check", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+
+	// Strict tier: 5/min with burst of 3
+	// First 3 requests should be allowed (burst)
+	for i := 0; i < 3; i++ {
+		allowed, _ := svc.Allow(req, "strict")
+		if !allowed {
+			t.Errorf("Request %d should be allowed (within burst)", i+1)
+		}
+	}
+
+	// 4th request should be denied (burst exhausted, need to wait for refill)
+	allowed, retryAfter := svc.Allow(req, "strict")
+	if allowed {
+		t.Error("4th request should be denied (burst exhausted)")
+	}
+	if retryAfter < 1 {
+		t.Error("Retry-After should be at least 1 second")
+	}
+}
+
+func TestRateLimitService_DifferentIPsNotShared(t *testing.T) {
+	svc := NewRateLimitService()
+
+	// Two different IPs
+	req1 := httptest.NewRequest("POST", "/api/password/check", nil)
+	req1.RemoteAddr = "192.168.1.100:12345"
+
+	req2 := httptest.NewRequest("POST", "/api/password/check", nil)
+	req2.RemoteAddr = "192.168.1.200:12345"
+
+	// Exhaust burst for IP1
+	for i := 0; i < 5; i++ {
+		svc.Allow(req1, "strict")
+	}
+
+	// IP1 should be rate limited
+	allowed1, _ := svc.Allow(req1, "strict")
+	if allowed1 {
+		t.Error("IP1 should be rate limited")
+	}
+
+	// IP2 should still have its full burst available
+	allowed2, _ := svc.Allow(req2, "strict")
+	if !allowed2 {
+		t.Error("IP2 should not be rate limited (separate bucket)")
+	}
+}
+
+func TestRateLimitService_DifferentTiers(t *testing.T) {
+	svc := NewRateLimitService()
+
+	req := httptest.NewRequest("POST", "/api/test", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+
+	// Exhaust strict tier burst (3)
+	for i := 0; i < 4; i++ {
+		svc.Allow(req, "strict")
+	}
+
+	// Strict tier should be exhausted
+	allowed, _ := svc.Allow(req, "strict")
+	if allowed {
+		t.Error("Strict tier should be exhausted")
+	}
+
+	// Normal tier should still be available (separate bucket)
+	allowed, _ = svc.Allow(req, "normal")
+	if !allowed {
+		t.Error("Normal tier should still be available")
+	}
+}
+
+func TestRateLimitService_TrustProxy(t *testing.T) {
+	// Test with TRUST_PROXY=false (default)
+	os.Unsetenv("TRUST_PROXY")
+	svc := NewRateLimitService()
+
+	req := httptest.NewRequest("POST", "/api/test", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50, 10.0.0.1")
+	req.Header.Set("CF-Connecting-IP", "203.0.113.100")
+
+	// Should use RemoteAddr, not headers
+	ip := svc.getClientIP(req)
+	if ip != "10.0.0.1" {
+		t.Errorf("Without TRUST_PROXY, should use RemoteAddr. Got: %s", ip)
+	}
+
+	// Test with TRUST_PROXY=true
+	os.Setenv("TRUST_PROXY", "true")
+	svc2 := NewRateLimitService()
+
+	// Should prefer CF-Connecting-IP when available
+	ip = svc2.getClientIP(req)
+	if ip != "203.0.113.100" {
+		t.Errorf("With TRUST_PROXY, should use CF-Connecting-IP. Got: %s", ip)
+	}
+
+	// Test X-Forwarded-For when CF-Connecting-IP is not set
+	req2 := httptest.NewRequest("POST", "/api/test", nil)
+	req2.RemoteAddr = "10.0.0.1:12345"
+	req2.Header.Set("X-Forwarded-For", "203.0.113.50, 10.0.0.1")
+
+	ip = svc2.getClientIP(req2)
+	if ip != "203.0.113.50" {
+		t.Errorf("With TRUST_PROXY and no CF-Connecting-IP, should use leftmost X-Forwarded-For. Got: %s", ip)
+	}
+
+	// Cleanup
+	os.Unsetenv("TRUST_PROXY")
+}
+
+func TestRateLimitService_RetryAfter(t *testing.T) {
+	svc := NewRateLimitService()
+
+	req := httptest.NewRequest("POST", "/api/test", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+
+	// Exhaust strict tier
+	for i := 0; i < 5; i++ {
+		svc.Allow(req, "strict")
+	}
+
+	// Next request should return a reasonable Retry-After value
+	_, retryAfter := svc.Allow(req, "strict")
+
+	// Strict tier: 5/min = 1 request per 12 seconds
+	// Retry-After should be reasonable (between 1 and 60 seconds)
+	if retryAfter < 1 || retryAfter > 60 {
+		t.Errorf("Retry-After should be between 1 and 60 seconds for strict tier. Got: %d", retryAfter)
+	}
+}
+
+func TestRateLimitService_Refill(t *testing.T) {
+	// Create a service with a faster refill for testing
+	// Note: This test may be flaky due to timing, so we use generous margins
+
+	svc := NewRateLimitService()
+
+	req := httptest.NewRequest("POST", "/api/test", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+
+	// Use normal tier (1 req/sec, burst 10)
+	// Exhaust some of the burst
+	for i := 0; i < 5; i++ {
+		svc.Allow(req, "normal")
+	}
+
+	// Wait a bit for refill (1 token per second)
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should be allowed again (at least 1 token refilled)
+	allowed, _ := svc.Allow(req, "normal")
+	if !allowed {
+		t.Error("Should have refilled at least 1 token after waiting")
+	}
+}
+
+func TestRateLimitService_Stats(t *testing.T) {
+	svc := NewRateLimitService()
+
+	// Make requests from different IPs
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("POST", "/api/test", nil)
+		req.RemoteAddr = "192.168.1." + string(rune('0'+i)) + ":12345"
+		svc.Allow(req, "strict")
+	}
+
+	stats := svc.Stats()
+	if stats["strict"] != 5 {
+		t.Errorf("Expected 5 limiters in strict tier, got %d", stats["strict"])
+	}
+}
+
+// TestRateLimitService_IPv6 ensures IPv6 addresses work correctly
+func TestRateLimitService_IPv6(t *testing.T) {
+	svc := NewRateLimitService()
+
+	req := httptest.NewRequest("POST", "/api/test", nil)
+	req.RemoteAddr = "[2001:db8::1]:12345"
+
+	allowed, _ := svc.Allow(req, "normal")
+	if !allowed {
+		t.Error("IPv6 request should be allowed")
+	}
+
+	// Verify it uses the correct IP
+	ip := svc.getClientIP(req)
+	if ip != "2001:db8::1" {
+		t.Errorf("Expected IPv6 address, got: %s", ip)
+	}
+}


### PR DESCRIPTION
Add token bucket rate limiting to protect abuse-prone endpoints:

Rate limit tiers:
- Strict (5/min, burst 3): POST /api/password/check
- Moderate (10/min, burst 5): POST /api/share/validate
- Normal (60/min, burst 10): GET /api/view/{slug}/*

Features:
- Token bucket algorithm via golang.org/x/time/rate
- Per-IP rate limiting with automatic cleanup
- TRUST_PROXY env var for proxy header handling
- CF-Connecting-IP support for Cloudflare deployments
- Standard 429 response with Retry-After header
- Non-leaky error messages (uniform response)

Security considerations:
- X-Forwarded-For only trusted when TRUST_PROXY=true
- Cloudflare's CF-Connecting-IP preferred when available
- In-memory storage (single-instance, non-persistent)

Refs: OWASP rate limiting, Kong sliding window research