### PR TITLE
feat: Add posts/blog system with public pages and admin CRUD

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,13 +49,14 @@ None (this is the starting phase)
 - [ ] Related projects (same categories) — Deferred to Phase 2.5
 - [x] Meta tags for sharing (Open Graph)
 
-#### 1.2 Posts/Blog System
-- [ ] Route: `/posts/<slug>`
-- [ ] Markdown rendering with syntax highlighting
-- [ ] Cover images
-- [ ] Tags with filtering
-- [ ] Previous/next navigation
-- [ ] Admin: Rich editor for posts
+#### 1.2 Posts/Blog System (Complete)
+- [x] Route: `/posts/<slug>`
+- [x] Markdown rendering with syntax highlighting
+- [x] Cover images
+- [x] Tags with filtering
+- [x] Previous/next navigation
+- [x] Admin: Full CRUD for posts
+- [ ] Rich text editor — Deferred (basic markdown sufficient)
 
 #### 1.3 Talks Section
 - [ ] Public display in profile

--- a/backend/hooks/routing_test.go
+++ b/backend/hooks/routing_test.go
@@ -199,9 +199,9 @@ func TestReservedSlugsProtection(t *testing.T) {
 // TestReservedSlugValidation verifies the isValidSlug function
 func TestReservedSlugValidation(t *testing.T) {
 	tests := []struct {
-		slug    string
-		valid   bool
-		reason  string
+		slug   string
+		valid  bool
+		reason string
 	}{
 		// Valid slugs
 		{"recruiter", true, "simple alphanumeric"},

--- a/frontend/src/components/public/PostsSection.svelte
+++ b/frontend/src/components/public/PostsSection.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import type { Post } from '$lib/pocketbase';
+	import { formatDate, truncate } from '$lib/utils';
+
+	export let items: Post[];
+</script>
+
+<section id="posts" class="mb-16">
+	<h2 class="section-title">Posts</h2>
+
+	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+		{#each items as post (post.id)}
+			<article class="card overflow-hidden group animate-fade-in">
+				{#if post.cover_image}
+					<div class="aspect-video overflow-hidden bg-gray-100 dark:bg-gray-700">
+						<img
+							src={post.cover_image}
+							alt={post.title}
+							class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+						/>
+					</div>
+				{:else}
+					<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
+						<svg class="w-12 h-12 text-white/50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
+						</svg>
+					</div>
+				{/if}
+
+				<div class="p-5">
+					<div class="flex items-start justify-between gap-2">
+						<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+							{#if post.slug}
+								<a href="/posts/{post.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+									{post.title}
+								</a>
+							{:else}
+								{post.title}
+							{/if}
+						</h3>
+					</div>
+
+					{#if post.published_at}
+						<time datetime={post.published_at} class="mt-1 text-sm text-gray-500 dark:text-gray-400 block">
+							{formatDate(post.published_at, { month: 'long', day: 'numeric', year: 'numeric' })}
+						</time>
+					{/if}
+
+					{#if post.excerpt}
+						<p class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+							{truncate(post.excerpt, 120)}
+						</p>
+					{/if}
+
+					{#if post.tags && post.tags.length > 0}
+						<div class="mt-3 flex flex-wrap gap-1.5">
+							{#each post.tags.slice(0, 4) as tag}
+								<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+									{tag}
+								</span>
+							{/each}
+							{#if post.tags.length > 4}
+								<span class="px-2 py-0.5 text-xs text-gray-500">
+									+{post.tags.length - 4}
+								</span>
+							{/if}
+						</div>
+					{/if}
+
+					{#if post.slug}
+						<div class="mt-4">
+							<a
+								href="/posts/{post.slug}"
+								class="inline-flex items-center gap-1.5 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
+							>
+								Read more
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+								</svg>
+							</a>
+						</div>
+					{/if}
+				</div>
+			</article>
+		{/each}
+	</div>
+</section>

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -96,6 +96,19 @@ export interface Skill {
 	sort_order: number;
 }
 
+export interface Post {
+	id: string;
+	title: string;
+	slug?: string;
+	excerpt?: string;
+	content?: string;
+	cover_image?: string;
+	tags?: string[];
+	visibility: 'public' | 'unlisted' | 'private';
+	is_draft: boolean;
+	published_at?: string;
+}
+
 export interface View {
 	id: string;
 	name: string;
@@ -201,6 +214,18 @@ export async function fetchSkills(): Promise<Skill[]> {
 			sort: 'category,sort_order'
 		});
 		return records.items as unknown as Skill[];
+	} catch {
+		return [];
+	}
+}
+
+export async function fetchPosts(): Promise<Post[]> {
+	try {
+		const records = await pb.collection('posts').getList(1, 100, {
+			filter: "visibility != 'private' && is_draft = false",
+			sort: '-published_at'
+		});
+		return records.items as unknown as Post[];
 	} catch {
 		return [];
 	}

--- a/frontend/src/params/slug.ts
+++ b/frontend/src/params/slug.ts
@@ -26,6 +26,7 @@ const RESERVED_SLUGS = new Set([
 	's',
 	'v',
 	'projects',
+	'posts',
 	// SvelteKit internal
 	'_app',
 	'_',

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -58,6 +58,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 						projects: viewData.sections?.projects || [],
 						education: viewData.sections?.education || [],
 						skills: viewData.sections?.skills || [],
+						posts: viewData.sections?.posts || [],
 						// Indicate this is a view-based homepage
 						isDefaultView: true
 					};
@@ -76,6 +77,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 				projects: [],
 				education: [],
 				skills: [],
+				posts: [],
 				error: 'Failed to load profile'
 			};
 		}
@@ -90,6 +92,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 				projects: [],
 				education: [],
 				skills: [],
+				posts: [],
 				error: 'Profile is private'
 			};
 		}
@@ -108,12 +111,18 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			cover_image: p.cover_image_url || null
 		}));
 
+		const posts = (data.posts || []).map((p: Record<string, unknown>) => ({
+			...p,
+			cover_image: p.cover_image_url || null
+		}));
+
 		return {
 			profile,
 			experience: data.experience || [],
 			projects,
 			education: data.education || [],
 			skills: data.skills || [],
+			posts,
 			// Indicate this is legacy homepage mode
 			isDefaultView: false
 		};
@@ -125,6 +134,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			projects: [],
 			education: [],
 			skills: [],
+			posts: [],
 			error: 'Failed to load profile'
 		};
 	}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import ProjectsSection from '$components/public/ProjectsSection.svelte';
 	import EducationSection from '$components/public/EducationSection.svelte';
 	import SkillsSection from '$components/public/SkillsSection.svelte';
+	import PostsSection from '$components/public/PostsSection.svelte';
 	import Footer from '$components/public/Footer.svelte';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
 
@@ -82,6 +83,10 @@
 
 			{#if data.skills.length > 0}
 				<SkillsSection items={data.skills} />
+			{/if}
+
+			{#if data.posts && data.posts.length > 0}
+				<PostsSection items={data.posts} />
 			{/if}
 		{/if}
 	</main>

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -7,6 +7,7 @@
 	import ProjectsSection from '$components/public/ProjectsSection.svelte';
 	import EducationSection from '$components/public/EducationSection.svelte';
 	import SkillsSection from '$components/public/SkillsSection.svelte';
+	import PostsSection from '$components/public/PostsSection.svelte';
 	import Footer from '$components/public/Footer.svelte';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
 	import PasswordPrompt from '$components/public/PasswordPrompt.svelte';
@@ -114,6 +115,10 @@
 
 			{#if data.sections?.skills?.length > 0}
 				<SkillsSection items={data.sections.skills} />
+			{/if}
+
+			{#if data.sections?.posts?.length > 0}
+				<PostsSection items={data.sections.posts} />
 			{/if}
 		</main>
 

--- a/frontend/src/routes/admin/posts/+page.svelte
+++ b/frontend/src/routes/admin/posts/+page.svelte
@@ -1,0 +1,455 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pb, type Post } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+	import { formatDate } from '$lib/utils';
+
+	let posts: Post[] = [];
+	let loading = true;
+	let showForm = false;
+	let editingPost: Post | null = null;
+
+	// Form fields
+	let title = '';
+	let slug = '';
+	let excerpt = '';
+	let content = '';
+	let tags: string[] = [];
+	let tagInput = '';
+	let visibility = 'public';
+	let isDraft = true;
+	let publishedAt = '';
+	let saving = false;
+
+	onMount(loadPosts);
+
+	async function loadPosts() {
+		loading = true;
+		try {
+			const records = await pb.collection('posts').getList(1, 100, {
+				sort: '-created'
+			});
+			posts = records.items as unknown as Post[];
+		} catch (err) {
+			console.error('Failed to load posts:', err);
+			toasts.add('error', 'Failed to load posts');
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		title = '';
+		slug = '';
+		excerpt = '';
+		content = '';
+		tags = [];
+		tagInput = '';
+		visibility = 'public';
+		isDraft = true;
+		publishedAt = '';
+		editingPost = null;
+	}
+
+	function openNewForm() {
+		resetForm();
+		showForm = true;
+	}
+
+	function openEditForm(post: Post) {
+		editingPost = post;
+		title = post.title;
+		slug = post.slug || '';
+		excerpt = post.excerpt || '';
+		content = post.content || '';
+		tags = post.tags || [];
+		visibility = post.visibility;
+		isDraft = post.is_draft;
+		publishedAt = post.published_at ? post.published_at.split('T')[0] : '';
+		showForm = true;
+	}
+
+	function closeForm() {
+		showForm = false;
+		resetForm();
+	}
+
+	function generateSlug() {
+		slug = title
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-|-$/g, '');
+	}
+
+	function addTag() {
+		const tag = tagInput.trim();
+		if (tag && !tags.includes(tag)) {
+			tags = [...tags, tag];
+		}
+		tagInput = '';
+	}
+
+	function removeTag(tag: string) {
+		tags = tags.filter(t => t !== tag);
+	}
+
+	function handleTagKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			addTag();
+		}
+	}
+
+	async function handleSubmit() {
+		if (!title.trim()) {
+			toasts.add('error', 'Title is required');
+			return;
+		}
+		if (!slug.trim()) {
+			toasts.add('error', 'Slug is required');
+			return;
+		}
+
+		saving = true;
+		try {
+			const data = {
+				title: title.trim(),
+				slug: slug.trim(),
+				excerpt: excerpt.trim(),
+				content: content,
+				tags: tags,
+				visibility,
+				is_draft: isDraft,
+				published_at: publishedAt ? new Date(publishedAt).toISOString() : null
+			};
+
+			if (editingPost) {
+				await pb.collection('posts').update(editingPost.id, data);
+				toasts.add('success', 'Post updated successfully');
+			} else {
+				await pb.collection('posts').create(data);
+				toasts.add('success', 'Post created successfully');
+			}
+
+			closeForm();
+			await loadPosts();
+		} catch (err: unknown) {
+			console.error('Failed to save post:', err);
+			const error = err as { data?: { data?: { slug?: { message?: string } } } };
+			if (error.data?.data?.slug?.message) {
+				toasts.add('error', 'Slug already exists');
+			} else {
+				toasts.add('error', 'Failed to save post');
+			}
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deletePost(post: Post) {
+		if (!confirm(`Are you sure you want to delete "${post.title}"?`)) {
+			return;
+		}
+
+		try {
+			await pb.collection('posts').delete(post.id);
+			toasts.add('success', 'Post deleted');
+			await loadPosts();
+		} catch (err) {
+			console.error('Failed to delete post:', err);
+			toasts.add('error', 'Failed to delete post');
+		}
+	}
+
+	async function togglePublish(post: Post) {
+		try {
+			const newDraftState = !post.is_draft;
+			await pb.collection('posts').update(post.id, {
+				is_draft: newDraftState,
+				published_at: newDraftState ? null : (post.published_at || new Date().toISOString())
+			});
+			toasts.add('success', newDraftState ? 'Post unpublished' : 'Post published');
+			await loadPosts();
+		} catch (err) {
+			console.error('Failed to toggle publish:', err);
+			toasts.add('error', 'Failed to update post');
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Posts | Me.yaml Admin</title>
+</svelte:head>
+
+<div class="max-w-5xl mx-auto">
+	<div class="flex items-center justify-between mb-6">
+		<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Posts</h1>
+		<button class="btn btn-primary" on:click={openNewForm}>
+			+ New Post
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading posts...</div>
+		</div>
+	{:else if showForm}
+		<!-- Post Form -->
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<div class="card p-6 space-y-4">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+						{editingPost ? 'Edit Post' : 'New Post'}
+					</h2>
+					<button type="button" class="text-gray-500 hover:text-gray-700" on:click={closeForm}>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+
+				<div>
+					<label for="title" class="label">Title *</label>
+					<input
+						type="text"
+						id="title"
+						bind:value={title}
+						class="input"
+						placeholder="My Awesome Post"
+						required
+						on:blur={() => !slug && generateSlug()}
+					/>
+				</div>
+
+				<div>
+					<label for="slug" class="label">
+						Slug *
+						<button type="button" class="text-xs text-primary-600 ml-2" on:click={generateSlug}>
+							Generate from title
+						</button>
+					</label>
+					<input
+						type="text"
+						id="slug"
+						bind:value={slug}
+						class="input"
+						placeholder="my-awesome-post"
+						required
+					/>
+					<p class="text-xs text-gray-500 mt-1">URL: /posts/{slug || 'my-awesome-post'}</p>
+				</div>
+
+				<div>
+					<label for="excerpt" class="label">Excerpt</label>
+					<textarea
+						id="excerpt"
+						bind:value={excerpt}
+						class="input"
+						rows="2"
+						placeholder="A brief summary of the post..."
+					></textarea>
+				</div>
+
+				<div>
+					<label for="content" class="label">Content</label>
+					<textarea
+						id="content"
+						bind:value={content}
+						class="input min-h-[300px] font-mono text-sm"
+						placeholder="Write your post content here... (Markdown supported)"
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">Markdown formatting is supported</p>
+				</div>
+
+				<div>
+					<span class="label">Tags</span>
+					<div class="flex flex-wrap gap-2 mb-2">
+						{#each tags as tag}
+							<span class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-sm">
+								{tag}
+								<button type="button" class="text-gray-500 hover:text-red-500" on:click={() => removeTag(tag)}>
+									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+									</svg>
+								</button>
+							</span>
+						{/each}
+					</div>
+					<div class="flex gap-2">
+						<input
+							type="text"
+							bind:value={tagInput}
+							class="input flex-1"
+							placeholder="Add a tag..."
+							on:keydown={handleTagKeydown}
+						/>
+						<button type="button" class="btn btn-secondary" on:click={addTag}>Add</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Publishing</h2>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public</option>
+							<option value="unlisted">Unlisted</option>
+							<option value="private">Private</option>
+						</select>
+					</div>
+
+					<div>
+						<label for="published_at" class="label">Publish Date</label>
+						<input
+							type="date"
+							id="published_at"
+							bind:value={publishedAt}
+							class="input"
+						/>
+					</div>
+				</div>
+
+				<div class="flex items-center gap-2">
+					<input
+						type="checkbox"
+						id="is_draft"
+						bind:checked={isDraft}
+						class="w-4 h-4 text-primary-600 rounded border-gray-300"
+					/>
+					<label for="is_draft" class="text-sm text-gray-700 dark:text-gray-300">
+						Save as draft (won't be visible publicly)
+					</label>
+				</div>
+			</div>
+
+			<div class="flex justify-end gap-3">
+				<button type="button" class="btn btn-secondary" on:click={closeForm}>Cancel</button>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					{editingPost ? 'Update Post' : 'Create Post'}
+				</button>
+			</div>
+		</form>
+	{:else if posts.length === 0}
+		<div class="card p-8 text-center">
+			<svg class="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+			</svg>
+			<h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No posts yet</h3>
+			<p class="text-gray-500 dark:text-gray-400 mb-4">
+				Start writing to share your thoughts and ideas.
+			</p>
+			<button class="btn btn-primary" on:click={openNewForm}>
+				Write your first post
+			</button>
+		</div>
+	{:else}
+		<!-- Posts List -->
+		<div class="space-y-4">
+			{#each posts as post (post.id)}
+				<div class="card p-4 hover:shadow-md transition-shadow">
+					<div class="flex items-start gap-4">
+						<div class="flex-1 min-w-0">
+							<div class="flex items-center gap-2 mb-1">
+								<h3 class="text-lg font-medium text-gray-900 dark:text-white truncate">
+									{post.title}
+								</h3>
+								{#if post.is_draft}
+									<span class="px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
+										Draft
+									</span>
+								{:else}
+									<span class="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 rounded">
+										Published
+									</span>
+								{/if}
+								<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded capitalize">
+									{post.visibility}
+								</span>
+							</div>
+
+							{#if post.excerpt}
+								<p class="text-sm text-gray-600 dark:text-gray-400 mb-2 line-clamp-2">
+									{post.excerpt}
+								</p>
+							{/if}
+
+							<div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+								{#if post.slug}
+									<span>/posts/{post.slug}</span>
+								{/if}
+								{#if post.published_at}
+									<span>Published: {formatDate(post.published_at, { month: 'short', day: 'numeric', year: 'numeric' })}</span>
+								{/if}
+								{#if post.tags && post.tags.length > 0}
+									<span class="flex items-center gap-1">
+										<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+										</svg>
+										{post.tags.length} {post.tags.length === 1 ? 'tag' : 'tags'}
+									</span>
+								{/if}
+							</div>
+						</div>
+
+						<div class="flex items-center gap-2 shrink-0">
+							{#if post.slug && !post.is_draft && post.visibility === 'public'}
+								<a
+									href="/posts/{post.slug}"
+									target="_blank"
+									class="btn btn-ghost btn-sm"
+									title="View post"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+									</svg>
+								</a>
+							{/if}
+							<button
+								class="btn btn-ghost btn-sm"
+								title={post.is_draft ? 'Publish' : 'Unpublish'}
+								on:click={() => togglePublish(post)}
+							>
+								{#if post.is_draft}
+									<svg class="w-4 h-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+									</svg>
+								{:else}
+									<svg class="w-4 h-4 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+									</svg>
+								{/if}
+							</button>
+							<button
+								class="btn btn-ghost btn-sm"
+								title="Edit"
+								on:click={() => openEditForm(post)}
+							>
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+								</svg>
+							</button>
+							<button
+								class="btn btn-ghost btn-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+								title="Delete"
+								on:click={() => deletePost(post)}
+							>
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+								</svg>
+							</button>
+						</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/posts/[slug]/+page.server.ts
+++ b/frontend/src/routes/posts/[slug]/+page.server.ts
@@ -1,0 +1,49 @@
+/**
+ * Post detail route: /posts/[slug]
+ *
+ * Displays a single blog post with full content.
+ * Only public, non-draft posts are accessible.
+ * Private/unlisted/draft posts return 404 (non-discoverable).
+ */
+
+import type { PageServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, fetch }) => {
+	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
+	const { slug } = params;
+
+	try {
+		const response = await fetch(`${pbUrl}/api/post/${slug}`);
+
+		if (!response.ok) {
+			throw error(404, 'Not Found');
+		}
+
+		const post = await response.json();
+
+		return {
+			post: {
+				id: post.id,
+				title: post.title,
+				slug: post.slug,
+				excerpt: post.excerpt || null,
+				content: post.content || '',
+				tags: post.tags || [],
+				published_at: post.published_at || null,
+				created: post.created,
+				updated: post.updated,
+				cover_image_url: post.cover_image_url || null
+			},
+			profile: post.profile || null,
+			prev_post: post.prev_post || null,
+			next_post: post.next_post || null
+		};
+	} catch (err) {
+		if ((err as { status?: number }).status === 404) {
+			throw err;
+		}
+		console.error('Failed to load post:', err);
+		throw error(404, 'Not Found');
+	}
+};

--- a/frontend/src/routes/posts/[slug]/+page.svelte
+++ b/frontend/src/routes/posts/[slug]/+page.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { parseMarkdown, formatDate } from '$lib/utils';
+	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
+	import Footer from '$components/public/Footer.svelte';
+
+	export let data: PageData;
+
+	// Format the published date
+	$: publishedDate = data.post.published_at ? formatDate(data.post.published_at) : null;
+</script>
+
+<svelte:head>
+	<title>{data.post.title} | {data.profile?.name || 'Blog'}</title>
+	<meta name="description" content={data.post.excerpt || ''} />
+	<link rel="canonical" href="/posts/{data.post.slug}" />
+	<!-- Open Graph -->
+	<meta property="og:title" content={data.post.title} />
+	<meta property="og:description" content={data.post.excerpt || ''} />
+	<meta property="og:type" content="article" />
+	{#if data.post.cover_image_url}
+		<meta property="og:image" content={data.post.cover_image_url} />
+	{/if}
+	{#if publishedDate}
+		<meta property="article:published_time" content={data.post.published_at} />
+	{/if}
+</svelte:head>
+
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900">
+	<!-- Theme toggle -->
+	<div class="fixed top-4 right-4 z-40">
+		<ThemeToggle />
+	</div>
+
+	<!-- Hero section with cover image -->
+	<header class="relative bg-gradient-to-br from-gray-900 to-gray-800 text-white">
+		{#if data.post.cover_image_url}
+			<div class="absolute inset-0">
+				<img
+					src={data.post.cover_image_url}
+					alt=""
+					class="w-full h-full object-cover opacity-30"
+				/>
+				<div class="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/80 to-transparent" />
+			</div>
+		{/if}
+
+		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+			<!-- Back navigation -->
+			<a
+				href="/"
+				class="inline-flex items-center gap-2 text-gray-300 hover:text-white mb-6 transition-colors"
+			>
+				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+				</svg>
+				<span>Back to Profile</span>
+			</a>
+
+			<!-- Post title -->
+			<h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight">
+				{data.post.title}
+			</h1>
+
+			<!-- Meta information -->
+			<div class="mt-6 flex flex-wrap items-center gap-4 text-gray-300">
+				{#if publishedDate}
+					<time datetime={data.post.published_at} class="flex items-center gap-2">
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+						</svg>
+						{publishedDate}
+					</time>
+				{/if}
+
+				{#if data.profile?.name}
+					<span class="flex items-center gap-2">
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+						</svg>
+						{data.profile.name}
+					</span>
+				{/if}
+			</div>
+
+			<!-- Tags -->
+			{#if data.post.tags && data.post.tags.length > 0}
+				<div class="mt-4 flex flex-wrap gap-2">
+					{#each data.post.tags as tag}
+						<span class="px-3 py-1 text-sm bg-white/10 rounded-full">
+							{tag}
+						</span>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</header>
+
+	<!-- Main content -->
+	<main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+		<!-- Excerpt -->
+		{#if data.post.excerpt}
+			<p class="text-xl text-gray-600 dark:text-gray-400 mb-8 italic border-l-4 border-primary-500 pl-4">
+				{data.post.excerpt}
+			</p>
+		{/if}
+
+		<!-- Content (Markdown) -->
+		{#if data.post.content}
+			<article class="prose prose-lg dark:prose-invert max-w-none prose-headings:scroll-mt-20 prose-a:text-primary-600 dark:prose-a:text-primary-400 prose-img:rounded-lg prose-pre:bg-gray-800 dark:prose-pre:bg-gray-950">
+				{@html parseMarkdown(data.post.content)}
+			</article>
+		{/if}
+
+		<!-- Previous/Next navigation -->
+		{#if data.prev_post || data.next_post}
+			<nav class="mt-16 pt-8 border-t border-gray-200 dark:border-gray-700">
+				<div class="flex flex-col sm:flex-row justify-between gap-4">
+					{#if data.prev_post}
+						<a
+							href="/posts/{data.prev_post.slug}"
+							class="group flex-1 p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-500 dark:hover:border-primary-500 transition-colors"
+						>
+							<span class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1">
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+								</svg>
+								Previous
+							</span>
+							<span class="mt-1 text-gray-900 dark:text-white font-medium group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors block">
+								{data.prev_post.title}
+							</span>
+						</a>
+					{:else}
+						<div class="flex-1"></div>
+					{/if}
+
+					{#if data.next_post}
+						<a
+							href="/posts/{data.next_post.slug}"
+							class="group flex-1 p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-500 dark:hover:border-primary-500 transition-colors text-right"
+						>
+							<span class="text-sm text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
+								Next
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+								</svg>
+							</span>
+							<span class="mt-1 text-gray-900 dark:text-white font-medium group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors block">
+								{data.next_post.title}
+							</span>
+						</a>
+					{/if}
+				</div>
+			</nav>
+		{/if}
+	</main>
+
+	<!-- Footer -->
+	<Footer profile={data.profile} />
+</div>


### PR DESCRIPTION
Implements Phase 1.2 of the roadmap - Posts/Blog System:
- Backend API endpoint for public posts (/api/post/{slug})
- Frontend post detail page route (/posts/{slug})
- PostsSection component for homepage/views
- Admin posts page with full CRUD functionality
- Posts included in homepage data aggregation
- Previous/next navigation between posts
- Tags support with filtering
- Cover image support
- 'posts' added to reserved slugs list