### PR TITLE
Public view contract: Fix token flow and eliminate direct collection …

### DIFF
--- a/frontend/src/components/public/PasswordPrompt.svelte
+++ b/frontend/src/components/public/PasswordPrompt.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	export let type: 'view' | 'project' | 'experience';
-	export let id: string;
+	export let viewId: string;
 
-	const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher<{
+		verified: { token: string; expiresIn: number };
+	}>();
 
 	let password = '';
 	let error = '';
@@ -23,7 +24,7 @@
 			const response = await fetch('/api/password/check', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ type, id, password })
+				body: JSON.stringify({ view_id: viewId, password })
 			});
 
 			if (!response.ok) {
@@ -32,7 +33,13 @@
 				return;
 			}
 
-			dispatch('verified');
+			const data = await response.json();
+
+			// Dispatch with token so parent can set cookie and reload
+			dispatch('verified', {
+				token: data.access_token,
+				expiresIn: data.expires_in
+			});
 		} catch (err) {
 			error = 'Failed to verify password';
 		} finally {
@@ -93,7 +100,7 @@
 
 		<div class="mt-6 text-center">
 			<a href="/" class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
-				← Back to main profile
+				Back to main profile
 			</a>
 		</div>
 	</div>

--- a/frontend/src/lib/tokens.ts
+++ b/frontend/src/lib/tokens.ts
@@ -1,0 +1,86 @@
+/**
+ * Token management utilities for share tokens and password JWTs
+ *
+ * Tokens are stored in httpOnly cookies for SSR access and cleaned from URLs.
+ */
+
+import type { Cookies } from '@sveltejs/kit';
+
+export const TOKEN_COOKIES = {
+	SHARE: 'me_share_token',
+	PASSWORD: 'me_password_token'
+} as const;
+
+// Cookie options for tokens
+const COOKIE_OPTIONS = {
+	path: '/',
+	httpOnly: true,
+	sameSite: 'lax' as const,
+	// Secure in production (HTTPS)
+	secure: typeof process !== 'undefined' && process.env.NODE_ENV === 'production'
+};
+
+/**
+ * Set a share token cookie
+ */
+export function setShareToken(cookies: Cookies, token: string, maxAge = 7 * 24 * 60 * 60) {
+	cookies.set(TOKEN_COOKIES.SHARE, token, {
+		...COOKIE_OPTIONS,
+		maxAge
+	});
+}
+
+/**
+ * Get share token from cookies
+ */
+export function getShareToken(cookies: Cookies): string | null {
+	return cookies.get(TOKEN_COOKIES.SHARE) || null;
+}
+
+/**
+ * Clear share token cookie
+ */
+export function clearShareToken(cookies: Cookies) {
+	cookies.delete(TOKEN_COOKIES.SHARE, { path: '/' });
+}
+
+/**
+ * Set a password JWT cookie
+ */
+export function setPasswordToken(cookies: Cookies, token: string, maxAge = 60 * 60) {
+	cookies.set(TOKEN_COOKIES.PASSWORD, token, {
+		...COOKIE_OPTIONS,
+		maxAge
+	});
+}
+
+/**
+ * Get password token from cookies
+ */
+export function getPasswordToken(cookies: Cookies): string | null {
+	return cookies.get(TOKEN_COOKIES.PASSWORD) || null;
+}
+
+/**
+ * Clear password token cookie
+ */
+export function clearPasswordToken(cookies: Cookies) {
+	cookies.delete(TOKEN_COOKIES.PASSWORD, { path: '/' });
+}
+
+/**
+ * Build headers for API requests with available tokens
+ */
+export function buildTokenHeaders(shareToken: string | null, passwordToken: string | null): Record<string, string> {
+	const headers: Record<string, string> = {};
+
+	if (shareToken) {
+		headers['X-Share-Token'] = shareToken;
+	}
+
+	if (passwordToken) {
+		headers['Authorization'] = passwordToken;
+	}
+
+	return headers;
+}

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -1,16 +1,28 @@
 import type { PageServerLoad } from './$types';
-import PocketBase from 'pocketbase';
 
 export const load: PageServerLoad = async ({ fetch }) => {
-	const pb = new PocketBase(process.env.POCKETBASE_URL || 'http://localhost:8090');
+	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
 
 	try {
-		// Fetch profile
-		const profileRecords = await pb.collection('profile').getList(1, 1);
-		const profile = profileRecords.items[0] || null;
+		// Fetch all public content from the API
+		const response = await fetch(`${pbUrl}/api/homepage`);
 
-		// Check visibility
-		if (profile && profile.visibility === 'private') {
+		if (!response.ok) {
+			console.error('Homepage API error:', response.status);
+			return {
+				profile: null,
+				experience: [],
+				projects: [],
+				education: [],
+				skills: [],
+				error: 'Failed to load profile'
+			};
+		}
+
+		const data = await response.json();
+
+		// Check if profile is private
+		if (!data.profile) {
 			return {
 				profile: null,
 				experience: [],
@@ -21,39 +33,24 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			};
 		}
 
-		// Fetch all public content in parallel
-		const [experienceRes, projectsRes, educationRes, skillsRes] = await Promise.all([
-			pb.collection('experience').getList(1, 100, {
-				filter: "visibility != 'private' && is_draft = false",
-				sort: '-sort_order,-start_date'
-			}).catch(() => ({ items: [] })),
-			pb.collection('projects').getList(1, 100, {
-				filter: "visibility != 'private' && is_draft = false",
-				sort: '-is_featured,-sort_order'
-			}).catch(() => ({ items: [] })),
-			pb.collection('education').getList(1, 100, {
-				filter: "visibility != 'private' && is_draft = false",
-				sort: '-sort_order,-end_date'
-			}).catch(() => ({ items: [] })),
-			pb.collection('skills').getList(1, 200, {
-				filter: "visibility != 'private'",
-				sort: 'category,sort_order'
-			}).catch(() => ({ items: [] }))
-		]);
+		// Map API response to expected format
+		const profile = data.profile ? {
+			...data.profile,
+			hero_image: data.profile.hero_image_url || null,
+			avatar: data.profile.avatar_url || null
+		} : null;
+
+		const projects = (data.projects || []).map((p: Record<string, unknown>) => ({
+			...p,
+			cover_image: p.cover_image_url || null
+		}));
 
 		return {
-			profile: profile ? {
-				...profile,
-				hero_image: profile.hero_image ? pb.files.getURL(profile, profile.hero_image) : null,
-				avatar: profile.avatar ? pb.files.getURL(profile, profile.avatar) : null
-			} : null,
-			experience: experienceRes.items,
-			projects: projectsRes.items.map((p: Record<string, unknown>) => ({
-				...p,
-				cover_image: p.cover_image ? pb.files.getURL(p, p.cover_image as string) : null
-			})),
-			education: educationRes.items,
-			skills: skillsRes.items
+			profile,
+			experience: data.experience || [],
+			projects,
+			education: data.education || [],
+			skills: data.skills || []
 		};
 	} catch (error) {
 		console.error('Failed to load profile data:', error);

--- a/frontend/src/routes/v/[slug]/+page.server.ts
+++ b/frontend/src/routes/v/[slug]/+page.server.ts
@@ -1,14 +1,22 @@
-import type { PageServerLoad } from './$types';
-import PocketBase from 'pocketbase';
+import type { PageServerLoad, Actions } from './$types';
 import { error } from '@sveltejs/kit';
+import { getShareToken, getPasswordToken, setPasswordToken, buildTokenHeaders } from '$lib/tokens';
 
-export const load: PageServerLoad = async ({ params }) => {
-	const pb = new PocketBase(process.env.POCKETBASE_URL || 'http://localhost:8090');
+export const load: PageServerLoad = async ({ params, cookies, url }) => {
+	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
 	const { slug } = params;
+
+	// Get tokens from cookies (set by /s/[token] or password flow)
+	const shareToken = getShareToken(cookies);
+	const passwordToken = getPasswordToken(cookies);
+
+	// Also check for legacy URL token (for backwards compatibility, will be cleaned client-side)
+	const urlToken = url.searchParams.get('t');
+	const effectiveShareToken = shareToken || urlToken;
 
 	try {
 		// Get view access info
-		const response = await fetch(`${pb.baseURL}/api/view/${slug}/access`);
+		const response = await fetch(`${pbUrl}/api/view/${slug}/access`);
 		if (!response.ok) {
 			throw error(404, 'View not found');
 		}
@@ -20,22 +28,51 @@ export const load: PageServerLoad = async ({ params }) => {
 			throw error(404, 'View not found');
 		}
 
-		if (accessInfo.visibility === 'unlisted') {
-			// Unlisted views require a share token
+		// For unlisted views, we need a share token
+		if (accessInfo.visibility === 'unlisted' && !effectiveShareToken) {
 			throw error(404, 'View not found');
 		}
 
-		// Fetch view data
-		const dataResponse = await fetch(`${pb.baseURL}/api/view/${slug}/data`);
+		// For password-protected views without a token, return minimal data for password prompt
+		if (accessInfo.visibility === 'password' && !passwordToken) {
+			return {
+				view: {
+					id: accessInfo.view_id,
+					slug,
+					name: accessInfo.view_name || 'Protected View'
+				},
+				profile: null,
+				sections: {},
+				requiresPassword: true
+			};
+		}
+
+		// Build headers with available tokens
+		const headers = buildTokenHeaders(effectiveShareToken, passwordToken);
+
+		// Fetch view data with tokens
+		const dataResponse = await fetch(`${pbUrl}/api/view/${slug}/data`, { headers });
+
 		if (!dataResponse.ok) {
+			// If we have a token but it's invalid, show appropriate error
+			if (dataResponse.status === 401 || dataResponse.status === 403) {
+				if (accessInfo.visibility === 'password') {
+					return {
+						view: { id: accessInfo.view_id, slug, name: accessInfo.view_name || 'Protected View' },
+						profile: null,
+						sections: {},
+						requiresPassword: true
+					};
+				}
+				throw error(404, 'View not found');
+			}
 			throw error(404, 'View not found');
 		}
 
 		const viewData = await dataResponse.json();
 
-		// Fetch profile
-		const profileRecords = await pb.collection('profile').getList(1, 1);
-		const profile = profileRecords.items[0] || null;
+		// Profile data comes from the API response (no direct PocketBase access)
+		const profile = viewData.profile || null;
 
 		return {
 			view: {
@@ -49,11 +86,12 @@ export const load: PageServerLoad = async ({ params }) => {
 			},
 			profile: profile ? {
 				...profile,
-				hero_image: profile.hero_image ? pb.files.getURL(profile, profile.hero_image) : null,
-				avatar: profile.avatar ? pb.files.getURL(profile, profile.avatar) : null
+				// File URLs come from API already resolved
+				hero_image: profile.hero_image_url || null,
+				avatar: profile.avatar_url || null
 			} : null,
 			sections: viewData.sections || {},
-			requiresPassword: accessInfo.visibility === 'password'
+			requiresPassword: false
 		};
 	} catch (err) {
 		if ((err as { status?: number }).status === 404) {
@@ -66,5 +104,20 @@ export const load: PageServerLoad = async ({ params }) => {
 			sections: {},
 			error: 'View not found'
 		};
+	}
+};
+
+// Form action to set password token cookie
+export const actions: Actions = {
+	setPasswordToken: async ({ cookies, request }) => {
+		const data = await request.formData();
+		const token = data.get('token') as string;
+		const maxAge = parseInt(data.get('maxAge') as string) || 3600;
+
+		if (token) {
+			setPasswordToken(cookies, token, maxAge);
+		}
+
+		return { success: true };
 	}
 };


### PR DESCRIPTION
Backend changes:
- Add /api/homepage endpoint for public content aggregation
- Add /api/view/{slug}/access endpoint returns view_name for frontend
- Add /api/view/{slug}/data returns profile data with file URLs
- Support X-Share-Token header for share token transport

Frontend changes:
- Create token utility ($lib/tokens.ts) for httpOnly cookie management
- Fix /s/[token] to store share token in cookie, redirect without URL token
- Fix /v/[slug] to read tokens from cookies, pass to API via headers
- Fix /v/[slug] to handle password-protected views with cookie-based JWT
- Fix PasswordPrompt to capture JWT and trigger cookie storage + reload
- Fix root homepage to use /api/homepage instead of direct PocketBase

Token flow:
- Share tokens: /s/[token] validates, sets cookie, redirects to /v/[slug]
- Password views: PasswordPrompt captures JWT, form action sets cookie
- SSR reads cookies and passes tokens to API via headers
- No tokens in URLs (clean URLs, no leaking via Referer/logs)

This eliminates all direct PocketBase collection access from public routes, ensuring the collection lockdown security model is maintained.