### PR TITLE
Phase B: First-run warmth and gentle guidance

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -304,9 +304,20 @@ Changes:
 - Import button: "Create Import Proposal" → "Review & Import"
 - Removed "(admin only)" from visibility dropdown
 
-### Phase B: First-Run Warmth (Planned)
+### Phase B: First-Run Warmth (Complete)
 
-Empty states, gentle guidance for new users.
+*Tag: `phase-first-run-warmth`*
+
+Improved empty states and first-run experience. No wizards or progress trackers.
+
+Changes:
+- Dashboard: "This is your space" welcome message when empty (replaces 0/0/0/0 stats)
+- Activity: "Nothing here yet — and that's okay" empty state
+- Profile hero: Removed "?" avatar fallback when no profile
+- Profile hero: Removed "Welcome" heading when no name set
+- Views: Descriptive empty state explaining what views do
+- Contact links: "Add links to help people reach you"
+- AI providers: Gentle guidance about optional enrichment
 
 ### Phase C: Visual Calm (Planned)
 

--- a/frontend/src/components/public/ProfileHero.svelte
+++ b/frontend/src/components/public/ProfileHero.svelte
@@ -27,16 +27,18 @@
 					alt={profile.name}
 					class="w-32 h-32 sm:w-40 sm:h-40 rounded-full border-4 border-white/20 shadow-xl object-cover"
 				/>
-			{:else}
+			{:else if profile?.name}
 				<div class="w-32 h-32 sm:w-40 sm:h-40 rounded-full bg-primary-600 flex items-center justify-center text-4xl font-bold border-4 border-white/20">
-					{profile?.name?.charAt(0) || '?'}
+					{profile.name.charAt(0)}
 				</div>
 			{/if}
 
 			<div class="text-center sm:text-left flex-1">
-				<h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-2">
-					{profile?.name || 'Welcome'}
-				</h1>
+				{#if profile?.name}
+					<h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-2">
+						{profile.name}
+					</h1>
+				{/if}
 
 				{#if profile?.headline}
 					<p class="text-xl sm:text-2xl text-gray-300 mb-4">

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -64,6 +64,8 @@
 			minute: '2-digit'
 		});
 	}
+
+	$: isEmpty = !loading && stats.projects === 0 && stats.experience === 0 && stats.views === 0;
 </script>
 
 <svelte:head>
@@ -71,67 +73,81 @@
 </svelte:head>
 
 <div class="max-w-6xl mx-auto">
-	<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">Dashboard</h1>
+	{#if isEmpty}
+		<!-- Welcome state for first-time users -->
+		<div class="card p-8 mb-8">
+			<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-3">This is your space.</h1>
+			<p class="text-gray-600 dark:text-gray-400">
+				You might start by <a href="/admin/profile" class="text-primary-600 dark:text-primary-400 hover:underline">adding your profile</a>,
+				or <a href="/admin/import" class="text-primary-600 dark:text-primary-400 hover:underline">import a project from GitHub</a>.
+			</p>
+			<p class="text-gray-500 dark:text-gray-500 text-sm mt-2">
+				There's no rush — add things as you're ready.
+			</p>
+		</div>
+	{:else}
+		<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">Dashboard</h1>
 
-	<!-- Stats grid -->
-	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-		<div class="card p-6">
-			<div class="flex items-center justify-between">
-				<div>
-					<p class="text-sm text-gray-500 dark:text-gray-400">Projects</p>
-					<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.projects}</p>
+		<!-- Stats grid -->
+		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+			<div class="card p-6">
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm text-gray-500 dark:text-gray-400">Projects</p>
+						<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.projects}</p>
+					</div>
+					<div class="w-12 h-12 rounded-lg bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
+						<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+						</svg>
+					</div>
 				</div>
-				<div class="w-12 h-12 rounded-lg bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
-					<svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-					</svg>
+			</div>
+
+			<div class="card p-6">
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm text-gray-500 dark:text-gray-400">Experience</p>
+						<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.experience}</p>
+					</div>
+					<div class="w-12 h-12 rounded-lg bg-green-100 dark:bg-green-900 flex items-center justify-center">
+						<svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+						</svg>
+					</div>
+				</div>
+			</div>
+
+			<div class="card p-6">
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm text-gray-500 dark:text-gray-400">Views</p>
+						<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.views}</p>
+					</div>
+					<div class="w-12 h-12 rounded-lg bg-purple-100 dark:bg-purple-900 flex items-center justify-center">
+						<svg class="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+						</svg>
+					</div>
+				</div>
+			</div>
+
+			<div class="card p-6">
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm text-gray-500 dark:text-gray-400">Pending Reviews</p>
+						<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.pendingProposals}</p>
+					</div>
+					<div class="w-12 h-12 rounded-lg bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center">
+						<svg class="w-6 h-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+						</svg>
+					</div>
 				</div>
 			</div>
 		</div>
-
-		<div class="card p-6">
-			<div class="flex items-center justify-between">
-				<div>
-					<p class="text-sm text-gray-500 dark:text-gray-400">Experience</p>
-					<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.experience}</p>
-				</div>
-				<div class="w-12 h-12 rounded-lg bg-green-100 dark:bg-green-900 flex items-center justify-center">
-					<svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-					</svg>
-				</div>
-			</div>
-		</div>
-
-		<div class="card p-6">
-			<div class="flex items-center justify-between">
-				<div>
-					<p class="text-sm text-gray-500 dark:text-gray-400">Views</p>
-					<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.views}</p>
-				</div>
-				<div class="w-12 h-12 rounded-lg bg-purple-100 dark:bg-purple-900 flex items-center justify-center">
-					<svg class="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-					</svg>
-				</div>
-			</div>
-		</div>
-
-		<div class="card p-6">
-			<div class="flex items-center justify-between">
-				<div>
-					<p class="text-sm text-gray-500 dark:text-gray-400">Pending Reviews</p>
-					<p class="text-2xl font-bold text-gray-900 dark:text-white">{stats.pendingProposals}</p>
-				</div>
-				<div class="w-12 h-12 rounded-lg bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center">
-					<svg class="w-6 h-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-					</svg>
-				</div>
-			</div>
-		</div>
-	</div>
+	{/if}
 
 	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 		<!-- Quick actions -->
@@ -182,7 +198,7 @@
 					{/each}
 				</div>
 			{:else if recentActivity.length === 0}
-				<p class="text-gray-500 dark:text-gray-400 text-sm">No recent activity</p>
+				<p class="text-gray-500 dark:text-gray-400 text-sm">Nothing here yet — and that's okay.</p>
 			{:else}
 				<div class="space-y-3">
 					{#each recentActivity as activity}

--- a/frontend/src/routes/admin/import/+page.svelte
+++ b/frontend/src/routes/admin/import/+page.svelte
@@ -265,9 +265,8 @@
 			{#if useAI}
 				<div class="pl-7 space-y-4">
 					{#if providers.length === 0}
-						<p class="text-yellow-600 dark:text-yellow-400 text-sm">
-							No AI providers configured.
-							<a href="/admin/settings" class="underline">Add one in Settings</a>
+						<p class="text-gray-600 dark:text-gray-400 text-sm">
+							You can <a href="/admin/settings" class="text-primary-600 dark:text-primary-400 underline">configure an AI provider</a> to automatically generate descriptions.
 						</p>
 					{:else}
 						<div>

--- a/frontend/src/routes/admin/profile/+page.svelte
+++ b/frontend/src/routes/admin/profile/+page.svelte
@@ -145,7 +145,7 @@
 					</div>
 
 					{#if contactLinks.length === 0}
-						<p class="text-gray-500 dark:text-gray-400 text-sm">No contact links added</p>
+						<p class="text-gray-500 dark:text-gray-400 text-sm">Add links to help people reach you.</p>
 					{:else}
 						<div class="space-y-3">
 							{#each contactLinks as link, i}

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -227,7 +227,7 @@
 			<div class="animate-pulse text-center py-4">Loading providers...</div>
 		{:else if providers.length === 0}
 			<p class="text-gray-500 dark:text-gray-400 text-center py-8">
-				No AI providers configured yet. Add one to enable project enrichment.
+				AI providers help generate project descriptions during import. Add one when you're ready.
 			</p>
 		{:else}
 			<div class="space-y-3">

--- a/frontend/src/routes/admin/views/+page.svelte
+++ b/frontend/src/routes/admin/views/+page.svelte
@@ -72,8 +72,9 @@
 		</div>
 	{:else if views.length === 0}
 		<div class="card p-8 text-center">
-			<p class="text-gray-500 dark:text-gray-400 mb-4">No views created yet</p>
-			<a href="/admin/views/new" class="btn btn-primary">Create Your First View</a>
+			<p class="text-gray-600 dark:text-gray-400 mb-2">You haven't created any views yet.</p>
+			<p class="text-gray-500 dark:text-gray-500 text-sm mb-4">Views let you show different versions of your profile to different audiences.</p>
+			<a href="/admin/views/new" class="btn btn-primary">Create a View</a>
 		</div>
 	{:else}
 		<div class="space-y-4">


### PR DESCRIPTION
Empty states now feel intentional rather than broken. No onboarding wizards or progress trackers - just warm, human-centered copy that gives new users permission to take their time.

Changes:
- Dashboard shows welcoming message when empty (vs 0/0/0/0 stats)
- Activity: "Nothing here yet — and that's okay"
- Profile hero: Removed "?" fallback and "Welcome" placeholder
- Views: Explains what views are before prompting creation
- Contact links: "Add links to help people reach you"
- AI providers: Gentle, optional framing for enrichment feature