### PR TITLE
fix: Downgrade PocketBase SDK to 0.23.x for backend compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
-    "pocketbase": "^0.26.5",
+    "pocketbase": "^0.23.0",
     "marked": "^11.0.0",
     "dompurify": "^3.0.0"
   },


### PR DESCRIPTION
SDK 0.26.5 is designed for PocketBase 0.34.x, but backend runs 0.23.4. This version mismatch caused 400 errors on all authenticated requests.

Changes:
- Downgrade SDK from 0.26.5 to 0.23.0 to match backend version
- Simplify beforeSend hook to ensure Bearer prefix is added