### PR TITLE
feat: Add project detail pages with public API endpoint

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -787,7 +787,7 @@ Based on codebase analysis, these features are incomplete or missing:
 
 | Gap | Current State | Impact |
 |-----|---------------|--------|
-| **Project detail pages** | Route exists, no implementation | Cannot deep-link to projects |
+| ~~**Project detail pages**~~ | ~~Route exists, no implementation~~ | ✅ Complete: `/projects/{slug}` |
 | **Post/blog pages** | Collection exists, no public UI | Cannot publish articles |
 | **Talks section** | Collection exists, no UI | Cannot showcase speaking |
 | **Certifications section** | Collection exists, no UI | Cannot show credentials |
@@ -801,7 +801,7 @@ Based on codebase analysis, these features are incomplete or missing:
 
 ### 13.2 Proposed Priority Order
 
-1. **Core content pages**: Project details, posts, talks, certifications
+1. **Core content pages**: ~~Project details~~, posts, talks, certifications
 2. **View editor improvements**: Drag-drop ordering, better section config
 3. **Share token management**: Full CRUD UI with usage stats
 4. **Resume export**: Generate PDF from profile/view
@@ -821,6 +821,7 @@ Based on codebase analysis, these features are incomplete or missing:
 | GET | `/api/default-view` | Normal | Get default view slug |
 | GET | `/api/view/{slug}/access` | Normal | Get view access requirements |
 | GET | `/api/view/{slug}/data` | Normal | Get view content |
+| GET | `/api/project/{slug}` | Normal | Get public project details |
 | GET | `/api/homepage` | Normal | Legacy aggregated content |
 | POST | `/api/share/validate` | Moderate | Validate share token |
 | POST | `/api/password/check` | Strict | Validate view password |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ This roadmap outlines the feature development plan for Me.yaml, organized into l
 
 ---
 
-## Phase 0: Foundation Stabilization (Current)
+## Phase 0: Foundation Stabilization (Complete)
 
 **Purpose**: Ensure the existing foundation is solid before adding new features.
 
@@ -36,18 +36,18 @@ None (this is the starting phase)
 
 ---
 
-## Phase 1: Content Completeness
+## Phase 1: Content Completeness (Current)
 
 **Purpose**: Fill in missing content types and their public-facing pages.
 
 ### Features
 
-#### 1.1 Project Detail Pages
-- [ ] Route: `/projects/<slug>`
-- [ ] Full project page with description, tech stack, media gallery
-- [ ] Links to GitHub, demo, etc.
-- [ ] Related projects (same categories)
-- [ ] Meta tags for sharing
+#### 1.1 Project Detail Pages (Complete)
+- [x] Route: `/projects/<slug>`
+- [x] Full project page with description, tech stack, media gallery
+- [x] Links to GitHub, demo, etc.
+- [ ] Related projects (same categories) — Deferred to Phase 2.5
+- [x] Meta tags for sharing (Open Graph)
 
 #### 1.2 Posts/Blog System
 - [ ] Route: `/posts/<slug>`

--- a/agent-instructions.md
+++ b/agent-instructions.md
@@ -1,0 +1,245 @@
+# Me.yaml Agent Instructions
+
+> **Reusable Phase Execution Prompt — Claude-Tuned**
+>
+> This prompt is explicitly written to prevent premature solutioning, doc drift, and "looks done" phases. It forces deliberate reasoning and verification.
+
+---
+
+## 0. Claude-Specific Operating Rules
+
+**Read these carefully. You are prone to:**
+
+- Skipping deep code reading
+- Overconfidence before verification
+- Treating documentation as an afterthought
+- Assuming intent instead of proving it
+
+**You must actively counter these tendencies:**
+
+- If you are unsure → **investigate**
+- If something "seems fine" → **verify it**
+- If anything is incomplete → **document it**
+
+---
+
+## 1. Your Role (All Hats, No Shortcuts)
+
+You are acting as:
+
+| Role | Responsibility |
+|------|----------------|
+| **Product Manager** | Define what and why |
+| **UX Designer** | Ensure usability and clarity |
+| **Software Architect** | Maintain system coherence |
+| **Senior Engineer** | Write quality, tested code |
+| **Documentation Owner** | Keep docs accurate and current |
+
+**You may not prioritize one role at the expense of the others.**
+
+**Speed is not a success metric.**
+
+---
+
+## 2. Mandatory Orientation Step (No Exceptions)
+
+Before selecting a phase, you **MUST**:
+
+1. Read the current repository state
+2. Read **all** existing docs:
+   - `DESIGN.md`
+   - `ARCHITECTURE.md`
+   - `ROADMAP.md`
+   - `IMPLEMENTATION_PLAN.md`
+   - `SECURITY.md`
+   - `DEV.md`
+3. Review recent commits and phase completion notes
+4. State (briefly) what you believe is:
+   - Complete
+   - Partially complete
+   - Not started
+
+> ⚠️ **If you skip this step, your output is invalid.**
+
+---
+
+## 3. Phase Selection (Justify It)
+
+Select one phase that:
+
+- Is **not** complete
+- Delivers **real user value**
+- Builds on **existing architecture**
+- Does **NOT** require a rewrite
+- Aligns with Me.yaml's **core purpose**
+
+Before implementation, you **MUST** explain:
+
+- Why this phase is the correct next one
+- What user problem it solves
+- What it intentionally does **not** solve
+
+**Tiebreaker:** If multiple phases qualify, choose the one that most improves the user's ability to express and share themselves accurately.
+
+---
+
+## 4. Scope Lock (No Creep)
+
+Define clearly:
+
+| Aspect | Description |
+|--------|-------------|
+| **In Scope** | What will be done this phase |
+| **Out of Scope** | What will NOT be done |
+| **Definition of Done** | Concrete acceptance criteria |
+
+**Anything deferred must be explicitly documented.**
+
+You may not leave implicit gaps.
+
+---
+
+## 5. Discovery & Design First (No Code Yet)
+
+Before writing code:
+
+1. Identify all related gaps
+2. Research current best practices (current year)
+3. Form explicit product, UX, and architectural stances
+
+**Define:**
+
+- Data model changes
+- API contracts
+- UX flows
+- Error and edge cases
+
+> 📝 **You must write this down before implementation.**
+
+---
+
+## 6. Implementation (Disciplined, Incremental)
+
+### Coding Standards
+
+- Follow existing patterns unless there is a clear reason not to
+- Avoid unnecessary abstraction
+- Preserve:
+  - Routing contracts
+  - Security invariants
+  - Visibility semantics
+
+### Hygiene Rules
+
+- Run tests early and often
+- Add tests for non-trivial logic
+- Fix any bug you encounter
+- Format code
+- Make small, coherent commits
+
+### On Failure
+
+If tests fail or bugs appear:
+
+```
+STOP → FIX → UPDATE DOCS → CONTINUE
+```
+
+---
+
+## 7. Documentation Contract (Strict)
+
+### 7.1 Continuous Documentation
+
+After every meaningful commit, you **MUST** update documentation to reflect:
+
+- What changed
+- Why it changed
+- Any new constraints or assumptions
+
+> **Docs must never lag behind code.**
+
+### 7.2 Explicit Incompleteness
+
+If anything is:
+- Deferred
+- Partially implemented
+- Blocked
+
+You **MUST** document:
+- What is incomplete
+- Why
+- Which future phase will address it
+
+> **"No comment" is not acceptable.**
+
+### 7.3 Documentation Targets
+
+Update whichever are affected:
+
+- `DESIGN.md`
+- `ARCHITECTURE.md`
+- `ROADMAP.md`
+- `IMPLEMENTATION_PLAN.md`
+- `SECURITY.md`
+- `DEV.md`
+
+**Documentation must describe reality, not intent.**
+
+---
+
+## 8. Testing & Verification (Required)
+
+You must verify:
+
+- End-to-end correctness
+- No regressions
+- Security invariants still hold
+- UX flows behave as designed
+
+Include:
+
+- Tests run
+- Manual verification where appropriate
+- Acceptance criteria confirmation
+
+---
+
+## 9. Environment Constraint
+
+In restricted environments, Go tooling must use:
+
+```bash
+export GOPROXY=https://goproxy.cn,https://proxy.golang.org,direct
+export GOSUMDB=off
+```
+
+**Assume this first if Go tooling fails.**
+
+---
+
+## 10. Final Response Format (Mandatory)
+
+Your response must include:
+
+1. **Selected Phase** (with rationale)
+2. **Scope Definition**
+3. **Design Summary**
+4. **Implementation Summary**
+5. **Testing & Verification**
+6. **Documentation Updates** (with explicit deferrals)
+7. **Repo Status** (tests passing, clean tree)
+8. **What This Unlocks Next** (1–2 sentences)
+
+---
+
+## 11. Final Rule
+
+**Do NOT ask for permission mid-phase.**
+
+If unsure:
+1. Make a reasonable assumption
+2. Document it
+3. Proceed
+
+**Complete the phase fully, cleanly, and professionally.**

--- a/frontend/src/components/public/ProjectsSection.svelte
+++ b/frontend/src/components/public/ProjectsSection.svelte
@@ -43,7 +43,7 @@
 					<div class="flex items-start justify-between gap-2">
 						<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
 							{#if project.slug}
-								<a href="/p/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+								<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
 									{project.title}
 								</a>
 							{:else}

--- a/frontend/src/params/slug.ts
+++ b/frontend/src/params/slug.ts
@@ -25,6 +25,7 @@ const RESERVED_SLUGS = new Set([
 	'api',
 	's',
 	'v',
+	'projects',
 	// SvelteKit internal
 	'_app',
 	'_',

--- a/frontend/src/routes/projects/[slug]/+page.server.ts
+++ b/frontend/src/routes/projects/[slug]/+page.server.ts
@@ -1,0 +1,48 @@
+/**
+ * Project detail route: /projects/[slug]
+ *
+ * Displays a single project with full details.
+ * Only public, non-draft projects are accessible.
+ * Private/unlisted/draft projects return 404 (non-discoverable).
+ */
+
+import type { PageServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, fetch }) => {
+	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
+	const { slug } = params;
+
+	try {
+		const response = await fetch(`${pbUrl}/api/project/${slug}`);
+
+		if (!response.ok) {
+			throw error(404, 'Not Found');
+		}
+
+		const project = await response.json();
+
+		return {
+			project: {
+				id: project.id,
+				title: project.title,
+				slug: project.slug,
+				summary: project.summary,
+				description: project.description,
+				tech_stack: project.tech_stack || [],
+				links: project.links || [],
+				categories: project.categories || [],
+				is_featured: project.is_featured,
+				cover_image_url: project.cover_image_url || null,
+				media_urls: project.media_urls || []
+			},
+			profile: project.profile || null
+		};
+	} catch (err) {
+		if ((err as { status?: number }).status === 404) {
+			throw err;
+		}
+		console.error('Failed to load project:', err);
+		throw error(404, 'Not Found');
+	}
+};

--- a/frontend/src/routes/projects/[slug]/+page.svelte
+++ b/frontend/src/routes/projects/[slug]/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { parseMarkdown } from '$lib/utils';
+	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
+	import Footer from '$components/public/Footer.svelte';
+
+	export let data: PageData;
+
+	function getLinkIcon(type: string) {
+		switch (type.toLowerCase()) {
+			case 'github':
+				return `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`;
+			case 'website':
+			case 'demo':
+				return `<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" /></svg>`;
+			case 'docs':
+			case 'documentation':
+				return `<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>`;
+			case 'npm':
+				return `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331zm4 0v1.336H8.001V8.667h5.334v5.332h-2.669v-.001zm12.001 0h-1.33v-4h-1.336v4h-1.335v-4h-1.33v4h-2.671V8.667h8.002v5.331z"/></svg>`;
+			default:
+				return `<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>`;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{data.project.title} | {data.profile?.name || 'Projects'}</title>
+	<meta name="description" content={data.project.summary || ''} />
+	<link rel="canonical" href="/projects/{data.project.slug}" />
+	<!-- Open Graph -->
+	<meta property="og:title" content={data.project.title} />
+	<meta property="og:description" content={data.project.summary || ''} />
+	<meta property="og:type" content="article" />
+	{#if data.project.cover_image_url}
+		<meta property="og:image" content={data.project.cover_image_url} />
+	{/if}
+</svelte:head>
+
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900">
+	<!-- Theme toggle -->
+	<div class="fixed top-4 right-4 z-40">
+		<ThemeToggle />
+	</div>
+
+	<!-- Hero section with cover image -->
+	<header class="relative bg-gradient-to-br from-gray-900 to-gray-800 text-white">
+		{#if data.project.cover_image_url}
+			<div class="absolute inset-0">
+				<img
+					src={data.project.cover_image_url}
+					alt=""
+					class="w-full h-full object-cover opacity-30"
+				/>
+				<div class="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/80 to-transparent" />
+			</div>
+		{/if}
+
+		<div class="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+			<!-- Back navigation -->
+			<a
+				href="/"
+				class="inline-flex items-center gap-2 text-gray-300 hover:text-white mb-6 transition-colors"
+			>
+				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+				</svg>
+				<span>Back to Profile</span>
+			</a>
+
+			<!-- Project title and badges -->
+			<div class="flex flex-wrap items-start gap-3 mb-4">
+				<h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold">
+					{data.project.title}
+				</h1>
+				{#if data.project.is_featured}
+					<span class="px-3 py-1 text-sm font-medium bg-yellow-500 text-yellow-900 rounded-full">
+						Featured
+					</span>
+				{/if}
+			</div>
+
+			<!-- Summary -->
+			{#if data.project.summary}
+				<p class="text-xl text-gray-300 max-w-3xl">
+					{data.project.summary}
+				</p>
+			{/if}
+
+			<!-- Links -->
+			{#if data.project.links && data.project.links.length > 0}
+				<div class="flex flex-wrap items-center gap-3 mt-6">
+					{#each data.project.links as link}
+						<a
+							href={link.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 transition-colors"
+						>
+							{@html getLinkIcon(link.type)}
+							<span class="capitalize">{link.type}</span>
+						</a>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</header>
+
+	<!-- Main content -->
+	<main class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+		<!-- Tech stack -->
+		{#if data.project.tech_stack && data.project.tech_stack.length > 0}
+			<section class="mb-10">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Tech Stack</h2>
+				<div class="flex flex-wrap gap-2">
+					{#each data.project.tech_stack as tech}
+						<span class="px-3 py-1.5 text-sm bg-primary-100 dark:bg-primary-900/30 text-primary-800 dark:text-primary-200 rounded-full">
+							{tech}
+						</span>
+					{/each}
+				</div>
+			</section>
+		{/if}
+
+		<!-- Categories -->
+		{#if data.project.categories && data.project.categories.length > 0}
+			<section class="mb-10">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Categories</h2>
+				<div class="flex flex-wrap gap-2">
+					{#each data.project.categories as category}
+						<span class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-full">
+							{category}
+						</span>
+					{/each}
+				</div>
+			</section>
+		{/if}
+
+		<!-- Description (Markdown) -->
+		{#if data.project.description}
+			<section class="mb-10">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">About</h2>
+				<div class="prose prose-lg dark:prose-invert max-w-none">
+					{@html parseMarkdown(data.project.description)}
+				</div>
+			</section>
+		{/if}
+
+		<!-- Media gallery -->
+		{#if data.project.media_urls && data.project.media_urls.length > 0}
+			<section class="mb-10">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Gallery</h2>
+				<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+					{#each data.project.media_urls as mediaUrl}
+						<a
+							href={mediaUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="block aspect-video overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800 hover:opacity-90 transition-opacity"
+						>
+							<img
+								src={mediaUrl}
+								alt="Project media"
+								class="w-full h-full object-cover"
+							/>
+						</a>
+					{/each}
+				</div>
+			</section>
+		{/if}
+	</main>
+
+	<!-- Footer -->
+	<Footer profile={data.profile} />
+</div>


### PR DESCRIPTION
Implements Phase 1.1 of the roadmap:
- Add GET /api/project/{slug} endpoint with visibility enforcement
- Create /projects/[slug] route with full project detail page
- Include tech stack, media gallery, links, and Open Graph meta tags
- Add 'projects' to reserved slugs (frontend + backend)
- Update project card links from /p/ to /projects/
- Add agent-instructions.md for Claude Code phase execution

Security: Only public, non-draft projects are accessible. Private/unlisted returns 404 to prevent discovery (consistent with view access model).

Deferred: Related projects feature moved to Phase 2.5.