### PR TITLE
fix: Replace invalid sort fields (-created/-updated) with -id

### DIFF
--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -33,23 +33,23 @@
 
 			// Get recent projects and experience for activity feed
 			const [recentProjects, recentExperience] = await Promise.all([
-				pb.collection('projects').getList(1, 3, { sort: '-updated' }),
-				pb.collection('experience').getList(1, 3, { sort: '-updated' })
+				pb.collection('projects').getList(1, 3, { sort: '-id' }),
+				pb.collection('experience').getList(1, 3, { sort: '-id' })
 			]);
 
 			recentActivity = [
 				...recentProjects.items.map((p) => ({
 					type: 'project',
 					title: p.title,
-					date: p.updated
+					date: p.id
 				})),
 				...recentExperience.items.map((e) => ({
 					type: 'experience',
 					title: `${e.title} at ${e.company}`,
-					date: e.updated
+					date: e.id
 				}))
 			]
-				.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+				.sort((a, b) => b.date.localeCompare(a.date))
 				.slice(0, 5);
 		} catch (err) {
 			console.error('Failed to load dashboard stats:', err);

--- a/frontend/src/routes/admin/posts/+page.svelte
+++ b/frontend/src/routes/admin/posts/+page.svelte
@@ -28,7 +28,7 @@
 		loading = true;
 		try {
 			const records = await pb.collection('posts').getList(1, 100, {
-				sort: '-created'
+				sort: '-published_at'
 			});
 			posts = records.items as unknown as Post[];
 		} catch (err) {

--- a/frontend/src/routes/admin/tokens/+page.svelte
+++ b/frontend/src/routes/admin/tokens/+page.svelte
@@ -28,7 +28,7 @@
 	async function loadTokens() {
 		try {
 			const result = await pb.collection('share_tokens').getList<ShareToken>(1, 100, {
-				sort: '-created',
+				sort: '-id',
 				expand: 'view_id'
 			});
 			tokens = result.items;

--- a/frontend/src/routes/admin/views/+page.svelte
+++ b/frontend/src/routes/admin/views/+page.svelte
@@ -14,7 +14,7 @@
 		loading = true;
 		try {
 			const result = await pb.collection('views').getList(1, 50, {
-				sort: '-is_default,-created'
+				sort: '-is_default,-id'
 			});
 			views = result.items;
 		} catch (err) {

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -130,7 +130,7 @@
 		for (const section of AVAILABLE_SECTIONS) {
 			try {
 				const records = await pb.collection(section.collection).getList(1, 100, {
-					sort: '-created'
+					sort: '-id'
 				});
 
 				sectionItems[section.key] = records.items.map((item) => ({

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -54,7 +54,7 @@
 		for (const section of AVAILABLE_SECTIONS) {
 			try {
 				const records = await pb.collection(section.collection).getList(1, 100, {
-					sort: '-created'
+					sort: '-id'
 				});
 
 				sectionItems[section.key] = records.items.map((item) => ({


### PR DESCRIPTION
PocketBase collections don't have 'created' or 'updated' fields in this setup. Using '-id' instead which is time-ordered and always available.

Files fixed:
- admin/posts: sort by -published_at
- admin/tokens: sort by -id
- admin/views: sort by -is_default,-id
- admin/views/[id]: sort by -id
- admin/views/new: sort by -id
- admin/+page: sort by -id (dashboard)