### PR TITLE
feat: Add admin CRUD pages for experience, projects, education, and s…

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -91,20 +91,20 @@
 - [ ] Ensure accessibility (a11y)
 
 ### Milestone 5: Frontend - Admin Dashboard
-- [ ] Set up admin layout with sidebar
-- [ ] Implement OAuth login flow
-- [ ] Create admin routes:
-  - [ ] `/admin` - Dashboard overview
-  - [ ] `/admin/profile` - Edit profile
-  - [ ] `/admin/experience` - CRUD experience
-  - [ ] `/admin/projects` - CRUD projects
-  - [ ] `/admin/education` - CRUD education
-  - [ ] `/admin/certifications` - CRUD certs
-  - [ ] `/admin/skills` - CRUD skills
-  - [ ] `/admin/posts` - CRUD posts
-  - [ ] `/admin/talks` - CRUD talks
-  - [ ] `/admin/media` - Media library
-  - [ ] `/admin/settings` - AI providers
+- [x] Set up admin layout with sidebar
+- [x] Implement OAuth login flow
+- [x] Create admin routes:
+  - [x] `/admin` - Dashboard overview
+  - [x] `/admin/profile` - Edit profile
+  - [x] `/admin/experience` - CRUD experience
+  - [x] `/admin/projects` - CRUD projects
+  - [x] `/admin/education` - CRUD education
+  - [x] `/admin/certifications` - CRUD certs
+  - [x] `/admin/skills` - CRUD skills
+  - [x] `/admin/posts` - CRUD posts
+  - [x] `/admin/talks` - CRUD talks
+  - [ ] `/admin/media` - Media library (deferred to Phase 7)
+  - [x] `/admin/settings` - AI providers
 - [ ] Create admin components:
   - [ ] DataTable (sortable, filterable)
   - [ ] FormField (text, textarea, date, file, JSON)
@@ -116,13 +116,13 @@
   - [ ] Toast notifications
 
 ### Milestone 6: Views & Share Tokens
-- [ ] Admin UI for views:
-  - [ ] `/admin/views` - List views
-  - [ ] `/admin/views/new` - Create view
-  - [ ] `/admin/views/[id]` - Edit view
-  - [ ] Section selector with drag ordering
-  - [ ] Item picker per section
-  - [ ] Override fields (headline, summary, CTA)
+- [x] Admin UI for views:
+  - [x] `/admin/views` - List views
+  - [x] `/admin/views/new` - Create view
+  - [x] `/admin/views/[id]` - Edit view
+  - [ ] Section selector with drag ordering (deferred)
+  - [x] Item picker per section
+  - [x] Override fields (headline, summary, CTA)
 - [ ] Share token management:
   - [ ] Generate token button
   - [ ] Copy shareable URL

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -415,6 +415,7 @@ These are ideas that may be explored after the core roadmap is complete:
 | 2025-12-31 | Content completeness before views | Need pages to link to before view improvements |
 | 2025-12-31 | Theming after core features | Premature optimization; default theme is sufficient |
 | 2025-12-31 | Phase 1 complete - certifications added | All core content types now have public display and admin CRUD |
+| 2025-12-31 | Admin CRUD pages complete | All admin routes now functional: experience, projects, education, skills |
 
 ---
 

--- a/frontend/src/routes/admin/education/+page.svelte
+++ b/frontend/src/routes/admin/education/+page.svelte
@@ -1,0 +1,418 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pb, type Education } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+
+	let educations: Education[] = [];
+	let loading = true;
+	let showForm = false;
+	let editingEdu: Education | null = null;
+
+	// Form fields
+	let institution = '';
+	let degree = '';
+	let field = '';
+	let startDate = '';
+	let endDate = '';
+	let description = '';
+	let visibility = 'public';
+	let isDraft = false;
+	let sortOrder = 0;
+	let saving = false;
+
+	onMount(loadEducations);
+
+	async function loadEducations() {
+		loading = true;
+		try {
+			const records = await pb.collection('education').getList(1, 100, {
+				sort: '-sort_order,-end_date'
+			});
+			educations = records.items as unknown as Education[];
+		} catch (err) {
+			console.error('Failed to load education:', err);
+			toasts.add('error', 'Failed to load education');
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		institution = '';
+		degree = '';
+		field = '';
+		startDate = '';
+		endDate = '';
+		description = '';
+		visibility = 'public';
+		isDraft = false;
+		sortOrder = 0;
+		editingEdu = null;
+	}
+
+	function openNewForm() {
+		resetForm();
+		showForm = true;
+	}
+
+	function openEditForm(edu: Education) {
+		editingEdu = edu;
+		institution = edu.institution;
+		degree = edu.degree || '';
+		field = edu.field || '';
+		startDate = edu.start_date ? edu.start_date.split('T')[0] : '';
+		endDate = edu.end_date ? edu.end_date.split('T')[0] : '';
+		description = edu.description || '';
+		visibility = edu.visibility;
+		isDraft = edu.is_draft;
+		sortOrder = edu.sort_order;
+		showForm = true;
+	}
+
+	function closeForm() {
+		showForm = false;
+		resetForm();
+	}
+
+	async function handleSubmit() {
+		if (!institution.trim()) {
+			toasts.add('error', 'Institution name is required');
+			return;
+		}
+
+		saving = true;
+		try {
+			const data = {
+				institution: institution.trim(),
+				degree: degree.trim(),
+				field: field.trim(),
+				start_date: startDate ? new Date(startDate).toISOString() : null,
+				end_date: endDate ? new Date(endDate).toISOString() : null,
+				description: description.trim(),
+				visibility,
+				is_draft: isDraft,
+				sort_order: sortOrder
+			};
+
+			if (editingEdu) {
+				await pb.collection('education').update(editingEdu.id, data);
+				toasts.add('success', 'Education updated successfully');
+			} else {
+				await pb.collection('education').create(data);
+				toasts.add('success', 'Education created successfully');
+			}
+
+			closeForm();
+			await loadEducations();
+		} catch (err) {
+			console.error('Failed to save education:', err);
+			toasts.add('error', 'Failed to save education');
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteEducation(edu: Education) {
+		if (!confirm(`Are you sure you want to delete "${edu.degree} at ${edu.institution}"?`)) {
+			return;
+		}
+
+		try {
+			await pb.collection('education').delete(edu.id);
+			toasts.add('success', 'Education deleted');
+			await loadEducations();
+		} catch (err) {
+			console.error('Failed to delete education:', err);
+			toasts.add('error', 'Failed to delete education');
+		}
+	}
+
+	async function togglePublish(edu: Education) {
+		try {
+			await pb.collection('education').update(edu.id, {
+				is_draft: !edu.is_draft
+			});
+			toasts.add('success', edu.is_draft ? 'Education published' : 'Education unpublished');
+			await loadEducations();
+		} catch (err) {
+			console.error('Failed to toggle publish:', err);
+			toasts.add('error', 'Failed to update education');
+		}
+	}
+
+	function formatDateRange(start: string | undefined, end: string | undefined): string {
+		if (!start && !end) return '';
+		const startStr = start ? new Date(start).getFullYear().toString() : '';
+		const endStr = end ? new Date(end).getFullYear().toString() : 'Present';
+		if (!startStr) return endStr;
+		return `${startStr} - ${endStr}`;
+	}
+</script>
+
+<svelte:head>
+	<title>Education | Me.yaml Admin</title>
+</svelte:head>
+
+<div class="max-w-5xl mx-auto">
+	<div class="flex items-center justify-between mb-6">
+		<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Education</h1>
+		<button class="btn btn-primary" on:click={openNewForm}>
+			+ New Education
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading education...</div>
+		</div>
+	{:else if showForm}
+		<!-- Education Form -->
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<div class="card p-6 space-y-4">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+						{editingEdu ? 'Edit Education' : 'New Education'}
+					</h2>
+					<button type="button" class="text-gray-500 hover:text-gray-700" on:click={closeForm}>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+
+				<div>
+					<label for="institution" class="label">Institution *</label>
+					<input
+						type="text"
+						id="institution"
+						bind:value={institution}
+						class="input"
+						placeholder="Stanford University"
+						required
+					/>
+				</div>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="degree" class="label">Degree</label>
+						<input
+							type="text"
+							id="degree"
+							bind:value={degree}
+							class="input"
+							placeholder="Bachelor of Science"
+						/>
+					</div>
+
+					<div>
+						<label for="field" class="label">Field of Study</label>
+						<input
+							type="text"
+							id="field"
+							bind:value={field}
+							class="input"
+							placeholder="Computer Science"
+						/>
+					</div>
+				</div>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="start_date" class="label">Start Date</label>
+						<input
+							type="date"
+							id="start_date"
+							bind:value={startDate}
+							class="input"
+						/>
+					</div>
+
+					<div>
+						<label for="end_date" class="label">End Date</label>
+						<input
+							type="date"
+							id="end_date"
+							bind:value={endDate}
+							class="input"
+						/>
+						<p class="text-xs text-gray-500 mt-1">Leave blank if still attending</p>
+					</div>
+				</div>
+
+				<div>
+					<label for="description" class="label">Description</label>
+					<textarea
+						id="description"
+						bind:value={description}
+						class="input min-h-[100px]"
+						placeholder="Activities, honors, relevant coursework..."
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">Markdown supported</p>
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public</option>
+							<option value="unlisted">Unlisted</option>
+							<option value="private">Private</option>
+						</select>
+					</div>
+
+					<div>
+						<label for="sort_order" class="label">Sort Order</label>
+						<input
+							type="number"
+							id="sort_order"
+							bind:value={sortOrder}
+							class="input"
+							min="0"
+						/>
+						<p class="text-xs text-gray-500 mt-1">Higher numbers appear first</p>
+					</div>
+				</div>
+
+				<div class="flex items-center gap-2">
+					<input
+						type="checkbox"
+						id="is_draft"
+						bind:checked={isDraft}
+						class="w-4 h-4 text-primary-600 rounded border-gray-300"
+					/>
+					<label for="is_draft" class="text-sm text-gray-700 dark:text-gray-300">
+						Save as draft (won't be visible publicly)
+					</label>
+				</div>
+			</div>
+
+			<div class="flex justify-end gap-3">
+				<button type="button" class="btn btn-secondary" on:click={closeForm}>Cancel</button>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					{editingEdu ? 'Update Education' : 'Create Education'}
+				</button>
+			</div>
+		</form>
+	{:else if educations.length === 0}
+		<div class="card p-8 text-center">
+			<svg class="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path d="M12 14l9-5-9-5-9 5 9 5z" />
+				<path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
+			</svg>
+			<h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No education added yet</h3>
+			<p class="text-gray-500 dark:text-gray-400 mb-4">
+				Add your educational background, degrees, and certifications.
+			</p>
+			<button class="btn btn-primary" on:click={openNewForm}>
+				+ Add Your First Education
+			</button>
+		</div>
+	{:else}
+		<!-- Education List -->
+		<div class="space-y-4">
+			{#each educations as edu (edu.id)}
+				<div class="card p-4">
+					<div class="flex items-start justify-between gap-4">
+						<div class="flex-1 min-w-0">
+							<div class="flex items-center gap-2 flex-wrap">
+								<h3 class="font-medium text-gray-900 dark:text-white">
+									{edu.degree || 'Education'}
+									{#if edu.field}
+										<span class="text-gray-500 dark:text-gray-400 font-normal">in {edu.field}</span>
+									{/if}
+								</h3>
+								{#if edu.is_draft}
+									<span class="px-2 py-0.5 text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded">
+										Draft
+									</span>
+								{/if}
+								{#if edu.visibility !== 'public'}
+									<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+										{edu.visibility}
+									</span>
+								{/if}
+								{#if !edu.end_date}
+									<span class="px-2 py-0.5 text-xs bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded">
+										Current
+									</span>
+								{/if}
+							</div>
+
+							<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+								<span class="flex items-center gap-1">
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path d="M12 14l9-5-9-5-9 5 9 5z" />
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0v7" />
+									</svg>
+									{edu.institution}
+								</span>
+								{#if edu.start_date || edu.end_date}
+									<span class="flex items-center gap-1">
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+										</svg>
+										{formatDateRange(edu.start_date, edu.end_date)}
+									</span>
+								{/if}
+							</div>
+
+							{#if edu.description}
+								<p class="text-sm text-gray-600 dark:text-gray-400 mt-2 line-clamp-2">
+									{edu.description}
+								</p>
+							{/if}
+						</div>
+
+						<div class="flex items-center gap-2">
+							<button
+								class="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+								on:click={() => togglePublish(edu)}
+								title={edu.is_draft ? 'Publish' : 'Unpublish'}
+							>
+								{#if edu.is_draft}
+									<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+									</svg>
+								{:else}
+									<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.542 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+									</svg>
+								{/if}
+							</button>
+							<button
+								class="p-2 text-gray-500 hover:text-blue-600"
+								on:click={() => openEditForm(edu)}
+								title="Edit"
+							>
+								<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+								</svg>
+							</button>
+							<button
+								class="p-2 text-gray-500 hover:text-red-600"
+								on:click={() => deleteEducation(edu)}
+								title="Delete"
+							>
+								<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+								</svg>
+							</button>
+						</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/admin/experience/+page.svelte
+++ b/frontend/src/routes/admin/experience/+page.svelte
@@ -1,0 +1,481 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pb, type Experience } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+	import { formatDate } from '$lib/utils';
+
+	let experiences: Experience[] = [];
+	let loading = true;
+	let showForm = false;
+	let editingExp: Experience | null = null;
+
+	// Form fields
+	let company = '';
+	let title = '';
+	let location = '';
+	let startDate = '';
+	let endDate = '';
+	let description = '';
+	let bullets: string[] = [];
+	let bulletsText = '';
+	let skills: string[] = [];
+	let skillsText = '';
+	let visibility = 'public';
+	let isDraft = false;
+	let sortOrder = 0;
+	let saving = false;
+
+	onMount(loadExperiences);
+
+	async function loadExperiences() {
+		loading = true;
+		try {
+			const records = await pb.collection('experience').getList(1, 100, {
+				sort: '-sort_order,-start_date'
+			});
+			experiences = records.items as unknown as Experience[];
+		} catch (err) {
+			console.error('Failed to load experiences:', err);
+			toasts.add('error', 'Failed to load experiences');
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		company = '';
+		title = '';
+		location = '';
+		startDate = '';
+		endDate = '';
+		description = '';
+		bullets = [];
+		bulletsText = '';
+		skills = [];
+		skillsText = '';
+		visibility = 'public';
+		isDraft = false;
+		sortOrder = 0;
+		editingExp = null;
+	}
+
+	function openNewForm() {
+		resetForm();
+		showForm = true;
+	}
+
+	function openEditForm(exp: Experience) {
+		editingExp = exp;
+		company = exp.company;
+		title = exp.title;
+		location = exp.location || '';
+		startDate = exp.start_date ? exp.start_date.split('T')[0] : '';
+		endDate = exp.end_date ? exp.end_date.split('T')[0] : '';
+		description = exp.description || '';
+		bullets = exp.bullets || [];
+		bulletsText = bullets.join('\n');
+		skills = exp.skills || [];
+		skillsText = skills.join(', ');
+		visibility = exp.visibility;
+		isDraft = exp.is_draft;
+		sortOrder = exp.sort_order;
+		showForm = true;
+	}
+
+	function closeForm() {
+		showForm = false;
+		resetForm();
+	}
+
+	async function handleSubmit() {
+		if (!company.trim() || !title.trim()) {
+			toasts.add('error', 'Company and title are required');
+			return;
+		}
+
+		saving = true;
+		try {
+			// Parse bullets from text (one per line)
+			const parsedBullets = bulletsText
+				.split('\n')
+				.map((b) => b.trim())
+				.filter((b) => b);
+
+			// Parse skills from comma-separated
+			const parsedSkills = skillsText
+				.split(',')
+				.map((s) => s.trim())
+				.filter((s) => s);
+
+			const data = {
+				company: company.trim(),
+				title: title.trim(),
+				location: location.trim(),
+				start_date: startDate ? new Date(startDate).toISOString() : null,
+				end_date: endDate ? new Date(endDate).toISOString() : null,
+				description: description.trim(),
+				bullets: parsedBullets,
+				skills: parsedSkills,
+				visibility,
+				is_draft: isDraft,
+				sort_order: sortOrder
+			};
+
+			if (editingExp) {
+				await pb.collection('experience').update(editingExp.id, data);
+				toasts.add('success', 'Experience updated successfully');
+			} else {
+				await pb.collection('experience').create(data);
+				toasts.add('success', 'Experience created successfully');
+			}
+
+			closeForm();
+			await loadExperiences();
+		} catch (err) {
+			console.error('Failed to save experience:', err);
+			toasts.add('error', 'Failed to save experience');
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteExperience(exp: Experience) {
+		if (!confirm(`Are you sure you want to delete "${exp.title} at ${exp.company}"?`)) {
+			return;
+		}
+
+		try {
+			await pb.collection('experience').delete(exp.id);
+			toasts.add('success', 'Experience deleted');
+			await loadExperiences();
+		} catch (err) {
+			console.error('Failed to delete experience:', err);
+			toasts.add('error', 'Failed to delete experience');
+		}
+	}
+
+	async function togglePublish(exp: Experience) {
+		try {
+			await pb.collection('experience').update(exp.id, {
+				is_draft: !exp.is_draft
+			});
+			toasts.add('success', exp.is_draft ? 'Experience published' : 'Experience unpublished');
+			await loadExperiences();
+		} catch (err) {
+			console.error('Failed to toggle publish:', err);
+			toasts.add('error', 'Failed to update experience');
+		}
+	}
+
+	function formatDateRange(start: string | undefined, end: string | undefined): string {
+		if (!start) return '';
+		const startStr = new Date(start).toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+		if (!end) return `${startStr} - Present`;
+		const endStr = new Date(end).toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+		return `${startStr} - ${endStr}`;
+	}
+</script>
+
+<svelte:head>
+	<title>Experience | Me.yaml Admin</title>
+</svelte:head>
+
+<div class="max-w-5xl mx-auto">
+	<div class="flex items-center justify-between mb-6">
+		<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Experience</h1>
+		<button class="btn btn-primary" on:click={openNewForm}>
+			+ New Experience
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading experiences...</div>
+		</div>
+	{:else if showForm}
+		<!-- Experience Form -->
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<div class="card p-6 space-y-4">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+						{editingExp ? 'Edit Experience' : 'New Experience'}
+					</h2>
+					<button type="button" class="text-gray-500 hover:text-gray-700" on:click={closeForm}>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="company" class="label">Company *</label>
+						<input
+							type="text"
+							id="company"
+							bind:value={company}
+							class="input"
+							placeholder="Acme Inc."
+							required
+						/>
+					</div>
+
+					<div>
+						<label for="title" class="label">Job Title *</label>
+						<input
+							type="text"
+							id="title"
+							bind:value={title}
+							class="input"
+							placeholder="Senior Software Engineer"
+							required
+						/>
+					</div>
+				</div>
+
+				<div>
+					<label for="location" class="label">Location</label>
+					<input
+						type="text"
+						id="location"
+						bind:value={location}
+						class="input"
+						placeholder="San Francisco, CA"
+					/>
+				</div>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="start_date" class="label">Start Date</label>
+						<input
+							type="date"
+							id="start_date"
+							bind:value={startDate}
+							class="input"
+						/>
+					</div>
+
+					<div>
+						<label for="end_date" class="label">End Date</label>
+						<input
+							type="date"
+							id="end_date"
+							bind:value={endDate}
+							class="input"
+						/>
+						<p class="text-xs text-gray-500 mt-1">Leave blank for current position</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Details</h2>
+
+				<div>
+					<label for="description" class="label">Description</label>
+					<textarea
+						id="description"
+						bind:value={description}
+						class="input min-h-[100px]"
+						placeholder="Brief overview of your role and responsibilities..."
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">Markdown supported</p>
+				</div>
+
+				<div>
+					<label for="bullets" class="label">Key Achievements</label>
+					<textarea
+						id="bullets"
+						bind:value={bulletsText}
+						class="input min-h-[120px]"
+						placeholder="Led migration to microservices architecture&#10;Reduced API response times by 40%&#10;Mentored junior developers"
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">One achievement per line</p>
+				</div>
+
+				<div>
+					<label for="skills" class="label">Technologies & Skills</label>
+					<input
+						type="text"
+						id="skills"
+						bind:value={skillsText}
+						class="input"
+						placeholder="Go, Docker, Kubernetes, PostgreSQL"
+					/>
+					<p class="text-xs text-gray-500 mt-1">Comma-separated list</p>
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public</option>
+							<option value="unlisted">Unlisted</option>
+							<option value="private">Private</option>
+						</select>
+					</div>
+
+					<div>
+						<label for="sort_order" class="label">Sort Order</label>
+						<input
+							type="number"
+							id="sort_order"
+							bind:value={sortOrder}
+							class="input"
+							min="0"
+						/>
+						<p class="text-xs text-gray-500 mt-1">Higher numbers appear first</p>
+					</div>
+				</div>
+
+				<div class="flex items-center gap-2">
+					<input
+						type="checkbox"
+						id="is_draft"
+						bind:checked={isDraft}
+						class="w-4 h-4 text-primary-600 rounded border-gray-300"
+					/>
+					<label for="is_draft" class="text-sm text-gray-700 dark:text-gray-300">
+						Save as draft (won't be visible publicly)
+					</label>
+				</div>
+			</div>
+
+			<div class="flex justify-end gap-3">
+				<button type="button" class="btn btn-secondary" on:click={closeForm}>Cancel</button>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					{editingExp ? 'Update Experience' : 'Create Experience'}
+				</button>
+			</div>
+		</form>
+	{:else if experiences.length === 0}
+		<div class="card p-8 text-center">
+			<svg class="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+			</svg>
+			<h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No experience added yet</h3>
+			<p class="text-gray-500 dark:text-gray-400 mb-4">
+				Add your work history, including positions, achievements, and skills used.
+			</p>
+			<button class="btn btn-primary" on:click={openNewForm}>
+				+ Add Your First Experience
+			</button>
+		</div>
+	{:else}
+		<!-- Experience List -->
+		<div class="space-y-4">
+			{#each experiences as exp (exp.id)}
+				<div class="card p-4">
+					<div class="flex items-start justify-between gap-4">
+						<div class="flex-1 min-w-0">
+							<div class="flex items-center gap-2 flex-wrap">
+								<h3 class="font-medium text-gray-900 dark:text-white">
+									{exp.title}
+								</h3>
+								<span class="text-gray-500 dark:text-gray-400">at</span>
+								<span class="font-medium text-gray-800 dark:text-gray-200">{exp.company}</span>
+								{#if exp.is_draft}
+									<span class="px-2 py-0.5 text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded">
+										Draft
+									</span>
+								{/if}
+								{#if exp.visibility !== 'public'}
+									<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+										{exp.visibility}
+									</span>
+								{/if}
+								{#if !exp.end_date}
+									<span class="px-2 py-0.5 text-xs bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded">
+										Current
+									</span>
+								{/if}
+							</div>
+
+							<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+								{#if exp.location}
+									<span class="flex items-center gap-1">
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+										</svg>
+										{exp.location}
+									</span>
+								{/if}
+								{#if exp.start_date}
+									<span class="flex items-center gap-1">
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+										</svg>
+										{formatDateRange(exp.start_date, exp.end_date)}
+									</span>
+								{/if}
+							</div>
+
+							{#if exp.skills && exp.skills.length > 0}
+								<div class="flex flex-wrap gap-1 mt-2">
+									{#each exp.skills.slice(0, 5) as skill}
+										<span class="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded">
+											{skill}
+										</span>
+									{/each}
+									{#if exp.skills.length > 5}
+										<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+											+{exp.skills.length - 5} more
+										</span>
+									{/if}
+								</div>
+							{/if}
+						</div>
+
+						<div class="flex items-center gap-2">
+							<button
+								class="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+								on:click={() => togglePublish(exp)}
+								title={exp.is_draft ? 'Publish' : 'Unpublish'}
+							>
+								{#if exp.is_draft}
+									<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+									</svg>
+								{:else}
+									<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.542 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+									</svg>
+								{/if}
+							</button>
+							<button
+								class="p-2 text-gray-500 hover:text-blue-600"
+								on:click={() => openEditForm(exp)}
+								title="Edit"
+							>
+								<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+								</svg>
+							</button>
+							<button
+								class="p-2 text-gray-500 hover:text-red-600"
+								on:click={() => deleteExperience(exp)}
+								title="Delete"
+							>
+								<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+								</svg>
+							</button>
+						</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/admin/projects/+page.svelte
+++ b/frontend/src/routes/admin/projects/+page.svelte
@@ -1,0 +1,609 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pb, type Project, getFileUrl } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+
+	let projects: Project[] = [];
+	let loading = true;
+	let showForm = false;
+	let editingProject: Project | null = null;
+
+	// Form fields
+	let title = '';
+	let slug = '';
+	let summary = '';
+	let description = '';
+	let techStackText = '';
+	let links: Array<{ type: string; url: string }> = [];
+	let categoriesText = '';
+	let visibility = 'public';
+	let isDraft = false;
+	let isFeatured = false;
+	let sortOrder = 0;
+	let coverImageFile: FileList | null = null;
+	let saving = false;
+
+	onMount(loadProjects);
+
+	async function loadProjects() {
+		loading = true;
+		try {
+			const records = await pb.collection('projects').getList(1, 100, {
+				sort: '-is_featured,-sort_order'
+			});
+			projects = records.items as unknown as Project[];
+		} catch (err) {
+			console.error('Failed to load projects:', err);
+			toasts.add('error', 'Failed to load projects');
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		title = '';
+		slug = '';
+		summary = '';
+		description = '';
+		techStackText = '';
+		links = [];
+		categoriesText = '';
+		visibility = 'public';
+		isDraft = false;
+		isFeatured = false;
+		sortOrder = 0;
+		coverImageFile = null;
+		editingProject = null;
+	}
+
+	function openNewForm() {
+		resetForm();
+		showForm = true;
+	}
+
+	function openEditForm(project: Project) {
+		editingProject = project;
+		title = project.title;
+		slug = project.slug || '';
+		summary = project.summary || '';
+		description = project.description || '';
+		techStackText = (project.tech_stack || []).join(', ');
+		links = project.links || [];
+		categoriesText = (project.categories || []).join(', ');
+		visibility = project.visibility;
+		isDraft = project.is_draft;
+		isFeatured = project.is_featured;
+		sortOrder = project.sort_order;
+		showForm = true;
+	}
+
+	function closeForm() {
+		showForm = false;
+		resetForm();
+	}
+
+	function addLink() {
+		links = [...links, { type: 'website', url: '' }];
+	}
+
+	function removeLink(index: number) {
+		links = links.filter((_, i) => i !== index);
+	}
+
+	function generateSlug() {
+		slug = title
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-|-$/g, '');
+	}
+
+	async function handleSubmit() {
+		if (!title.trim()) {
+			toasts.add('error', 'Project title is required');
+			return;
+		}
+
+		saving = true;
+		try {
+			// Parse tech stack from comma-separated
+			const techStack = techStackText
+				.split(',')
+				.map((s) => s.trim())
+				.filter((s) => s);
+
+			// Parse categories from comma-separated
+			const categories = categoriesText
+				.split(',')
+				.map((s) => s.trim())
+				.filter((s) => s);
+
+			// Filter out empty links
+			const validLinks = links.filter((l) => l.url.trim());
+
+			const formData = new FormData();
+			formData.append('title', title.trim());
+			if (slug.trim()) formData.append('slug', slug.trim());
+			formData.append('summary', summary.trim());
+			formData.append('description', description.trim());
+			formData.append('tech_stack', JSON.stringify(techStack));
+			formData.append('links', JSON.stringify(validLinks));
+			formData.append('categories', JSON.stringify(categories));
+			formData.append('visibility', visibility);
+			formData.append('is_draft', String(isDraft));
+			formData.append('is_featured', String(isFeatured));
+			formData.append('sort_order', String(sortOrder));
+
+			if (coverImageFile && coverImageFile.length > 0) {
+				formData.append('cover_image', coverImageFile[0]);
+			}
+
+			if (editingProject) {
+				await pb.collection('projects').update(editingProject.id, formData);
+				toasts.add('success', 'Project updated successfully');
+			} else {
+				await pb.collection('projects').create(formData);
+				toasts.add('success', 'Project created successfully');
+			}
+
+			closeForm();
+			await loadProjects();
+		} catch (err: any) {
+			console.error('Failed to save project:', err);
+			const message = err?.response?.data?.slug?.message || 'Failed to save project';
+			toasts.add('error', message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteProject(project: Project) {
+		if (!confirm(`Are you sure you want to delete "${project.title}"?`)) {
+			return;
+		}
+
+		try {
+			await pb.collection('projects').delete(project.id);
+			toasts.add('success', 'Project deleted');
+			await loadProjects();
+		} catch (err) {
+			console.error('Failed to delete project:', err);
+			toasts.add('error', 'Failed to delete project');
+		}
+	}
+
+	async function togglePublish(project: Project) {
+		try {
+			await pb.collection('projects').update(project.id, {
+				is_draft: !project.is_draft
+			});
+			toasts.add('success', project.is_draft ? 'Project published' : 'Project unpublished');
+			await loadProjects();
+		} catch (err) {
+			console.error('Failed to toggle publish:', err);
+			toasts.add('error', 'Failed to update project');
+		}
+	}
+
+	async function toggleFeatured(project: Project) {
+		try {
+			await pb.collection('projects').update(project.id, {
+				is_featured: !project.is_featured
+			});
+			toasts.add('success', project.is_featured ? 'Project unfeatured' : 'Project featured');
+			await loadProjects();
+		} catch (err) {
+			console.error('Failed to toggle featured:', err);
+			toasts.add('error', 'Failed to update project');
+		}
+	}
+
+	function getCoverImageUrl(project: Project): string {
+		if (!project.cover_image) return '';
+		return getFileUrl(
+			{ id: project.id, collectionName: 'projects' },
+			project.cover_image
+		);
+	}
+
+	const linkTypes = [
+		{ value: 'website', label: 'Website' },
+		{ value: 'github', label: 'GitHub' },
+		{ value: 'demo', label: 'Demo' },
+		{ value: 'docs', label: 'Documentation' },
+		{ value: 'npm', label: 'NPM' },
+		{ value: 'other', label: 'Other' }
+	];
+</script>
+
+<svelte:head>
+	<title>Projects | Me.yaml Admin</title>
+</svelte:head>
+
+<div class="max-w-5xl mx-auto">
+	<div class="flex items-center justify-between mb-6">
+		<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Projects</h1>
+		<div class="flex gap-2">
+			<a href="/admin/import" class="btn btn-secondary">
+				Import from GitHub
+			</a>
+			<button class="btn btn-primary" on:click={openNewForm}>
+				+ New Project
+			</button>
+		</div>
+	</div>
+
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading projects...</div>
+		</div>
+	{:else if showForm}
+		<!-- Project Form -->
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<div class="card p-6 space-y-4">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+						{editingProject ? 'Edit Project' : 'New Project'}
+					</h2>
+					<button type="button" class="text-gray-500 hover:text-gray-700" on:click={closeForm}>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+
+				<div>
+					<label for="title" class="label">Project Title *</label>
+					<input
+						type="text"
+						id="title"
+						bind:value={title}
+						class="input"
+						placeholder="My Awesome Project"
+						required
+						on:blur={() => !slug && generateSlug()}
+					/>
+				</div>
+
+				<div>
+					<label for="slug" class="label">URL Slug</label>
+					<div class="flex gap-2">
+						<input
+							type="text"
+							id="slug"
+							bind:value={slug}
+							class="input flex-1"
+							placeholder="my-awesome-project"
+						/>
+						<button type="button" class="btn btn-secondary" on:click={generateSlug}>
+							Generate
+						</button>
+					</div>
+					<p class="text-xs text-gray-500 mt-1">Used in the URL: /projects/{slug || 'my-project'}</p>
+				</div>
+
+				<div>
+					<label for="summary" class="label">Summary</label>
+					<textarea
+						id="summary"
+						bind:value={summary}
+						class="input"
+						rows="2"
+						placeholder="A brief one-liner about the project"
+					></textarea>
+				</div>
+
+				<div>
+					<label for="description" class="label">Description</label>
+					<textarea
+						id="description"
+						bind:value={description}
+						class="input min-h-[150px]"
+						placeholder="Full project description with details about features, architecture, etc."
+					></textarea>
+					<p class="text-xs text-gray-500 mt-1">Markdown supported</p>
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Technical Details</h2>
+
+				<div>
+					<label for="tech_stack" class="label">Tech Stack</label>
+					<input
+						type="text"
+						id="tech_stack"
+						bind:value={techStackText}
+						class="input"
+						placeholder="Go, TypeScript, Docker, PostgreSQL"
+					/>
+					<p class="text-xs text-gray-500 mt-1">Comma-separated list of technologies</p>
+				</div>
+
+				<div>
+					<label for="categories" class="label">Categories</label>
+					<input
+						type="text"
+						id="categories"
+						bind:value={categoriesText}
+						class="input"
+						placeholder="web, devtools, open-source"
+					/>
+					<p class="text-xs text-gray-500 mt-1">Comma-separated list of categories</p>
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Links</h2>
+					<button type="button" class="btn btn-secondary btn-sm" on:click={addLink}>
+						+ Add Link
+					</button>
+				</div>
+
+				{#if links.length === 0}
+					<p class="text-sm text-gray-500 dark:text-gray-400">
+						No links added yet. Add links to your project's repo, demo, or documentation.
+					</p>
+				{:else}
+					<div class="space-y-3">
+						{#each links as link, i}
+							<div class="flex gap-2">
+								<select bind:value={link.type} class="input w-32">
+									{#each linkTypes as lt}
+										<option value={lt.value}>{lt.label}</option>
+									{/each}
+								</select>
+								<input
+									type="url"
+									bind:value={link.url}
+									class="input flex-1"
+									placeholder="https://..."
+								/>
+								<button type="button" class="btn btn-secondary" on:click={() => removeLink(i)}>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+									</svg>
+								</button>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Media</h2>
+
+				<div>
+					<label for="cover_image" class="label">Cover Image</label>
+					<input
+						type="file"
+						id="cover_image"
+						accept="image/*"
+						bind:files={coverImageFile}
+						class="input"
+					/>
+					{#if editingProject?.cover_image && !coverImageFile}
+						<div class="mt-2 flex items-center gap-2">
+							<img
+								src={getCoverImageUrl(editingProject)}
+								alt="Current cover"
+								class="w-20 h-20 object-cover rounded"
+							/>
+							<span class="text-sm text-gray-500">Current image</span>
+						</div>
+					{/if}
+				</div>
+			</div>
+
+			<div class="card p-6 space-y-4">
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public</option>
+							<option value="unlisted">Unlisted</option>
+							<option value="private">Private</option>
+						</select>
+					</div>
+
+					<div>
+						<label for="sort_order" class="label">Sort Order</label>
+						<input
+							type="number"
+							id="sort_order"
+							bind:value={sortOrder}
+							class="input"
+							min="0"
+						/>
+					</div>
+				</div>
+
+				<div class="space-y-2">
+					<div class="flex items-center gap-2">
+						<input
+							type="checkbox"
+							id="is_draft"
+							bind:checked={isDraft}
+							class="w-4 h-4 text-primary-600 rounded border-gray-300"
+						/>
+						<label for="is_draft" class="text-sm text-gray-700 dark:text-gray-300">
+							Save as draft
+						</label>
+					</div>
+
+					<div class="flex items-center gap-2">
+						<input
+							type="checkbox"
+							id="is_featured"
+							bind:checked={isFeatured}
+							class="w-4 h-4 text-primary-600 rounded border-gray-300"
+						/>
+						<label for="is_featured" class="text-sm text-gray-700 dark:text-gray-300">
+							Featured project (appears first)
+						</label>
+					</div>
+				</div>
+			</div>
+
+			<div class="flex justify-end gap-3">
+				<button type="button" class="btn btn-secondary" on:click={closeForm}>Cancel</button>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					{editingProject ? 'Update Project' : 'Create Project'}
+				</button>
+			</div>
+		</form>
+	{:else if projects.length === 0}
+		<div class="card p-8 text-center">
+			<svg class="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+			</svg>
+			<h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No projects yet</h3>
+			<p class="text-gray-500 dark:text-gray-400 mb-4">
+				Add projects to showcase your work, or import them from GitHub.
+			</p>
+			<div class="flex gap-2 justify-center">
+				<a href="/admin/import" class="btn btn-secondary">
+					Import from GitHub
+				</a>
+				<button class="btn btn-primary" on:click={openNewForm}>
+					+ Add Manually
+				</button>
+			</div>
+		</div>
+	{:else}
+		<!-- Projects Grid -->
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			{#each projects as project (project.id)}
+				<div class="card overflow-hidden">
+					{#if project.cover_image}
+						<div class="h-32 bg-gray-100 dark:bg-gray-800">
+							<img
+								src={getCoverImageUrl(project)}
+								alt={project.title}
+								class="w-full h-full object-cover"
+							/>
+						</div>
+					{/if}
+					<div class="p-4">
+						<div class="flex items-start justify-between gap-2">
+							<div class="flex-1 min-w-0">
+								<div class="flex items-center gap-2 flex-wrap">
+									<h3 class="font-medium text-gray-900 dark:text-white truncate">
+										{project.title}
+									</h3>
+									{#if project.is_featured}
+										<span class="px-2 py-0.5 text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded">
+											Featured
+										</span>
+									{/if}
+									{#if project.is_draft}
+										<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+											Draft
+										</span>
+									{/if}
+									{#if project.visibility !== 'public'}
+										<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+											{project.visibility}
+										</span>
+									{/if}
+								</div>
+
+								{#if project.summary}
+									<p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">
+										{project.summary}
+									</p>
+								{/if}
+
+								{#if project.tech_stack && project.tech_stack.length > 0}
+									<div class="flex flex-wrap gap-1 mt-2">
+										{#each project.tech_stack.slice(0, 4) as tech}
+											<span class="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded">
+												{tech}
+											</span>
+										{/each}
+										{#if project.tech_stack.length > 4}
+											<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+												+{project.tech_stack.length - 4}
+											</span>
+										{/if}
+									</div>
+								{/if}
+							</div>
+						</div>
+
+						<div class="flex items-center justify-between mt-4 pt-3 border-t border-gray-100 dark:border-gray-700">
+							<div class="flex gap-1">
+								{#if project.slug}
+									<a
+										href="/projects/{project.slug}"
+										target="_blank"
+										class="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+										title="View"
+									>
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+										</svg>
+									</a>
+								{/if}
+							</div>
+
+							<div class="flex items-center gap-1">
+								<button
+									class="p-2 text-gray-500 hover:text-yellow-600"
+									on:click={() => toggleFeatured(project)}
+									title={project.is_featured ? 'Unfeature' : 'Feature'}
+								>
+									<svg class="w-4 h-4" fill={project.is_featured ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+									</svg>
+								</button>
+								<button
+									class="p-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+									on:click={() => togglePublish(project)}
+									title={project.is_draft ? 'Publish' : 'Unpublish'}
+								>
+									{#if project.is_draft}
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+										</svg>
+									{:else}
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.542 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+										</svg>
+									{/if}
+								</button>
+								<button
+									class="p-2 text-gray-500 hover:text-blue-600"
+									on:click={() => openEditForm(project)}
+									title="Edit"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+									</svg>
+								</button>
+								<button
+									class="p-2 text-gray-500 hover:text-red-600"
+									on:click={() => deleteProject(project)}
+									title="Delete"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/admin/skills/+page.svelte
+++ b/frontend/src/routes/admin/skills/+page.svelte
@@ -1,0 +1,365 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pb, type Skill } from '$lib/pocketbase';
+	import { toasts } from '$lib/stores';
+
+	let skills: Skill[] = [];
+	let loading = true;
+	let showForm = false;
+	let editingSkill: Skill | null = null;
+
+	// Form fields
+	let name = '';
+	let category = '';
+	let proficiency: 'expert' | 'proficient' | 'familiar' = 'proficient';
+	let visibility = 'public';
+	let sortOrder = 0;
+	let saving = false;
+
+	// Available categories (derived from existing skills)
+	let availableCategories: string[] = [];
+
+	onMount(loadSkills);
+
+	async function loadSkills() {
+		loading = true;
+		try {
+			const records = await pb.collection('skills').getList(1, 200, {
+				sort: 'category,sort_order,name'
+			});
+			skills = records.items as unknown as Skill[];
+
+			// Extract unique categories
+			availableCategories = [...new Set(skills.map(s => s.category).filter(Boolean))] as string[];
+		} catch (err) {
+			console.error('Failed to load skills:', err);
+			toasts.add('error', 'Failed to load skills');
+		} finally {
+			loading = false;
+		}
+	}
+
+	function resetForm() {
+		name = '';
+		category = '';
+		proficiency = 'proficient';
+		visibility = 'public';
+		sortOrder = 0;
+		editingSkill = null;
+	}
+
+	function openNewForm() {
+		resetForm();
+		showForm = true;
+	}
+
+	function openEditForm(skill: Skill) {
+		editingSkill = skill;
+		name = skill.name;
+		category = skill.category || '';
+		proficiency = skill.proficiency || 'proficient';
+		visibility = skill.visibility;
+		sortOrder = skill.sort_order;
+		showForm = true;
+	}
+
+	function closeForm() {
+		showForm = false;
+		resetForm();
+	}
+
+	async function handleSubmit() {
+		if (!name.trim()) {
+			toasts.add('error', 'Skill name is required');
+			return;
+		}
+
+		saving = true;
+		try {
+			const data = {
+				name: name.trim(),
+				category: category.trim(),
+				proficiency,
+				visibility,
+				sort_order: sortOrder
+			};
+
+			if (editingSkill) {
+				await pb.collection('skills').update(editingSkill.id, data);
+				toasts.add('success', 'Skill updated successfully');
+			} else {
+				await pb.collection('skills').create(data);
+				toasts.add('success', 'Skill created successfully');
+			}
+
+			closeForm();
+			await loadSkills();
+		} catch (err) {
+			console.error('Failed to save skill:', err);
+			toasts.add('error', 'Failed to save skill');
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteSkill(skill: Skill) {
+		if (!confirm(`Are you sure you want to delete "${skill.name}"?`)) {
+			return;
+		}
+
+		try {
+			await pb.collection('skills').delete(skill.id);
+			toasts.add('success', 'Skill deleted');
+			await loadSkills();
+		} catch (err) {
+			console.error('Failed to delete skill:', err);
+			toasts.add('error', 'Failed to delete skill');
+		}
+	}
+
+	// Group skills by category
+	function groupByCategory(skillList: Skill[]): Map<string, Skill[]> {
+		const groups = new Map<string, Skill[]>();
+		for (const skill of skillList) {
+			const categoryKey = skill.category || 'Other';
+			if (!groups.has(categoryKey)) {
+				groups.set(categoryKey, []);
+			}
+			groups.get(categoryKey)!.push(skill);
+		}
+		return groups;
+	}
+
+	function getProficiencyColor(level: string | undefined): string {
+		switch (level) {
+			case 'expert':
+				return 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200';
+			case 'proficient':
+				return 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200';
+			case 'familiar':
+				return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
+			default:
+				return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
+		}
+	}
+
+	function getProficiencyLabel(level: string | undefined): string {
+		switch (level) {
+			case 'expert':
+				return 'Expert';
+			case 'proficient':
+				return 'Proficient';
+			case 'familiar':
+				return 'Familiar';
+			default:
+				return '';
+		}
+	}
+
+	$: groupedSkills = groupByCategory(skills);
+
+	// Default categories to suggest
+	const suggestedCategories = [
+		'Languages',
+		'Frameworks',
+		'Databases',
+		'DevOps',
+		'Cloud',
+		'Tools',
+		'Soft Skills'
+	];
+
+	$: categoryOptions = [...new Set([...suggestedCategories, ...availableCategories])].sort();
+</script>
+
+<svelte:head>
+	<title>Skills | Me.yaml Admin</title>
+</svelte:head>
+
+<div class="max-w-5xl mx-auto">
+	<div class="flex items-center justify-between mb-6">
+		<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Skills</h1>
+		<button class="btn btn-primary" on:click={openNewForm}>
+			+ New Skill
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="card p-8 text-center">
+			<div class="animate-pulse">Loading skills...</div>
+		</div>
+	{:else if showForm}
+		<!-- Skill Form -->
+		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
+			<div class="card p-6 space-y-4">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+						{editingSkill ? 'Edit Skill' : 'New Skill'}
+					</h2>
+					<button type="button" class="text-gray-500 hover:text-gray-700" on:click={closeForm}>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+
+				<div>
+					<label for="name" class="label">Skill Name *</label>
+					<input
+						type="text"
+						id="name"
+						bind:value={name}
+						class="input"
+						placeholder="Python"
+						required
+					/>
+				</div>
+
+				<div>
+					<label for="category" class="label">Category</label>
+					<input
+						type="text"
+						id="category"
+						bind:value={category}
+						list="category-options"
+						class="input"
+						placeholder="Languages"
+					/>
+					<datalist id="category-options">
+						{#each categoryOptions as cat}
+							<option value={cat} />
+						{/each}
+					</datalist>
+					<p class="text-xs text-gray-500 mt-1">Group related skills together</p>
+				</div>
+
+				<div>
+					<label for="proficiency" class="label">Proficiency Level</label>
+					<select id="proficiency" bind:value={proficiency} class="input">
+						<option value="expert">Expert - Deep expertise, can teach others</option>
+						<option value="proficient">Proficient - Strong working knowledge</option>
+						<option value="familiar">Familiar - Basic understanding</option>
+					</select>
+				</div>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label for="visibility" class="label">Visibility</label>
+						<select id="visibility" bind:value={visibility} class="input">
+							<option value="public">Public</option>
+							<option value="unlisted">Unlisted</option>
+							<option value="private">Private</option>
+						</select>
+					</div>
+
+					<div>
+						<label for="sort_order" class="label">Sort Order</label>
+						<input
+							type="number"
+							id="sort_order"
+							bind:value={sortOrder}
+							class="input"
+							min="0"
+						/>
+						<p class="text-xs text-gray-500 mt-1">Higher numbers appear first in category</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="flex justify-end gap-3">
+				<button type="button" class="btn btn-secondary" on:click={closeForm}>Cancel</button>
+				<button type="submit" class="btn btn-primary" disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					{editingSkill ? 'Update Skill' : 'Create Skill'}
+				</button>
+			</div>
+		</form>
+	{:else if skills.length === 0}
+		<div class="card p-8 text-center">
+			<svg class="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
+			</svg>
+			<h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No skills added yet</h3>
+			<p class="text-gray-500 dark:text-gray-400 mb-4">
+				Add your technical and professional skills, organized by category.
+			</p>
+			<button class="btn btn-primary" on:click={openNewForm}>
+				+ Add Your First Skill
+			</button>
+		</div>
+	{:else}
+		<!-- Skills List - Grouped by Category -->
+		<div class="space-y-6">
+			{#each [...groupedSkills] as [categoryName, categorySkills] (categoryName)}
+				<div class="card p-4">
+					<h2 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
+						{categoryName}
+					</h2>
+					<div class="flex flex-wrap gap-2">
+						{#each categorySkills as skill (skill.id)}
+							<div class="group relative inline-flex items-center gap-1 px-3 py-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-sm">
+								<span class="font-medium text-gray-800 dark:text-gray-200">{skill.name}</span>
+								{#if skill.proficiency}
+									<span class="px-1.5 py-0.5 text-xs rounded {getProficiencyColor(skill.proficiency)}">
+										{getProficiencyLabel(skill.proficiency)}
+									</span>
+								{/if}
+								{#if skill.visibility !== 'public'}
+									<span class="px-1.5 py-0.5 text-xs rounded bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200">
+										{skill.visibility}
+									</span>
+								{/if}
+
+								<!-- Action buttons on hover -->
+								<div class="hidden group-hover:flex items-center gap-1 ml-1 pl-1 border-l border-gray-300 dark:border-gray-600">
+									<button
+										class="p-1 text-gray-500 hover:text-blue-600 rounded"
+										on:click={() => openEditForm(skill)}
+										title="Edit"
+									>
+										<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+										</svg>
+									</button>
+									<button
+										class="p-1 text-gray-500 hover:text-red-600 rounded"
+										on:click={() => deleteSkill(skill)}
+										title="Delete"
+									>
+										<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+										</svg>
+									</button>
+								</div>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<!-- Legend -->
+		<div class="mt-6 card p-4">
+			<h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Proficiency Levels</h3>
+			<div class="flex flex-wrap gap-3 text-xs">
+				<div class="flex items-center gap-1">
+					<span class="px-2 py-0.5 rounded {getProficiencyColor('expert')}">Expert</span>
+					<span class="text-gray-500">Deep expertise</span>
+				</div>
+				<div class="flex items-center gap-1">
+					<span class="px-2 py-0.5 rounded {getProficiencyColor('proficient')}">Proficient</span>
+					<span class="text-gray-500">Strong knowledge</span>
+				</div>
+				<div class="flex items-center gap-1">
+					<span class="px-2 py-0.5 rounded {getProficiencyColor('familiar')}">Familiar</span>
+					<span class="text-gray-500">Basic understanding</span>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
…kills

Complete the admin dashboard with full CRUD functionality for all core content types. Each admin page includes:
- List view with status badges (draft, visibility, etc.)
- Create/edit forms with all relevant fields
- Inline actions for publish/unpublish, edit, delete
- Form validation and error handling

Admin routes added:
- /admin/experience - Work history management
- /admin/projects - Portfolio projects with cover images and links
- /admin/education - Academic background
- /admin/skills - Categorized skills with proficiency levels

Updates documentation to reflect completed admin functionality.