### PR TITLE
feat: Implement Phase 6.1 Per-Section Layout Presets

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -382,3 +382,77 @@ This phase improves accessibility to ensure the application is usable by all use
 - [x] `svelte-check` passes with 0 errors and 0 warnings
 - [x] Focus styles already present in app.css
 - [x] Keyboard navigation works throughout application
+
+---
+
+## Phase 6.1: Per-Section Layout Presets ✅ Complete
+
+This phase enables users to customize how each section renders with curated layout presets.
+
+### Overview
+Users can now select different layout styles for each section in the view editor. This provides visual variety without requiring design expertise, using guardrails (curated presets) instead of freeform controls.
+
+### Available Layouts
+
+| Section | Layouts | Default |
+|---------|---------|---------|
+| Experience | default (cards), timeline, compact | default |
+| Projects | grid-3, grid-2, list, featured | grid-3 |
+| Education | default, timeline | default |
+| Certifications | grouped, grid, timeline | grouped |
+| Skills | grouped, cloud, bars, flat | grouped |
+| Posts | grid-3, grid-2, list, featured | grid-3 |
+| Talks | default, cards, list | default |
+
+### Implementation
+
+#### Backend Changes
+- [x] Add `section_layouts` map to `/api/view/{slug}/data` response
+- [x] Extract layout from sections JSON for each enabled section
+- [x] Add `getDefaultLayout()` helper function
+
+#### Frontend Type Changes
+- [x] Add `layout?: SectionLayout` to `ViewSection` interface
+- [x] Add `VALID_LAYOUTS` constant with section-to-layouts mapping
+- [x] Add `getSectionLayout()` helper function
+
+#### View Editor Changes
+- [x] Add layout dropdown to section headers (when section enabled)
+- [x] Include layout in saved sections data
+- [x] Updated both `/admin/views/[id]` and `/admin/views/new`
+
+#### Section Component Changes
+- [x] ExperienceSection: default, timeline, compact variants
+- [x] ProjectsSection: grid-3, grid-2, list, featured variants
+- [x] SkillsSection: grouped, cloud, bars, flat variants
+- [x] EducationSection: default, timeline variants
+- [x] CertificationsSection: layout prop added (grouped default)
+- [x] PostsSection: grid-3, grid-2, list support
+- [x] TalksSection: layout prop added (default)
+
+#### Public View Changes
+- [x] Page receives `sectionLayouts` from API
+- [x] Pass layout prop to each section component
+- [x] Components render appropriate variant based on layout
+
+### Files Changed
+- `backend/hooks/view.go` - Add section_layouts to response, getDefaultLayout()
+- `frontend/src/lib/pocketbase.ts` - Add layout field, VALID_LAYOUTS constant
+- `frontend/src/routes/admin/views/[id]/+page.svelte` - Layout dropdown UI
+- `frontend/src/routes/admin/views/new/+page.svelte` - Layout dropdown UI
+- `frontend/src/routes/[slug=slug]/+page.svelte` - Pass layouts to sections
+- `frontend/src/routes/[slug=slug]/+page.server.ts` - Include sectionLayouts
+- `frontend/src/components/public/ExperienceSection.svelte` - 3 layouts
+- `frontend/src/components/public/ProjectsSection.svelte` - 4 layouts
+- `frontend/src/components/public/SkillsSection.svelte` - 4 layouts
+- `frontend/src/components/public/EducationSection.svelte` - 2 layouts
+- `frontend/src/components/public/CertificationsSection.svelte` - layout prop
+- `frontend/src/components/public/PostsSection.svelte` - layout prop + grid variants
+- `frontend/src/components/public/TalksSection.svelte` - layout prop
+
+### Usage
+1. Navigate to View Editor (/admin/views/[id])
+2. Enable a section (toggle on)
+3. Layout dropdown appears next to the expand button
+4. Select desired layout preset
+5. Save view - layout is applied on public view

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Me.yaml Roadmap
 
-**Last Updated:** 2025-12-31
+**Last Updated:** 2026-01-01
 
 This roadmap outlines the feature development plan for Me.yaml, organized into logical phases. Each phase is independently valuable and builds toward a complete personal profile platform.
 
@@ -444,7 +444,7 @@ cmd := exec.Command("pandoc", "-f", "markdown", "-o", "output.docx", "input.md")
 
 ### Features
 
-#### 6.1 Per-Section Layout Presets (Phase A - Foundation)
+#### 6.1 Per-Section Layout Presets (Phase A - Foundation) ✅ Complete
 
 Add a `layout` field to each section in the view editor. Each section type has its own curated set of valid layouts.
 
@@ -476,12 +476,12 @@ interface ViewSection {
 | Talks | `default`, `cards`, `list` | default | Default embeds video |
 
 **Implementation:**
-- [ ] Add `layout` field to ViewSection type in `pocketbase.ts`
-- [ ] Add `VALID_LAYOUTS` constant mapping section → allowed layouts
-- [ ] Add layout dropdown in view editor (in section header when expanded)
-- [ ] Backend passes layout through in `/api/view/:slug/data` response
-- [ ] Update section components to accept `layout` prop
-- [ ] Implement 2-3 layout variants per section (start with most valuable)
+- [x] Add `layout` field to ViewSection type in `pocketbase.ts`
+- [x] Add `VALID_LAYOUTS` constant mapping section → allowed layouts
+- [x] Add layout dropdown in view editor (in section header when expanded)
+- [x] Backend passes layout through in `/api/view/:slug/data` response
+- [x] Update section components to accept `layout` prop
+- [x] Implement 2-3 layout variants per section (start with most valuable)
 
 **UX Flow:**
 1. User expands section in view editor

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -224,6 +224,8 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 			sectionData := make(map[string]interface{})
 			// Track section order for frontend rendering
 			var sectionOrder []string
+			// Track layouts for each section
+			sectionLayouts := make(map[string]string)
 
 			for _, section := range sections {
 				sectionName, ok := section["section"].(string)
@@ -236,6 +238,13 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 				}
 				// Add to order list
 				sectionOrder = append(sectionOrder, sectionName)
+
+				// Extract layout (default to "default" if not specified)
+				if layout, ok := section["layout"].(string); ok && layout != "" {
+					sectionLayouts[sectionName] = layout
+				} else {
+					sectionLayouts[sectionName] = getDefaultLayout(sectionName)
+				}
 
 				items, ok := section["items"].([]interface{})
 				collectionName := getCollectionName(sectionName)
@@ -283,6 +292,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 
 			response["sections"] = sectionData
 			response["section_order"] = sectionOrder
+			response["section_layouts"] = sectionLayouts
 
 			// Fetch profile data for the view
 			profileRecords, err := app.FindRecordsByFilter(
@@ -869,6 +879,29 @@ func getCollectionName(section string) string {
 		return "talks"
 	default:
 		return ""
+	}
+}
+
+// getDefaultLayout returns the default layout for a section type
+// Sync with VALID_LAYOUTS in frontend/src/lib/pocketbase.ts
+func getDefaultLayout(section string) string {
+	switch section {
+	case "experience":
+		return "default"
+	case "projects":
+		return "grid-3"
+	case "education":
+		return "default"
+	case "certifications":
+		return "grouped"
+	case "skills":
+		return "grouped"
+	case "posts":
+		return "grid-3"
+	case "talks":
+		return "default"
+	default:
+		return "default"
 	}
 }
 

--- a/frontend/src/components/public/CertificationsSection.svelte
+++ b/frontend/src/components/public/CertificationsSection.svelte
@@ -3,6 +3,7 @@
 	import { formatDate } from '$lib/utils';
 
 	export let items: Certification[];
+	export let layout: string = 'grouped';
 
 	// Group certifications by issuer
 	function groupByIssuer(certs: Certification[]): Map<string, Certification[]> {

--- a/frontend/src/components/public/EducationSection.svelte
+++ b/frontend/src/components/public/EducationSection.svelte
@@ -3,44 +3,86 @@
 	import { formatDateRange, parseMarkdown } from '$lib/utils';
 
 	export let items: Education[];
+	export let layout: string = 'default';
 </script>
 
 <section id="education" class="mb-16">
 	<h2 class="section-title">Education</h2>
 
-	<div class="space-y-6">
-		{#each items as item (item.id)}
-			<article class="card p-6 animate-fade-in">
-				<div class="flex items-start gap-4">
-					<div class="shrink-0 w-12 h-12 rounded-lg bg-primary-100 dark:bg-primary-900 flex items-center justify-center">
-						<svg class="w-6 h-6 text-primary-600 dark:text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-							<path d="M12 14l9-5-9-5-9 5 9 5z" />
-							<path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
-						</svg>
-					</div>
+	{#if layout === 'timeline'}
+		<!-- Timeline Layout -->
+		<div class="relative">
+			<div class="absolute left-4 top-0 bottom-0 w-0.5 bg-gray-200 dark:bg-gray-700"></div>
 
-					<div class="flex-1">
-						<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-							{item.institution}
-						</h3>
-						{#if item.degree || item.field}
-							<p class="text-primary-600 dark:text-primary-400">
-								{[item.degree, item.field].filter(Boolean).join(' in ')}
+			<div class="space-y-6 pl-12">
+				{#each items as item (item.id)}
+					<article class="relative animate-fade-in">
+						<div class="absolute -left-12 w-8 h-8 bg-primary-600 rounded-full flex items-center justify-center z-10">
+							<svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+								<path d="M12 14l9-5-9-5-9 5 9 5z" />
+							</svg>
+						</div>
+
+						<div>
+							<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+								{item.institution}
+							</h3>
+							{#if item.degree || item.field}
+								<p class="text-primary-600 dark:text-primary-400">
+									{[item.degree, item.field].filter(Boolean).join(' in ')}
+								</p>
+							{/if}
+							<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+								{formatDateRange(item.start_date, item.end_date)}
 							</p>
-						{/if}
-						<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-							{formatDateRange(item.start_date, item.end_date)}
-						</p>
 
-						{#if item.description}
-							<div class="mt-3 prose-custom text-gray-600 dark:text-gray-300 text-sm">
-								{@html parseMarkdown(item.description)}
-							</div>
-						{/if}
+							{#if item.description}
+								<div class="mt-2 prose-custom text-gray-600 dark:text-gray-300 text-sm">
+									{@html parseMarkdown(item.description)}
+								</div>
+							{/if}
+						</div>
+					</article>
+				{/each}
+			</div>
+		</div>
+
+	{:else}
+		<!-- Default Layout (Cards with icons) -->
+		<div class="space-y-6">
+			{#each items as item (item.id)}
+				<article class="card p-6 animate-fade-in">
+					<div class="flex items-start gap-4">
+						<div class="shrink-0 w-12 h-12 rounded-lg bg-primary-100 dark:bg-primary-900 flex items-center justify-center">
+							<svg class="w-6 h-6 text-primary-600 dark:text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+								<path d="M12 14l9-5-9-5-9 5 9 5z" />
+								<path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
+							</svg>
+						</div>
+
+						<div class="flex-1">
+							<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+								{item.institution}
+							</h3>
+							{#if item.degree || item.field}
+								<p class="text-primary-600 dark:text-primary-400">
+									{[item.degree, item.field].filter(Boolean).join(' in ')}
+								</p>
+							{/if}
+							<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+								{formatDateRange(item.start_date, item.end_date)}
+							</p>
+
+							{#if item.description}
+								<div class="mt-3 prose-custom text-gray-600 dark:text-gray-300 text-sm">
+									{@html parseMarkdown(item.description)}
+								</div>
+							{/if}
+						</div>
 					</div>
-				</div>
-			</article>
-		{/each}
-	</div>
+				</article>
+			{/each}
+		</div>
+	{/if}
 </section>

--- a/frontend/src/components/public/ExperienceSection.svelte
+++ b/frontend/src/components/public/ExperienceSection.svelte
@@ -3,63 +3,162 @@
 	import { formatDateRange, parseMarkdown } from '$lib/utils';
 
 	export let items: Experience[];
+	export let layout: string = 'default';
 </script>
 
 <section id="experience" class="mb-16">
 	<h2 class="section-title">Experience</h2>
 
-	<div class="space-y-8">
-		{#each items as item (item.id)}
-			<article class="card p-6 animate-fade-in">
-				<div class="flex flex-col sm:flex-row sm:items-start gap-4">
-					<div class="flex-1">
-						<h3 class="text-xl font-semibold text-gray-900 dark:text-white">
-							{item.title}
-						</h3>
-						<p class="text-lg text-primary-600 dark:text-primary-400 font-medium">
-							{item.company}
-						</p>
-						<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
-							<span>{formatDateRange(item.start_date, item.end_date)}</span>
-							{#if item.location}
-								<span class="flex items-center gap-1">
-									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-									</svg>
-									{item.location}
+	{#if layout === 'timeline'}
+		<!-- Timeline Layout -->
+		<div class="relative">
+			<!-- Timeline line -->
+			<div class="absolute left-4 top-0 bottom-0 w-0.5 bg-gray-200 dark:bg-gray-700"></div>
+
+			<div class="space-y-8 pl-12">
+				{#each items as item, index (item.id)}
+					<article class="relative animate-fade-in">
+						<!-- Timeline node -->
+						<div class="absolute -left-12 w-8 h-8 bg-primary-600 rounded-full flex items-center justify-center z-10">
+							<div class="w-3 h-3 bg-white rounded-full"></div>
+						</div>
+
+						<div class="pb-2">
+							<div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+								<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+									{item.title}
+								</h3>
+								<span class="text-primary-600 dark:text-primary-400 font-medium">
+									{item.company}
 								</span>
-							{/if}
+							</div>
+							<div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+								<span class="font-medium">{formatDateRange(item.start_date, item.end_date)}</span>
+								{#if item.location}
+									<span>• {item.location}</span>
+								{/if}
+							</div>
+						</div>
+
+						{#if item.description}
+							<div class="prose-custom text-gray-600 dark:text-gray-300 text-sm">
+								{@html parseMarkdown(item.description)}
+							</div>
+						{/if}
+
+						{#if item.bullets && item.bullets.length > 0}
+							<ul class="mt-2 space-y-1">
+								{#each item.bullets as bullet}
+									<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300 text-sm">
+										<span class="text-primary-500 mt-0.5">•</span>
+										<span>{bullet}</span>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+
+						{#if item.skills && item.skills.length > 0}
+							<div class="mt-3 flex flex-wrap gap-1.5">
+								{#each item.skills as skill}
+									<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+										{skill}
+									</span>
+								{/each}
+							</div>
+						{/if}
+					</article>
+				{/each}
+			</div>
+		</div>
+
+	{:else if layout === 'compact'}
+		<!-- Compact Layout -->
+		<div class="divide-y divide-gray-200 dark:divide-gray-700">
+			{#each items as item (item.id)}
+				<article class="py-4 first:pt-0 animate-fade-in">
+					<div class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
+						<div class="flex-1 flex flex-wrap items-baseline gap-x-2">
+							<h3 class="font-semibold text-gray-900 dark:text-white">
+								{item.title}
+							</h3>
+							<span class="text-gray-500 dark:text-gray-400">at</span>
+							<span class="text-primary-600 dark:text-primary-400 font-medium">
+								{item.company}
+							</span>
+						</div>
+						<span class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+							{formatDateRange(item.start_date, item.end_date)}
+						</span>
+					</div>
+
+					{#if item.location}
+						<p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{item.location}</p>
+					{/if}
+
+					{#if item.description}
+						<div class="mt-2 prose-custom text-gray-600 dark:text-gray-300 text-sm">
+							{@html parseMarkdown(item.description)}
+						</div>
+					{/if}
+				</article>
+			{/each}
+		</div>
+
+	{:else}
+		<!-- Default Layout (Cards) -->
+		<div class="space-y-8">
+			{#each items as item (item.id)}
+				<article class="card p-6 animate-fade-in">
+					<div class="flex flex-col sm:flex-row sm:items-start gap-4">
+						<div class="flex-1">
+							<h3 class="text-xl font-semibold text-gray-900 dark:text-white">
+								{item.title}
+							</h3>
+							<p class="text-lg text-primary-600 dark:text-primary-400 font-medium">
+								{item.company}
+							</p>
+							<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+								<span>{formatDateRange(item.start_date, item.end_date)}</span>
+								{#if item.location}
+									<span class="flex items-center gap-1">
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+										</svg>
+										{item.location}
+									</span>
+								{/if}
+							</div>
 						</div>
 					</div>
-				</div>
 
-				{#if item.description}
-					<div class="mt-4 prose-custom text-gray-600 dark:text-gray-300">
-						{@html parseMarkdown(item.description)}
-					</div>
-				{/if}
+					{#if item.description}
+						<div class="mt-4 prose-custom text-gray-600 dark:text-gray-300">
+							{@html parseMarkdown(item.description)}
+						</div>
+					{/if}
 
-				{#if item.bullets && item.bullets.length > 0}
-					<ul class="mt-4 space-y-2">
-						{#each item.bullets as bullet}
-							<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300">
-								<span class="text-primary-500 mt-1">•</span>
-								<span>{bullet}</span>
-							</li>
-						{/each}
-					</ul>
-				{/if}
+					{#if item.bullets && item.bullets.length > 0}
+						<ul class="mt-4 space-y-2">
+							{#each item.bullets as bullet}
+								<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300">
+									<span class="text-primary-500 mt-1">•</span>
+									<span>{bullet}</span>
+								</li>
+							{/each}
+						</ul>
+					{/if}
 
-				{#if item.skills && item.skills.length > 0}
-					<div class="mt-4 flex flex-wrap gap-2">
-						{#each item.skills as skill}
-							<span class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
-								{skill}
-							</span>
-						{/each}
-					</div>
-				{/if}
-			</article>
-		{/each}
-	</div>
+					{#if item.skills && item.skills.length > 0}
+						<div class="mt-4 flex flex-wrap gap-2">
+							{#each item.skills as skill}
+								<span class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+									{skill}
+								</span>
+							{/each}
+						</div>
+					{/if}
+				</article>
+			{/each}
+		</div>
+	{/if}
 </section>

--- a/frontend/src/components/public/PostsSection.svelte
+++ b/frontend/src/components/public/PostsSection.svelte
@@ -3,12 +3,13 @@
 	import { formatDate, truncate } from '$lib/utils';
 
 	export let items: Post[];
+	export let layout: string = 'grid-3';
 </script>
 
 <section id="posts" class="mb-16">
 	<h2 class="section-title">Posts</h2>
 
-	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+	<div class="grid grid-cols-1 {layout === 'grid-2' ? 'md:grid-cols-2' : layout === 'list' ? '' : 'md:grid-cols-2 lg:grid-cols-3'} gap-6">
 		{#each items as post (post.id)}
 			<article class="card overflow-hidden group animate-fade-in">
 				{#if post.cover_image}

--- a/frontend/src/components/public/ProjectsSection.svelte
+++ b/frontend/src/components/public/ProjectsSection.svelte
@@ -1,100 +1,398 @@
 <script lang="ts">
 	import type { Project } from '$lib/pocketbase';
-	import { truncate } from '$lib/utils';
+	import { truncate, parseMarkdown } from '$lib/utils';
 
 	export let items: Project[];
+	export let layout: string = 'grid-3';
 
 	function getLinkIcon(type: string) {
 		switch (type.toLowerCase()) {
 			case 'github':
-				return `<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`;
+				return `<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`;
 			case 'website':
 			case 'demo':
-				return `<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" /></svg>`;
+				return `<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" /></svg>`;
 			default:
-				return `<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>`;
+				return `<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>`;
 		}
 	}
+
+	// Split items for featured layout
+	$: featuredItem = items[0];
+	$: remainingItems = items.slice(1);
 </script>
 
 <section id="projects" class="mb-16">
 	<h2 class="section-title">Projects</h2>
 
-	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-		{#each items as project (project.id)}
+	{#if layout === 'featured' && items.length > 0}
+		<!-- Featured Layout: First item large, rest in grid -->
+		<div class="space-y-8">
+			<!-- Featured Project -->
 			<article class="card overflow-hidden group animate-fade-in">
-				{#if project.cover_image}
-					<div class="aspect-video overflow-hidden bg-gray-100 dark:bg-gray-700">
-						<img
-							src={project.cover_image}
-							alt={project.title}
-							class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-						/>
-					</div>
-				{:else}
-					<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
-						<span class="text-4xl font-bold text-white/50">
-							{project.title.charAt(0)}
-						</span>
-					</div>
-				{/if}
+				<div class="grid md:grid-cols-2 gap-0">
+					{#if featuredItem.cover_image}
+						<div class="aspect-video md:aspect-auto md:h-full overflow-hidden bg-gray-100 dark:bg-gray-700">
+							<img
+								src={featuredItem.cover_image}
+								alt={featuredItem.title}
+								class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+							/>
+						</div>
+					{:else}
+						<div class="aspect-video md:aspect-auto md:h-full bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
+							<span class="text-6xl font-bold text-white/50">
+								{featuredItem.title.charAt(0)}
+							</span>
+						</div>
+					{/if}
 
-				<div class="p-5">
-					<div class="flex items-start justify-between gap-2">
-						<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-							{#if project.slug}
-								<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
-									{project.title}
-								</a>
-							{:else}
-								{project.title}
-							{/if}
-						</h3>
-						{#if project.is_featured}
+					<div class="p-6 flex flex-col justify-center">
+						<div class="flex items-start justify-between gap-2">
+							<h3 class="text-2xl font-semibold text-gray-900 dark:text-white">
+								{#if featuredItem.slug}
+									<a href="/projects/{featuredItem.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+										{featuredItem.title}
+									</a>
+								{:else}
+									{featuredItem.title}
+								{/if}
+							</h3>
 							<span class="shrink-0 px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
 								Featured
 							</span>
+						</div>
+
+						{#if featuredItem.summary}
+							<p class="mt-3 text-gray-600 dark:text-gray-400">
+								{featuredItem.summary}
+							</p>
+						{/if}
+
+						{#if featuredItem.tech_stack && featuredItem.tech_stack.length > 0}
+							<div class="mt-4 flex flex-wrap gap-2">
+								{#each featuredItem.tech_stack as tech}
+									<span class="px-2.5 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+										{tech}
+									</span>
+								{/each}
+							</div>
+						{/if}
+
+						{#if featuredItem.links && featuredItem.links.length > 0}
+							<div class="mt-4 flex items-center gap-4">
+								{#each featuredItem.links as link}
+									<a
+										href={link.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
+									>
+										{@html getLinkIcon(link.type)}
+										<span class="capitalize">{link.type}</span>
+									</a>
+								{/each}
+							</div>
 						{/if}
 					</div>
+				</div>
+			</article>
 
-					{#if project.summary}
-						<p class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
-							{truncate(project.summary, 120)}
-						</p>
+			<!-- Remaining Projects in Grid -->
+			{#if remainingItems.length > 0}
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+					{#each remainingItems as project (project.id)}
+						<article class="card overflow-hidden group animate-fade-in">
+							{#if project.cover_image}
+								<div class="aspect-video overflow-hidden bg-gray-100 dark:bg-gray-700">
+									<img
+										src={project.cover_image}
+										alt={project.title}
+										class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+									/>
+								</div>
+							{:else}
+								<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
+									<span class="text-4xl font-bold text-white/50">
+										{project.title.charAt(0)}
+									</span>
+								</div>
+							{/if}
+
+							<div class="p-5">
+								<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+									{#if project.slug}
+										<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+											{project.title}
+										</a>
+									{:else}
+										{project.title}
+									{/if}
+								</h3>
+
+								{#if project.summary}
+									<p class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+										{truncate(project.summary, 100)}
+									</p>
+								{/if}
+
+								{#if project.tech_stack && project.tech_stack.length > 0}
+									<div class="mt-3 flex flex-wrap gap-1.5">
+										{#each project.tech_stack.slice(0, 3) as tech}
+											<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+												{tech}
+											</span>
+										{/each}
+										{#if project.tech_stack.length > 3}
+											<span class="px-2 py-0.5 text-xs text-gray-500">
+												+{project.tech_stack.length - 3}
+											</span>
+										{/if}
+									</div>
+								{/if}
+							</div>
+						</article>
+					{/each}
+				</div>
+			{/if}
+		</div>
+
+	{:else if layout === 'list'}
+		<!-- List Layout -->
+		<div class="space-y-4">
+			{#each items as project (project.id)}
+				<article class="card overflow-hidden group animate-fade-in">
+					<div class="flex flex-col sm:flex-row">
+						{#if project.cover_image}
+							<div class="sm:w-48 sm:shrink-0 aspect-video sm:aspect-square overflow-hidden bg-gray-100 dark:bg-gray-700">
+								<img
+									src={project.cover_image}
+									alt={project.title}
+									class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+								/>
+							</div>
+						{/if}
+
+						<div class="p-5 flex-1">
+							<div class="flex items-start justify-between gap-2">
+								<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+									{#if project.slug}
+										<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+											{project.title}
+										</a>
+									{:else}
+										{project.title}
+									{/if}
+								</h3>
+								{#if project.is_featured}
+									<span class="shrink-0 px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
+										Featured
+									</span>
+								{/if}
+							</div>
+
+							{#if project.summary}
+								<p class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+									{project.summary}
+								</p>
+							{/if}
+
+							<div class="mt-3 flex flex-wrap items-center gap-4">
+								{#if project.tech_stack && project.tech_stack.length > 0}
+									<div class="flex flex-wrap gap-1.5">
+										{#each project.tech_stack.slice(0, 5) as tech}
+											<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+												{tech}
+											</span>
+										{/each}
+										{#if project.tech_stack.length > 5}
+											<span class="px-2 py-0.5 text-xs text-gray-500">
+												+{project.tech_stack.length - 5}
+											</span>
+										{/if}
+									</div>
+								{/if}
+
+								{#if project.links && project.links.length > 0}
+									<div class="flex items-center gap-3 ml-auto">
+										{#each project.links as link}
+											<a
+												href={link.url}
+												target="_blank"
+												rel="noopener noreferrer"
+												class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
+											>
+												{@html getLinkIcon(link.type)}
+												<span class="capitalize">{link.type}</span>
+											</a>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						</div>
+					</div>
+				</article>
+			{/each}
+		</div>
+
+	{:else if layout === 'grid-2'}
+		<!-- 2-Column Grid Layout -->
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+			{#each items as project (project.id)}
+				<article class="card overflow-hidden group animate-fade-in">
+					{#if project.cover_image}
+						<div class="aspect-video overflow-hidden bg-gray-100 dark:bg-gray-700">
+							<img
+								src={project.cover_image}
+								alt={project.title}
+								class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+							/>
+						</div>
+					{:else}
+						<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
+							<span class="text-5xl font-bold text-white/50">
+								{project.title.charAt(0)}
+							</span>
+						</div>
 					{/if}
 
-					{#if project.tech_stack && project.tech_stack.length > 0}
-						<div class="mt-3 flex flex-wrap gap-1.5">
-							{#each project.tech_stack.slice(0, 4) as tech}
-								<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
-									{tech}
-								</span>
-							{/each}
-							{#if project.tech_stack.length > 4}
-								<span class="px-2 py-0.5 text-xs text-gray-500">
-									+{project.tech_stack.length - 4}
+					<div class="p-6">
+						<div class="flex items-start justify-between gap-2">
+							<h3 class="text-xl font-semibold text-gray-900 dark:text-white">
+								{#if project.slug}
+									<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+										{project.title}
+									</a>
+								{:else}
+									{project.title}
+								{/if}
+							</h3>
+							{#if project.is_featured}
+								<span class="shrink-0 px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
+									Featured
 								</span>
 							{/if}
 						</div>
-					{/if}
 
-					{#if project.links && project.links.length > 0}
-						<div class="mt-4 flex items-center gap-3">
-							{#each project.links as link}
-								<a
-									href={link.url}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
-								>
-									{@html getLinkIcon(link.type)}
-									<span class="capitalize">{link.type}</span>
-								</a>
-							{/each}
+						{#if project.summary}
+							<p class="mt-2 text-gray-600 dark:text-gray-400">
+								{truncate(project.summary, 150)}
+							</p>
+						{/if}
+
+						{#if project.tech_stack && project.tech_stack.length > 0}
+							<div class="mt-4 flex flex-wrap gap-2">
+								{#each project.tech_stack.slice(0, 5) as tech}
+									<span class="px-2.5 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+										{tech}
+									</span>
+								{/each}
+								{#if project.tech_stack.length > 5}
+									<span class="px-2.5 py-1 text-sm text-gray-500">
+										+{project.tech_stack.length - 5}
+									</span>
+								{/if}
+							</div>
+						{/if}
+
+						{#if project.links && project.links.length > 0}
+							<div class="mt-4 flex items-center gap-4">
+								{#each project.links as link}
+									<a
+										href={link.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
+									>
+										{@html getLinkIcon(link.type)}
+										<span class="capitalize">{link.type}</span>
+									</a>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				</article>
+			{/each}
+		</div>
+
+	{:else}
+		<!-- Default: 3-Column Grid Layout -->
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+			{#each items as project (project.id)}
+				<article class="card overflow-hidden group animate-fade-in">
+					{#if project.cover_image}
+						<div class="aspect-video overflow-hidden bg-gray-100 dark:bg-gray-700">
+							<img
+								src={project.cover_image}
+								alt={project.title}
+								class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+							/>
+						</div>
+					{:else}
+						<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
+							<span class="text-4xl font-bold text-white/50">
+								{project.title.charAt(0)}
+							</span>
 						</div>
 					{/if}
-				</div>
-			</article>
-		{/each}
-	</div>
+
+					<div class="p-5">
+						<div class="flex items-start justify-between gap-2">
+							<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+								{#if project.slug}
+									<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+										{project.title}
+									</a>
+								{:else}
+									{project.title}
+								{/if}
+							</h3>
+							{#if project.is_featured}
+								<span class="shrink-0 px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded">
+									Featured
+								</span>
+							{/if}
+						</div>
+
+						{#if project.summary}
+							<p class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+								{truncate(project.summary, 120)}
+							</p>
+						{/if}
+
+						{#if project.tech_stack && project.tech_stack.length > 0}
+							<div class="mt-3 flex flex-wrap gap-1.5">
+								{#each project.tech_stack.slice(0, 4) as tech}
+									<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded">
+										{tech}
+									</span>
+								{/each}
+								{#if project.tech_stack.length > 4}
+									<span class="px-2 py-0.5 text-xs text-gray-500">
+										+{project.tech_stack.length - 4}
+									</span>
+								{/if}
+							</div>
+						{/if}
+
+						{#if project.links && project.links.length > 0}
+							<div class="mt-4 flex items-center gap-3">
+								{#each project.links as link}
+									<a
+										href={link.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
+									>
+										{@html getLinkIcon(link.type)}
+										<span class="capitalize">{link.type}</span>
+									</a>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				</article>
+			{/each}
+		</div>
+	{/if}
 </section>

--- a/frontend/src/components/public/SkillsSection.svelte
+++ b/frontend/src/components/public/SkillsSection.svelte
@@ -2,6 +2,7 @@
 	import type { Skill } from '$lib/pocketbase';
 
 	export let items: Skill[];
+	export let layout: string = 'grouped';
 
 	// Group skills by category
 	$: groupedSkills = items.reduce((acc, skill) => {
@@ -18,28 +19,113 @@
 		proficient: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
 		familiar: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200'
 	};
+
+	const proficiencyBarColors = {
+		expert: 'bg-green-500 dark:bg-green-400',
+		proficient: 'bg-blue-500 dark:bg-blue-400',
+		familiar: 'bg-gray-400 dark:bg-gray-500'
+	};
+
+	const proficiencyWidth = {
+		expert: 'w-full',
+		proficient: 'w-3/4',
+		familiar: 'w-1/2'
+	};
+
+	// Tag cloud sizing based on proficiency
+	const cloudSizes = {
+		expert: 'text-xl font-semibold',
+		proficient: 'text-base font-medium',
+		familiar: 'text-sm'
+	};
 </script>
 
 <section id="skills" class="mb-16">
 	<h2 class="section-title">Skills</h2>
 
-	<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-		{#each Object.entries(groupedSkills) as [category, skills] (category)}
-			<div class="card p-6 animate-fade-in">
-				<h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-					{category}
-				</h3>
-				<div class="flex flex-wrap gap-2">
-					{#each skills as skill (skill.id)}
-						<span
-							class="px-3 py-1.5 text-sm rounded-full {proficiencyColors[skill.proficiency || 'familiar']}"
-							title={skill.proficiency ? `Proficiency: ${skill.proficiency}` : undefined}
-						>
-							{skill.name}
-						</span>
-					{/each}
-				</div>
+	{#if layout === 'cloud'}
+		<!-- Tag Cloud Layout -->
+		<div class="card p-8 animate-fade-in">
+			<div class="flex flex-wrap items-center justify-center gap-x-4 gap-y-3">
+				{#each items as skill (skill.id)}
+					<span
+						class="{cloudSizes[skill.proficiency || 'familiar']} text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 transition-colors cursor-default"
+						title={skill.proficiency ? `${skill.category || 'Skill'} - ${skill.proficiency}` : skill.category}
+					>
+						{skill.name}
+					</span>
+				{/each}
 			</div>
-		{/each}
-	</div>
+		</div>
+
+	{:else if layout === 'bars'}
+		<!-- Skill Bars Layout -->
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+			{#each Object.entries(groupedSkills) as [category, skills] (category)}
+				<div class="card p-6 animate-fade-in">
+					<h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+						{category}
+					</h3>
+					<div class="space-y-4">
+						{#each skills as skill (skill.id)}
+							<div>
+								<div class="flex items-center justify-between mb-1">
+									<span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+										{skill.name}
+									</span>
+									{#if skill.proficiency}
+										<span class="text-xs text-gray-500 dark:text-gray-400 capitalize">
+											{skill.proficiency}
+										</span>
+									{/if}
+								</div>
+								<div class="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+									<div
+										class="h-full rounded-full transition-all duration-500 {proficiencyBarColors[skill.proficiency || 'familiar']} {proficiencyWidth[skill.proficiency || 'familiar']}"
+									></div>
+								</div>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+
+	{:else if layout === 'flat'}
+		<!-- Flat List Layout -->
+		<div class="card p-6 animate-fade-in">
+			<div class="flex flex-wrap gap-2">
+				{#each items as skill (skill.id)}
+					<span
+						class="px-3 py-1.5 text-sm rounded-full {proficiencyColors[skill.proficiency || 'familiar']}"
+						title={skill.proficiency ? `${skill.category || 'Skill'} - ${skill.proficiency}` : skill.category}
+					>
+						{skill.name}
+					</span>
+				{/each}
+			</div>
+		</div>
+
+	{:else}
+		<!-- Default: Grouped Layout -->
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+			{#each Object.entries(groupedSkills) as [category, skills] (category)}
+				<div class="card p-6 animate-fade-in">
+					<h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+						{category}
+					</h3>
+					<div class="flex flex-wrap gap-2">
+						{#each skills as skill (skill.id)}
+							<span
+								class="px-3 py-1.5 text-sm rounded-full {proficiencyColors[skill.proficiency || 'familiar']}"
+								title={skill.proficiency ? `Proficiency: ${skill.proficiency}` : undefined}
+							>
+								{skill.name}
+							</span>
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
 </section>

--- a/frontend/src/components/public/TalksSection.svelte
+++ b/frontend/src/components/public/TalksSection.svelte
@@ -3,6 +3,7 @@
 	import { formatDate, parseMarkdown } from '$lib/utils';
 
 	export let items: Talk[];
+	export let layout: string = 'default';
 
 	// Extract YouTube video ID from various URL formats
 	function getYouTubeId(url: string): string | null {

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -162,12 +162,93 @@ export interface ItemConfig {
 	overrides?: Record<string, string | string[]>;
 }
 
+// Layout types for each section
+export type SectionLayout = string;
+
 export interface ViewSection {
 	section: string;
 	enabled: boolean;
 	items?: string[];
 	order?: number;
+	layout?: SectionLayout;
 	itemConfig?: Record<string, ItemConfig>;
+}
+
+// Valid layouts per section type (curated presets)
+export const VALID_LAYOUTS: Record<string, { layouts: string[]; default: string; labels: Record<string, string> }> = {
+	experience: {
+		layouts: ['default', 'timeline', 'compact'],
+		default: 'default',
+		labels: {
+			default: 'Default',
+			timeline: 'Timeline',
+			compact: 'Compact'
+		}
+	},
+	projects: {
+		layouts: ['grid-3', 'grid-2', 'list', 'featured'],
+		default: 'grid-3',
+		labels: {
+			'grid-3': '3-Column Grid',
+			'grid-2': '2-Column Grid',
+			list: 'List',
+			featured: 'Featured + Grid'
+		}
+	},
+	education: {
+		layouts: ['default', 'timeline'],
+		default: 'default',
+		labels: {
+			default: 'Default',
+			timeline: 'Timeline'
+		}
+	},
+	certifications: {
+		layouts: ['grouped', 'grid', 'timeline'],
+		default: 'grouped',
+		labels: {
+			grouped: 'Grouped by Issuer',
+			grid: 'Grid',
+			timeline: 'Timeline'
+		}
+	},
+	skills: {
+		layouts: ['grouped', 'cloud', 'bars', 'flat'],
+		default: 'grouped',
+		labels: {
+			grouped: 'Grouped by Category',
+			cloud: 'Tag Cloud',
+			bars: 'Skill Bars',
+			flat: 'Flat List'
+		}
+	},
+	posts: {
+		layouts: ['grid-3', 'grid-2', 'list', 'featured'],
+		default: 'grid-3',
+		labels: {
+			'grid-3': '3-Column Grid',
+			'grid-2': '2-Column Grid',
+			list: 'List',
+			featured: 'Featured + Grid'
+		}
+	},
+	talks: {
+		layouts: ['default', 'cards', 'list'],
+		default: 'default',
+		labels: {
+			default: 'Default',
+			cards: 'Cards',
+			list: 'List'
+		}
+	}
+};
+
+// Helper to get section layout with fallback to default
+export function getSectionLayout(section: string, layout?: string): string {
+	const config = VALID_LAYOUTS[section];
+	if (!config) return 'default';
+	if (layout && config.layouts.includes(layout)) return layout;
+	return config.default;
 }
 
 // Define which fields can be overridden per collection

--- a/frontend/src/routes/[slug=slug]/+page.server.ts
+++ b/frontend/src/routes/[slug=slug]/+page.server.ts
@@ -129,6 +129,7 @@ export const load: PageServerLoad = async ({ params, cookies, url, fetch }) => {
 			} : null,
 			sections: viewData.sections || {},
 			sectionOrder: viewData.section_order || [],
+			sectionLayouts: viewData.section_layouts || {},
 			requiresPassword: false
 		};
 	} catch (err) {

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -24,6 +24,11 @@
 		? data.sectionOrder
 		: DEFAULT_SECTION_ORDER;
 
+	// Get layout for a section (from API response or default)
+	function getSectionLayout(sectionKey: string): string {
+		return data.sectionLayouts?.[sectionKey] || 'default';
+	}
+
 	// Hidden form ref for setting password token cookie
 	let passwordForm: HTMLFormElement;
 	let tokenInput: HTMLInputElement;
@@ -124,19 +129,19 @@
 		<main id="main-content" class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
 			{#each effectiveSectionOrder as sectionKey}
 				{#if sectionKey === 'experience' && data.sections?.experience?.length > 0}
-					<ExperienceSection items={data.sections.experience} />
+					<ExperienceSection items={data.sections.experience} layout={getSectionLayout('experience')} />
 				{:else if sectionKey === 'projects' && data.sections?.projects?.length > 0}
-					<ProjectsSection items={data.sections.projects} />
+					<ProjectsSection items={data.sections.projects} layout={getSectionLayout('projects')} />
 				{:else if sectionKey === 'education' && data.sections?.education?.length > 0}
-					<EducationSection items={data.sections.education} />
+					<EducationSection items={data.sections.education} layout={getSectionLayout('education')} />
 				{:else if sectionKey === 'certifications' && data.sections?.certifications?.length > 0}
-					<CertificationsSection items={data.sections.certifications} />
+					<CertificationsSection items={data.sections.certifications} layout={getSectionLayout('certifications')} />
 				{:else if sectionKey === 'skills' && data.sections?.skills?.length > 0}
-					<SkillsSection items={data.sections.skills} />
+					<SkillsSection items={data.sections.skills} layout={getSectionLayout('skills')} />
 				{:else if sectionKey === 'posts' && data.sections?.posts?.length > 0}
-					<PostsSection items={data.sections.posts} />
+					<PostsSection items={data.sections.posts} layout={getSectionLayout('posts')} />
 				{:else if sectionKey === 'talks' && data.sections?.talks?.length > 0}
-					<TalksSection items={data.sections.talks} />
+					<TalksSection items={data.sections.talks} layout={getSectionLayout('talks')} />
 				{/if}
 			{/each}
 		</main>


### PR DESCRIPTION
Adds per-section layout customization with curated presets:

Frontend:
- Add layout field and VALID_LAYOUTS to ViewSection type
- Add layout dropdown to view editor section headers
- Update section components with layout variants:
  - ExperienceSection: default, timeline, compact
  - ProjectsSection: grid-3, grid-2, list, featured
  - SkillsSection: grouped, cloud, bars, flat
  - EducationSection: default, timeline
  - CertificationsSection, PostsSection, TalksSection: layout prop

Backend:
- Add section_layouts map to view data API response
- Add getDefaultLayout() helper function

Docs:
- Update IMPLEMENTATION_PLAN.md with Phase 6.1 details
- Update ROADMAP.md to mark Phase 6.1 complete