### PR TITLE
feat: Add view editor with section/item selection and default view ma…

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -791,8 +791,8 @@ Based on codebase analysis, these features are incomplete or missing:
 | ~~**Post/blog pages**~~ | ~~Collection exists, no public UI~~ | ✅ Complete: `/posts/{slug}` |
 | ~~**Talks section**~~ | ~~Collection exists, no UI~~ | ✅ Complete: Public display with video embeds |
 | ~~**Certifications section**~~ | ~~Collection exists, no UI~~ | ✅ Complete: Public display with issuer grouping |
+| ~~**View editor**~~ | ~~Basic, no drag-drop~~ | ✅ Complete: Full editor with section/item selection |
 | **Media library** | No implementation | Cannot manage uploaded files |
-| **View editor** | Basic, no drag-drop | Limited section/item ordering |
 | **Share token management UI** | Listed in views page, no full UI | Cannot manage tokens easily |
 | **Scheduled GitHub sync** | Not implemented | Manual refresh only |
 | **Resume PDF export** | Not implemented | Cannot generate printable resume |
@@ -802,13 +802,14 @@ Based on codebase analysis, these features are incomplete or missing:
 ### 13.2 Proposed Priority Order
 
 1. ~~**Core content pages**: Project details, posts, talks, certifications~~ ✅ Complete
-2. **View editor improvements**: Drag-drop ordering, better section config
-3. **Share token management**: Full CRUD UI with usage stats
-4. **Resume export**: Generate PDF from profile/view
-5. **Theme system**: Light/dark modes, color customization
-6. **Scheduled sync**: Cron-based GitHub refresh
-7. **Media library**: Upload management, image optimization
-8. **Audit log**: Access history for share tokens
+2. ~~**View editor core**: Section toggles, item selection, hero overrides~~ ✅ Complete
+3. **View editor improvements**: Drag-drop ordering, preview pane
+4. **Share token management**: Full CRUD UI with usage stats
+5. **Resume export**: Generate PDF from profile/view
+6. **Theme system**: Light/dark modes, color customization
+7. **Scheduled sync**: Cron-based GitHub refresh
+8. **Media library**: Upload management, image optimization
+9. **Audit log**: Access history for share tokens
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,21 +85,29 @@ None (this is the starting phase)
 
 ### Features
 
-#### 2.1 View Editor Overhaul
-- [ ] Drag-and-drop section ordering
-- [ ] Per-section item selection with checkboxes
-- [ ] Preview pane showing live result
-- [ ] Item reordering within sections
+#### 2.1 View Editor Core (Complete)
+- [x] View editor page (`/admin/views/[id]`)
+- [x] View create page (`/admin/views/new`)
+- [x] Per-section toggle controls (enable/disable sections)
+- [x] Per-section item selection with checkboxes
+- [x] Hero overrides (custom headline, summary per view)
+- [x] CTA configuration (button text and URL)
+- [x] Visibility settings (public, unlisted, password, private)
+- [ ] Drag-and-drop section ordering — Deferred (requires library)
+- [ ] Preview pane showing live result — Deferred to Phase 2.2
 
 #### 2.2 Section Customization
 - [ ] Custom section headings per view
 - [ ] Show/hide section titles
 - [ ] Section layout options (list, grid, compact)
+- [ ] Drag-and-drop section/item reordering
 
-#### 2.3 Default View Management
-- [ ] Clear UI for setting default view
-- [ ] Warning when changing default
-- [ ] Preview of how homepage will look
+#### 2.3 Default View Management (Complete)
+- [x] Clear UI for setting default view (checkbox in editor)
+- [x] Default view badge in views list
+- [x] Only one view can be default (enforced)
+- [ ] Warning when changing default — Minor, deferred
+- [ ] Preview of how homepage will look — Deferred to 2.2
 
 #### 2.4 View Analytics (Minimal)
 - [ ] View count per view (opt-in)

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -149,6 +149,7 @@ export interface View {
 	cta_url?: string;
 	sections?: ViewSection[];
 	is_active: boolean;
+	is_default?: boolean;
 }
 
 export interface ViewSection {

--- a/frontend/src/routes/admin/views/+page.svelte
+++ b/frontend/src/routes/admin/views/+page.svelte
@@ -14,7 +14,7 @@
 	async function loadViews() {
 		try {
 			const result = await pb.collection('views').getList(1, 50, {
-				sort: '-created'
+				sort: '-is_default,-created'
 			});
 			views = result.items;
 		} catch (err) {
@@ -47,7 +47,7 @@
 	}
 
 	function copyViewUrl(slug: string) {
-		const url = `${window.location.origin}/v/${slug}`;
+		const url = `${window.location.origin}/${slug}`;
 		navigator.clipboard.writeText(url);
 		toasts.add('success', 'URL copied to clipboard');
 	}
@@ -83,8 +83,13 @@
 				<div class="card p-4">
 					<div class="flex items-start justify-between">
 						<div class="flex-1">
-							<div class="flex items-center gap-2">
+							<div class="flex items-center gap-2 flex-wrap">
 								<h3 class="font-medium text-gray-900 dark:text-white">{view.name}</h3>
+								{#if view.is_default}
+									<span class="px-2 py-0.5 text-xs bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300 rounded font-medium">
+										Default
+									</span>
+								{/if}
 								{#if !view.is_active}
 									<span class="px-2 py-0.5 text-xs bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 rounded">
 										Inactive
@@ -102,7 +107,7 @@
 								</span>
 							</div>
 							<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-								<code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">/v/{view.slug}</code>
+								<code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">/{view.slug}</code>
 								{#if view.description}
 									- {view.description}
 								{/if}
@@ -118,7 +123,7 @@
 								{@html icon('copy')}
 							</button>
 							<a
-								href="/v/{view.slug}"
+								href="/{view.slug}"
 								target="_blank"
 								class="btn btn-sm btn-ghost"
 								title="Preview"

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -1,0 +1,552 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { pb, type View, type ViewSection } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+
+	// Available sections - must match backend
+	const AVAILABLE_SECTIONS = [
+		{ key: 'experience', label: 'Experience', collection: 'experience' },
+		{ key: 'projects', label: 'Projects', collection: 'projects' },
+		{ key: 'education', label: 'Education', collection: 'education' },
+		{ key: 'certifications', label: 'Certifications', collection: 'certifications' },
+		{ key: 'skills', label: 'Skills', collection: 'skills' },
+		{ key: 'posts', label: 'Posts', collection: 'posts' },
+		{ key: 'talks', label: 'Talks', collection: 'talks' }
+	];
+
+	let loading = true;
+	let saving = false;
+	let view: View | null = null;
+
+	// Form fields
+	let name = '';
+	let slug = '';
+	let description = '';
+	let visibility: 'public' | 'unlisted' | 'private' | 'password' = 'public';
+	let heroHeadline = '';
+	let heroSummary = '';
+	let ctaText = '';
+	let ctaUrl = '';
+	let isActive = true;
+	let isDefault = false;
+
+	// Sections configuration
+	let sections: Record<string, { enabled: boolean; items: string[]; expanded: boolean }> = {};
+
+	// Available items for each section
+	let sectionItems: Record<string, Array<{ id: string; label: string; visibility: string; is_draft?: boolean }>> = {};
+
+	$: viewId = $page.params.id as string;
+
+	onMount(async () => {
+		if (!viewId) {
+			toasts.add('error', 'Invalid view ID');
+			goto('/admin/views');
+			return;
+		}
+		await loadView();
+		await loadSectionItems();
+	});
+
+	async function loadView() {
+		if (!viewId) return;
+		loading = true;
+		try {
+			const record = await pb.collection('views').getOne(viewId);
+			view = record as unknown as View;
+
+			// Populate form fields
+			name = view.name;
+			slug = view.slug;
+			description = view.description || '';
+			visibility = view.visibility;
+			heroHeadline = view.hero_headline || '';
+			heroSummary = view.hero_summary || '';
+			ctaText = view.cta_text || '';
+			ctaUrl = view.cta_url || '';
+			isActive = view.is_active;
+
+			// Check if this is the default view
+			const defaultViews = await pb.collection('views').getList(1, 1, {
+				filter: 'is_default = true'
+			});
+			isDefault = defaultViews.items.length > 0 && defaultViews.items[0].id === viewId;
+
+			// Initialize sections from view data
+			initializeSections(view.sections);
+		} catch (err) {
+			console.error('Failed to load view:', err);
+			toasts.add('error', 'Failed to load view');
+			goto('/admin/views');
+		} finally {
+			loading = false;
+		}
+	}
+
+	function initializeSections(viewSections?: ViewSection[]) {
+		// Start with all sections disabled
+		for (const section of AVAILABLE_SECTIONS) {
+			sections[section.key] = { enabled: false, items: [], expanded: false };
+		}
+
+		// Apply saved section configuration
+		if (viewSections) {
+			for (const vs of viewSections) {
+				if (sections[vs.section]) {
+					sections[vs.section].enabled = vs.enabled;
+					sections[vs.section].items = vs.items || [];
+				}
+			}
+		}
+	}
+
+	async function loadSectionItems() {
+		for (const section of AVAILABLE_SECTIONS) {
+			try {
+				const records = await pb.collection(section.collection).getList(1, 100, {
+					sort: '-created'
+				});
+
+				sectionItems[section.key] = records.items.map((item) => ({
+					id: item.id,
+					label: getItemLabel(section.key, item),
+					visibility: (item as Record<string, unknown>).visibility as string || 'public',
+					is_draft: (item as Record<string, unknown>).is_draft as boolean || false
+				}));
+			} catch (err) {
+				console.error(`Failed to load ${section.key} items:`, err);
+				sectionItems[section.key] = [];
+			}
+		}
+	}
+
+	function getItemLabel(sectionKey: string, item: Record<string, unknown>): string {
+		switch (sectionKey) {
+			case 'experience':
+				return `${item.title} at ${item.company}`;
+			case 'projects':
+				return item.title as string;
+			case 'education':
+				return `${item.degree || 'Degree'} - ${item.institution}`;
+			case 'certifications':
+				return `${item.name} (${item.issuer || 'Unknown issuer'})`;
+			case 'skills':
+				return `${item.name}${item.category ? ` (${item.category})` : ''}`;
+			case 'posts':
+				return item.title as string;
+			case 'talks':
+				return `${item.title}${item.event ? ` @ ${item.event}` : ''}`;
+			default:
+				return item.title as string || item.name as string || item.id as string;
+		}
+	}
+
+	function toggleSection(key: string) {
+		sections[key].enabled = !sections[key].enabled;
+		sections = sections; // Trigger reactivity
+	}
+
+	function toggleSectionExpand(key: string) {
+		sections[key].expanded = !sections[key].expanded;
+		sections = sections;
+	}
+
+	function toggleItem(sectionKey: string, itemId: string) {
+		const idx = sections[sectionKey].items.indexOf(itemId);
+		if (idx === -1) {
+			sections[sectionKey].items.push(itemId);
+		} else {
+			sections[sectionKey].items.splice(idx, 1);
+		}
+		sections = sections;
+	}
+
+	function selectAllItems(sectionKey: string) {
+		sections[sectionKey].items = sectionItems[sectionKey]?.map((i) => i.id) || [];
+		sections = sections;
+	}
+
+	function clearAllItems(sectionKey: string) {
+		sections[sectionKey].items = [];
+		sections = sections;
+	}
+
+	function generateSlug(value: string): string {
+		return value
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-+|-+$/g, '')
+			.slice(0, 50);
+	}
+
+	async function handleSubmit() {
+		if (!name.trim()) {
+			toasts.add('error', 'Name is required');
+			return;
+		}
+		if (!slug.trim()) {
+			toasts.add('error', 'Slug is required');
+			return;
+		}
+
+		saving = true;
+		try {
+			// Build sections array
+			const sectionsData: ViewSection[] = AVAILABLE_SECTIONS
+				.filter((s) => sections[s.key].enabled)
+				.map((s) => ({
+					section: s.key,
+					enabled: true,
+					items: sections[s.key].items
+				}));
+
+			const data = {
+				name: name.trim(),
+				slug: slug.trim(),
+				description: description.trim(),
+				visibility,
+				hero_headline: heroHeadline.trim() || null,
+				hero_summary: heroSummary.trim() || null,
+				cta_text: ctaText.trim() || null,
+				cta_url: ctaUrl.trim() || null,
+				is_active: isActive,
+				sections: sectionsData
+			};
+
+			await pb.collection('views').update(viewId, data);
+
+			// Handle default view setting
+			if (isDefault) {
+				// Clear other defaults first
+				const currentDefaults = await pb.collection('views').getList(1, 100, {
+					filter: `is_default = true && id != "${viewId}"`
+				});
+				for (const v of currentDefaults.items) {
+					await pb.collection('views').update(v.id, { is_default: false });
+				}
+				await pb.collection('views').update(viewId, { is_default: true });
+			}
+
+			toasts.add('success', 'View updated successfully');
+		} catch (err) {
+			console.error('Failed to save view:', err);
+			toasts.add('error', 'Failed to save view');
+		} finally {
+			saving = false;
+		}
+	}
+
+	function previewView() {
+		window.open(`/${slug}`, '_blank');
+	}
+</script>
+
+<svelte:head>
+	<title>Edit View | Me.yaml</title>
+</svelte:head>
+
+<div class="max-w-4xl mx-auto">
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading view...</div>
+		</div>
+	{:else}
+		<div class="flex items-center justify-between mb-6">
+			<div class="flex items-center gap-4">
+				<a href="/admin/views" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+					</svg>
+				</a>
+				<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Edit View</h1>
+			</div>
+			<div class="flex items-center gap-2">
+				<button type="button" class="btn btn-secondary" on:click={previewView}>
+					Preview
+				</button>
+				<button type="button" class="btn btn-primary" on:click={handleSubmit} disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					Save Changes
+				</button>
+			</div>
+		</div>
+
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<!-- Basic Info -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Basic Information</h2>
+
+				<div>
+					<label for="name" class="label">Name *</label>
+					<input
+						type="text"
+						id="name"
+						bind:value={name}
+						on:input={() => { if (!view?.slug) slug = generateSlug(name); }}
+						class="input"
+						placeholder="Recruiter View"
+						required
+					/>
+					<p class="text-xs text-gray-500 mt-1">Internal name for this view</p>
+				</div>
+
+				<div>
+					<label for="slug" class="label">URL Slug *</label>
+					<div class="flex items-center gap-2">
+						<span class="text-gray-500 text-sm">/</span>
+						<input
+							type="text"
+							id="slug"
+							bind:value={slug}
+							class="input flex-1"
+							placeholder="recruiter"
+							required
+						/>
+					</div>
+					<p class="text-xs text-gray-500 mt-1">Public URL will be: /{slug}</p>
+				</div>
+
+				<div>
+					<label for="description" class="label">Description</label>
+					<textarea
+						id="description"
+						bind:value={description}
+						class="input min-h-[80px]"
+						placeholder="Internal notes about this view..."
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">Private notes (not shown publicly)</p>
+				</div>
+			</div>
+
+			<!-- Hero Overrides -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Hero Overrides</h2>
+				<p class="text-sm text-gray-500 -mt-2">Override your profile headline and summary for this view</p>
+
+				<div>
+					<label for="hero_headline" class="label">Custom Headline</label>
+					<input
+						type="text"
+						id="hero_headline"
+						bind:value={heroHeadline}
+						class="input"
+						placeholder="Leave empty to use profile headline"
+					/>
+				</div>
+
+				<div>
+					<label for="hero_summary" class="label">Custom Summary</label>
+					<textarea
+						id="hero_summary"
+						bind:value={heroSummary}
+						class="input min-h-[120px]"
+						placeholder="Leave empty to use profile summary (Markdown supported)"
+					></textarea>
+				</div>
+			</div>
+
+			<!-- Call to Action -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Call to Action</h2>
+				<p class="text-sm text-gray-500 -mt-2">Add a prominent button to this view</p>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="cta_text" class="label">Button Text</label>
+						<input
+							type="text"
+							id="cta_text"
+							bind:value={ctaText}
+							class="input"
+							placeholder="Download Resume"
+						/>
+					</div>
+					<div>
+						<label for="cta_url" class="label">Button URL</label>
+						<input
+							type="url"
+							id="cta_url"
+							bind:value={ctaUrl}
+							class="input"
+							placeholder="https://..."
+						/>
+					</div>
+				</div>
+			</div>
+
+			<!-- Settings -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public - Anyone can access</option>
+							<option value="unlisted">Unlisted - Only with share token</option>
+							<option value="password">Password - Requires password</option>
+							<option value="private">Private - Admin only</option>
+						</select>
+					</div>
+				</div>
+
+				<div class="flex flex-col gap-3 pt-2">
+					<label class="flex items-center gap-3">
+						<input
+							type="checkbox"
+							bind:checked={isActive}
+							class="w-4 h-4 text-primary-600 rounded border-gray-300"
+						/>
+						<div>
+							<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Active</span>
+							<p class="text-xs text-gray-500">Inactive views are not accessible publicly</p>
+						</div>
+					</label>
+
+					<label class="flex items-center gap-3">
+						<input
+							type="checkbox"
+							bind:checked={isDefault}
+							class="w-4 h-4 text-primary-600 rounded border-gray-300"
+						/>
+						<div>
+							<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Default View</span>
+							<p class="text-xs text-gray-500">Show this view on the homepage (/)</p>
+						</div>
+					</label>
+				</div>
+			</div>
+
+			<!-- Sections -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Content Sections</h2>
+				<p class="text-sm text-gray-500 -mt-2">Choose which sections to show in this view. Expand each section to select specific items.</p>
+
+				<div class="space-y-3">
+					{#each AVAILABLE_SECTIONS as section}
+						{@const sectionConfig = sections[section.key] || { enabled: false, items: [], expanded: false }}
+						{@const items = sectionItems[section.key] || []}
+						{@const publicItems = items.filter(i => i.visibility !== 'private' && !i.is_draft)}
+
+						<div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+							<!-- Section Header -->
+							<div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50">
+								<div class="flex items-center gap-3">
+									<button
+										type="button"
+										class="w-10 h-6 rounded-full transition-colors relative
+											{sectionConfig.enabled ? 'bg-primary-600' : 'bg-gray-300 dark:bg-gray-600'}"
+										on:click={() => toggleSection(section.key)}
+									>
+										<span
+											class="absolute top-1 w-4 h-4 bg-white rounded-full transition-transform shadow-sm
+												{sectionConfig.enabled ? 'left-5' : 'left-1'}"
+										></span>
+									</button>
+									<span class="font-medium text-gray-900 dark:text-white">{section.label}</span>
+									<span class="text-xs text-gray-500">
+										{#if sectionConfig.items.length > 0}
+											{sectionConfig.items.length} selected
+										{:else if sectionConfig.enabled}
+											all items ({publicItems.length})
+										{:else}
+											{publicItems.length} available
+										{/if}
+									</span>
+								</div>
+
+								{#if sectionConfig.enabled && items.length > 0}
+									<button
+										type="button"
+										class="p-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+										on:click={() => toggleSectionExpand(section.key)}
+									>
+										<svg
+											class="w-5 h-5 transition-transform {sectionConfig.expanded ? 'rotate-180' : ''}"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+										</svg>
+									</button>
+								{/if}
+							</div>
+
+							<!-- Section Items -->
+							{#if sectionConfig.enabled && sectionConfig.expanded && items.length > 0}
+								<div class="p-3 border-t border-gray-200 dark:border-gray-700">
+									<div class="flex items-center justify-between mb-2">
+										<p class="text-xs text-gray-500">
+											{sectionConfig.items.length === 0
+												? 'All public items will be shown. Select specific items below to customize.'
+												: `${sectionConfig.items.length} of ${publicItems.length} items selected`}
+										</p>
+										<div class="flex gap-2">
+											<button
+												type="button"
+												class="text-xs text-primary-600 hover:underline"
+												on:click={() => selectAllItems(section.key)}
+											>
+												Select All
+											</button>
+											<button
+												type="button"
+												class="text-xs text-gray-500 hover:underline"
+												on:click={() => clearAllItems(section.key)}
+											>
+												Clear
+											</button>
+										</div>
+									</div>
+
+									<div class="space-y-1 max-h-48 overflow-y-auto">
+										{#each items as item}
+											{@const isSelected = sectionConfig.items.includes(item.id)}
+											<label class="flex items-center gap-2 p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer">
+												<input
+													type="checkbox"
+													checked={isSelected}
+													on:change={() => toggleItem(section.key, item.id)}
+													class="w-4 h-4 text-primary-600 rounded border-gray-300"
+												/>
+												<span class="flex-1 text-sm text-gray-700 dark:text-gray-300 truncate">
+													{item.label}
+												</span>
+												{#if item.visibility !== 'public'}
+													<span class="px-1.5 py-0.5 text-xs bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300 rounded">
+														{item.visibility}
+													</span>
+												{/if}
+												{#if item.is_draft}
+													<span class="px-1.5 py-0.5 text-xs bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 rounded">
+														draft
+													</span>
+												{/if}
+											</label>
+										{/each}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Form Actions (Mobile) -->
+			<div class="flex justify-end gap-3 md:hidden">
+				<a href="/admin/views" class="btn btn-secondary">Cancel</a>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{saving ? 'Saving...' : 'Save Changes'}
+				</button>
+			</div>
+		</form>
+	{/if}
+</div>

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -1,0 +1,512 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { pb, type ViewSection } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+
+	// Available sections - must match backend
+	const AVAILABLE_SECTIONS = [
+		{ key: 'experience', label: 'Experience', collection: 'experience' },
+		{ key: 'projects', label: 'Projects', collection: 'projects' },
+		{ key: 'education', label: 'Education', collection: 'education' },
+		{ key: 'certifications', label: 'Certifications', collection: 'certifications' },
+		{ key: 'skills', label: 'Skills', collection: 'skills' },
+		{ key: 'posts', label: 'Posts', collection: 'posts' },
+		{ key: 'talks', label: 'Talks', collection: 'talks' }
+	];
+
+	let loading = true;
+	let saving = false;
+
+	// Form fields
+	let name = '';
+	let slug = '';
+	let description = '';
+	let visibility: 'public' | 'unlisted' | 'private' | 'password' = 'public';
+	let heroHeadline = '';
+	let heroSummary = '';
+	let ctaText = '';
+	let ctaUrl = '';
+	let isActive = true;
+	let isDefault = false;
+
+	// Sections configuration
+	let sections: Record<string, { enabled: boolean; items: string[]; expanded: boolean }> = {};
+
+	// Available items for each section
+	let sectionItems: Record<string, Array<{ id: string; label: string; visibility: string; is_draft?: boolean }>> = {};
+
+	onMount(async () => {
+		initializeSections();
+		await loadSectionItems();
+		loading = false;
+	});
+
+	function initializeSections() {
+		// Start with all sections enabled by default for new views
+		for (const section of AVAILABLE_SECTIONS) {
+			sections[section.key] = { enabled: true, items: [], expanded: false };
+		}
+	}
+
+	async function loadSectionItems() {
+		for (const section of AVAILABLE_SECTIONS) {
+			try {
+				const records = await pb.collection(section.collection).getList(1, 100, {
+					sort: '-created'
+				});
+
+				sectionItems[section.key] = records.items.map((item) => ({
+					id: item.id,
+					label: getItemLabel(section.key, item),
+					visibility: (item as Record<string, unknown>).visibility as string || 'public',
+					is_draft: (item as Record<string, unknown>).is_draft as boolean || false
+				}));
+			} catch (err) {
+				console.error(`Failed to load ${section.key} items:`, err);
+				sectionItems[section.key] = [];
+			}
+		}
+	}
+
+	function getItemLabel(sectionKey: string, item: Record<string, unknown>): string {
+		switch (sectionKey) {
+			case 'experience':
+				return `${item.title} at ${item.company}`;
+			case 'projects':
+				return item.title as string;
+			case 'education':
+				return `${item.degree || 'Degree'} - ${item.institution}`;
+			case 'certifications':
+				return `${item.name} (${item.issuer || 'Unknown issuer'})`;
+			case 'skills':
+				return `${item.name}${item.category ? ` (${item.category})` : ''}`;
+			case 'posts':
+				return item.title as string;
+			case 'talks':
+				return `${item.title}${item.event ? ` @ ${item.event}` : ''}`;
+			default:
+				return item.title as string || item.name as string || item.id as string;
+		}
+	}
+
+	function toggleSection(key: string) {
+		sections[key].enabled = !sections[key].enabled;
+		sections = sections;
+	}
+
+	function toggleSectionExpand(key: string) {
+		sections[key].expanded = !sections[key].expanded;
+		sections = sections;
+	}
+
+	function toggleItem(sectionKey: string, itemId: string) {
+		const idx = sections[sectionKey].items.indexOf(itemId);
+		if (idx === -1) {
+			sections[sectionKey].items.push(itemId);
+		} else {
+			sections[sectionKey].items.splice(idx, 1);
+		}
+		sections = sections;
+	}
+
+	function selectAllItems(sectionKey: string) {
+		sections[sectionKey].items = sectionItems[sectionKey]?.map((i) => i.id) || [];
+		sections = sections;
+	}
+
+	function clearAllItems(sectionKey: string) {
+		sections[sectionKey].items = [];
+		sections = sections;
+	}
+
+	function generateSlug(value: string): string {
+		return value
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-+|-+$/g, '')
+			.slice(0, 50);
+	}
+
+	function handleNameInput() {
+		slug = generateSlug(name);
+	}
+
+	async function handleSubmit() {
+		if (!name.trim()) {
+			toasts.add('error', 'Name is required');
+			return;
+		}
+		if (!slug.trim()) {
+			toasts.add('error', 'Slug is required');
+			return;
+		}
+
+		// Check for reserved slugs
+		const reservedSlugs = [
+			'admin', 'api', 's', 'v', '_app', '_', 'assets', 'static',
+			'favicon.ico', 'robots.txt', 'sitemap.xml',
+			'health', 'healthz', 'ready', 'login', 'logout',
+			'auth', 'oauth', 'callback', 'home', 'index', 'default', 'profile',
+			'projects', 'posts', 'new'
+		];
+		if (reservedSlugs.includes(slug.toLowerCase())) {
+			toasts.add('error', `"${slug}" is a reserved slug. Please choose another.`);
+			return;
+		}
+
+		saving = true;
+		try {
+			// Build sections array
+			const sectionsData: ViewSection[] = AVAILABLE_SECTIONS
+				.filter((s) => sections[s.key].enabled)
+				.map((s) => ({
+					section: s.key,
+					enabled: true,
+					items: sections[s.key].items
+				}));
+
+			const data = {
+				name: name.trim(),
+				slug: slug.trim(),
+				description: description.trim(),
+				visibility,
+				hero_headline: heroHeadline.trim() || null,
+				hero_summary: heroSummary.trim() || null,
+				cta_text: ctaText.trim() || null,
+				cta_url: ctaUrl.trim() || null,
+				is_active: isActive,
+				is_default: isDefault,
+				sections: sectionsData
+			};
+
+			const newView = await pb.collection('views').create(data);
+
+			// If setting as default, clear other defaults
+			if (isDefault) {
+				const currentDefaults = await pb.collection('views').getList(1, 100, {
+					filter: `is_default = true && id != "${newView.id}"`
+				});
+				for (const v of currentDefaults.items) {
+					await pb.collection('views').update(v.id, { is_default: false });
+				}
+			}
+
+			toasts.add('success', 'View created successfully');
+			goto('/admin/views');
+		} catch (err) {
+			console.error('Failed to create view:', err);
+			const message = err instanceof Error ? err.message : 'Failed to create view';
+			if (message.includes('slug')) {
+				toasts.add('error', 'A view with this slug already exists');
+			} else {
+				toasts.add('error', message);
+			}
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Create View | Me.yaml</title>
+</svelte:head>
+
+<div class="max-w-4xl mx-auto">
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading...</div>
+		</div>
+	{:else}
+		<div class="flex items-center justify-between mb-6">
+			<div class="flex items-center gap-4">
+				<a href="/admin/views" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+					</svg>
+				</a>
+				<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Create View</h1>
+			</div>
+			<button type="button" class="btn btn-primary" on:click={handleSubmit} disabled={saving}>
+				{#if saving}
+					<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+					</svg>
+				{/if}
+				Create View
+			</button>
+		</div>
+
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<!-- Basic Info -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Basic Information</h2>
+
+				<div>
+					<label for="name" class="label">Name *</label>
+					<input
+						type="text"
+						id="name"
+						bind:value={name}
+						on:input={handleNameInput}
+						class="input"
+						placeholder="Recruiter View"
+						required
+					/>
+					<p class="text-xs text-gray-500 mt-1">Internal name for this view</p>
+				</div>
+
+				<div>
+					<label for="slug" class="label">URL Slug *</label>
+					<div class="flex items-center gap-2">
+						<span class="text-gray-500 text-sm">/</span>
+						<input
+							type="text"
+							id="slug"
+							bind:value={slug}
+							class="input flex-1"
+							placeholder="recruiter"
+							required
+						/>
+					</div>
+					<p class="text-xs text-gray-500 mt-1">Public URL will be: /{slug}</p>
+				</div>
+
+				<div>
+					<label for="description" class="label">Description</label>
+					<textarea
+						id="description"
+						bind:value={description}
+						class="input min-h-[80px]"
+						placeholder="Internal notes about this view..."
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">Private notes (not shown publicly)</p>
+				</div>
+			</div>
+
+			<!-- Hero Overrides -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Hero Overrides</h2>
+				<p class="text-sm text-gray-500 -mt-2">Override your profile headline and summary for this view</p>
+
+				<div>
+					<label for="hero_headline" class="label">Custom Headline</label>
+					<input
+						type="text"
+						id="hero_headline"
+						bind:value={heroHeadline}
+						class="input"
+						placeholder="Leave empty to use profile headline"
+					/>
+				</div>
+
+				<div>
+					<label for="hero_summary" class="label">Custom Summary</label>
+					<textarea
+						id="hero_summary"
+						bind:value={heroSummary}
+						class="input min-h-[120px]"
+						placeholder="Leave empty to use profile summary (Markdown supported)"
+					></textarea>
+				</div>
+			</div>
+
+			<!-- Call to Action -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Call to Action</h2>
+				<p class="text-sm text-gray-500 -mt-2">Add a prominent button to this view</p>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="cta_text" class="label">Button Text</label>
+						<input
+							type="text"
+							id="cta_text"
+							bind:value={ctaText}
+							class="input"
+							placeholder="Download Resume"
+						/>
+					</div>
+					<div>
+						<label for="cta_url" class="label">Button URL</label>
+						<input
+							type="url"
+							id="cta_url"
+							bind:value={ctaUrl}
+							class="input"
+							placeholder="https://..."
+						/>
+					</div>
+				</div>
+			</div>
+
+			<!-- Settings -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public - Anyone can access</option>
+							<option value="unlisted">Unlisted - Only with share token</option>
+							<option value="password">Password - Requires password</option>
+							<option value="private">Private - Admin only</option>
+						</select>
+					</div>
+				</div>
+
+				<div class="flex flex-col gap-3 pt-2">
+					<label class="flex items-center gap-3">
+						<input
+							type="checkbox"
+							bind:checked={isActive}
+							class="w-4 h-4 text-primary-600 rounded border-gray-300"
+						/>
+						<div>
+							<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Active</span>
+							<p class="text-xs text-gray-500">Inactive views are not accessible publicly</p>
+						</div>
+					</label>
+
+					<label class="flex items-center gap-3">
+						<input
+							type="checkbox"
+							bind:checked={isDefault}
+							class="w-4 h-4 text-primary-600 rounded border-gray-300"
+						/>
+						<div>
+							<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Default View</span>
+							<p class="text-xs text-gray-500">Show this view on the homepage (/)</p>
+						</div>
+					</label>
+				</div>
+			</div>
+
+			<!-- Sections -->
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Content Sections</h2>
+				<p class="text-sm text-gray-500 -mt-2">Choose which sections to show in this view. Expand each section to select specific items.</p>
+
+				<div class="space-y-3">
+					{#each AVAILABLE_SECTIONS as section}
+						{@const sectionConfig = sections[section.key] || { enabled: false, items: [], expanded: false }}
+						{@const items = sectionItems[section.key] || []}
+						{@const publicItems = items.filter(i => i.visibility !== 'private' && !i.is_draft)}
+
+						<div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+							<!-- Section Header -->
+							<div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50">
+								<div class="flex items-center gap-3">
+									<button
+										type="button"
+										class="w-10 h-6 rounded-full transition-colors relative
+											{sectionConfig.enabled ? 'bg-primary-600' : 'bg-gray-300 dark:bg-gray-600'}"
+										on:click={() => toggleSection(section.key)}
+									>
+										<span
+											class="absolute top-1 w-4 h-4 bg-white rounded-full transition-transform shadow-sm
+												{sectionConfig.enabled ? 'left-5' : 'left-1'}"
+										></span>
+									</button>
+									<span class="font-medium text-gray-900 dark:text-white">{section.label}</span>
+									<span class="text-xs text-gray-500">
+										{#if sectionConfig.items.length > 0}
+											{sectionConfig.items.length} selected
+										{:else if sectionConfig.enabled}
+											all items ({publicItems.length})
+										{:else}
+											{publicItems.length} available
+										{/if}
+									</span>
+								</div>
+
+								{#if sectionConfig.enabled && items.length > 0}
+									<button
+										type="button"
+										class="p-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+										on:click={() => toggleSectionExpand(section.key)}
+									>
+										<svg
+											class="w-5 h-5 transition-transform {sectionConfig.expanded ? 'rotate-180' : ''}"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+										</svg>
+									</button>
+								{/if}
+							</div>
+
+							<!-- Section Items -->
+							{#if sectionConfig.enabled && sectionConfig.expanded && items.length > 0}
+								<div class="p-3 border-t border-gray-200 dark:border-gray-700">
+									<div class="flex items-center justify-between mb-2">
+										<p class="text-xs text-gray-500">
+											{sectionConfig.items.length === 0
+												? 'All public items will be shown. Select specific items below to customize.'
+												: `${sectionConfig.items.length} of ${publicItems.length} items selected`}
+										</p>
+										<div class="flex gap-2">
+											<button
+												type="button"
+												class="text-xs text-primary-600 hover:underline"
+												on:click={() => selectAllItems(section.key)}
+											>
+												Select All
+											</button>
+											<button
+												type="button"
+												class="text-xs text-gray-500 hover:underline"
+												on:click={() => clearAllItems(section.key)}
+											>
+												Clear
+											</button>
+										</div>
+									</div>
+
+									<div class="space-y-1 max-h-48 overflow-y-auto">
+										{#each items as item}
+											{@const isSelected = sectionConfig.items.includes(item.id)}
+											<label class="flex items-center gap-2 p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer">
+												<input
+													type="checkbox"
+													checked={isSelected}
+													on:change={() => toggleItem(section.key, item.id)}
+													class="w-4 h-4 text-primary-600 rounded border-gray-300"
+												/>
+												<span class="flex-1 text-sm text-gray-700 dark:text-gray-300 truncate">
+													{item.label}
+												</span>
+												{#if item.visibility !== 'public'}
+													<span class="px-1.5 py-0.5 text-xs bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300 rounded">
+														{item.visibility}
+													</span>
+												{/if}
+												{#if item.is_draft}
+													<span class="px-1.5 py-0.5 text-xs bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 rounded">
+														draft
+													</span>
+												{/if}
+											</label>
+										{/each}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Form Actions (Mobile) -->
+			<div class="flex justify-end gap-3 md:hidden">
+				<a href="/admin/views" class="btn btn-secondary">Cancel</a>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{saving ? 'Creating...' : 'Create View'}
+				</button>
+			</div>
+		</form>
+	{/if}
+</div>


### PR DESCRIPTION
…nagement

- Add /admin/views/[id] page for editing existing views
- Add /admin/views/new page for creating new views
- Section toggle controls with expandable item selection
- Per-section item selection with checkboxes
- Hero overrides (custom headline/summary per view)
- CTA configuration (button text and URL)
- Visibility settings (public, unlisted, password, private)
- Default view management with single-default enforcement
- Add is_default field to View type
- Update views list to show Default badge
- Fix URLs to use canonical /{slug} pattern instead of /v/{slug}
- Update DESIGN.md and ROADMAP.md to reflect Phase 2.1 completion