### PR TITLE
feat: Implement Phase 6.2 Live Preview Pane

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -206,6 +206,7 @@
 | 10. Documentation | 🟡 Partial | Core docs done |
 | 11. Testing | 🟡 Partial | Backend tests exist |
 | 12. Print & Export | 🟡 Partial | Print stylesheet complete, data export deferred |
+| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) complete |
 
 ---
 
@@ -216,15 +217,18 @@
 
 ### Medium Priority
 1. ~~Drag-drop section/item reordering for views (Phase 2.2 continued)~~ ✅ Complete
-2. Media library (Phase 7)
-3. Additional frontend tests
+2. ~~Live preview pane for view editor (Phase 6.2)~~ ✅ Complete
+3. Media library (Phase 7)
+4. Additional frontend tests
 
 ### Low Priority
-4. SETUP.md and UPGRADE.md documentation
-5. AI provider mock tests
-6. Integration tests
-7. View access log / audit logging (Phase 8)
-8. Data export (JSON/YAML) - Phase 4.3
+5. SETUP.md and UPGRADE.md documentation
+6. AI provider mock tests
+7. Integration tests
+8. View access log / audit logging (Phase 8)
+9. Data export (JSON/YAML) - Phase 4.4
+10. Section width & columns (Phase 6.3)
+11. Mobile preview mode (Phase 6.2.2)
 
 ---
 
@@ -456,3 +460,67 @@ Users can now select different layout styles for each section in the view editor
 3. Layout dropdown appears next to the expand button
 4. Select desired layout preset
 5. Save view - layout is applied on public view
+
+---
+
+## Phase 6.2: Live Preview Pane ✅ Complete
+
+This phase adds a side-by-side live preview in the view editor for immediate visual feedback when customizing views.
+
+### Overview
+Users can now see how their view will look while editing, without needing to save and navigate to the public page. The preview updates instantly as changes are made to sections, layouts, items, and overrides.
+
+### Features
+- [x] Split-pane layout: editor (~60%) and preview (~40%)
+- [x] Preview updates reactively on any editor change
+- [x] Preview reuses actual public section components (not mockups)
+- [x] Toggle button to hide/show preview for more editor space
+- [x] Responsive layout: side-by-side on desktop, stacked on mobile
+- [x] Profile data loaded and displayed in preview hero
+- [x] Hero overrides (headline, summary) shown in preview
+- [x] CTA banner shown when configured
+- [x] Section layouts applied in real-time
+- [x] Item-level overrides reflected in preview
+
+### Implementation
+
+#### New Component
+- `frontend/src/components/admin/ViewPreview.svelte`
+  - Reuses all public section components (ExperienceSection, ProjectsSection, etc.)
+  - Accepts editor state as props (profile, sections, sectionOrder, sectionItems, etc.)
+  - Filters items based on enabled sections and selected items
+  - Applies item-level overrides before rendering
+  - Scaled-down styling for compact preview display
+
+#### View Editor Changes
+- [x] Import ViewPreview component
+- [x] Add profile data loading on mount
+- [x] Add `showPreview` toggle state (default: true)
+- [x] Split layout with editor-pane and preview-pane
+- [x] Toggle button with eye icon in header
+- [x] Pass all editor state to ViewPreview component
+
+#### View Create Page Changes
+- [x] Same changes applied to `/admin/views/new`
+- [x] Preview works during initial view creation
+- [x] All sections enabled by default for new views
+
+### Files Changed
+- `frontend/src/components/admin/ViewPreview.svelte` (new)
+- `frontend/src/routes/admin/views/[id]/+page.svelte` - Split layout, preview toggle, profile loading
+- `frontend/src/routes/admin/views/new/+page.svelte` - Split layout, preview toggle, profile loading
+
+### Technical Details
+- Preview rendered in same page (not iframe) for simplicity
+- Svelte reactive bindings update preview instantly (no debouncing needed)
+- CSS scales down components for compact display
+- Responsive: preview appears above editor on mobile screens
+- Profile avatar URL resolved for preview display
+
+### Usage
+1. Navigate to View Editor (/admin/views/[id] or /admin/views/new)
+2. Preview appears on the right side (or top on mobile)
+3. Make any change: enable/disable sections, change layouts, select items, add overrides
+4. See changes reflected immediately in preview
+5. Click "Hide/Show Preview" button to toggle preview visibility
+6. Click "Open in Tab" to see full-size public view in new tab

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,7 +94,7 @@ None (this is the starting phase)
 - [x] CTA configuration (button text and URL)
 - [x] Visibility settings (public, unlisted, password, private)
 - [x] Drag-and-drop section ordering (svelte-dnd-action)
-- [ ] Preview pane showing live result — Deferred
+- [x] Preview pane showing live result — Implemented in Phase 6.2
 
 #### 2.2 Section & Item Customization (Complete)
 - [x] Drag-and-drop section reordering
@@ -130,7 +130,7 @@ Enable per-view customization of individual items without modifying source recor
 - [x] Default view badge in views list
 - [x] Only one view can be default (enforced)
 - [ ] Warning when changing default — Minor, deferred
-- [ ] Preview of how homepage will look — Deferred to 2.2
+- [x] Preview of how homepage will look — Implemented in Phase 6.2
 
 #### 2.4 View Analytics (Minimal)
 - [ ] View count per view (opt-in)
@@ -490,21 +490,22 @@ interface ViewSection {
 4. Selection saves with view config
 5. Public view renders with selected layout
 
-#### 6.2 Live Preview Pane (Phase B - Feedback)
+#### 6.2 Live Preview Pane (Phase B - Feedback) ✅ Complete
 
 Add side-by-side preview in the view editor for immediate visual feedback.
 
-- [ ] Split-pane layout: editor left (60%), preview right (40%)
-- [ ] Preview updates on any change (debounced 300ms)
-- [ ] Preview uses actual section components (not mockups)
-- [ ] Toggle to hide preview for more editor space
-- [ ] Mobile preview mode (preview shown at mobile width)
+- [x] Split-pane layout: editor left (~60%), preview right (~40%)
+- [x] Preview updates on any change (reactive Svelte bindings)
+- [x] Preview uses actual section components (not mockups)
+- [x] Toggle button to hide preview for more editor space
+- [ ] Mobile preview mode (preview shown at mobile width) — Deferred
 
-**Technical Approach:**
+**Implementation Details:**
+- `ViewPreview.svelte` component reuses public section components
+- Reactive updates via Svelte props (no debouncing needed)
 - Preview rendered in same page (not iframe) for simplicity
-- Pass current form state to preview components
-- Use Svelte stores for reactive updates
-- Consider iframe for true isolation (Phase C)
+- Responsive layout: side-by-side on desktop, stacked on mobile
+- Preview scales down content for compact display
 
 #### 6.3 Section Width & Columns (Phase C - Advanced)
 

--- a/frontend/src/components/admin/ViewPreview.svelte
+++ b/frontend/src/components/admin/ViewPreview.svelte
@@ -1,0 +1,350 @@
+<script lang="ts">
+	/**
+	 * ViewPreview.svelte
+	 *
+	 * Live preview component for the view editor. Renders a scaled-down version
+	 * of the public view using the same section components.
+	 *
+	 * Features:
+	 * - Reuses public section components for consistency
+	 * - Applies item overrides from editor state
+	 * - Filters items based on selection
+	 * - Respects section order and layouts
+	 * - Scaled-down for side-by-side editing
+	 */
+	import type {
+		Profile,
+		Experience,
+		Project,
+		Education,
+		Certification,
+		Skill,
+		Post,
+		Talk,
+		ItemConfig
+	} from '$lib/pocketbase';
+	import ProfileHero from '$components/public/ProfileHero.svelte';
+	import ExperienceSection from '$components/public/ExperienceSection.svelte';
+	import ProjectsSection from '$components/public/ProjectsSection.svelte';
+	import EducationSection from '$components/public/EducationSection.svelte';
+	import CertificationsSection from '$components/public/CertificationsSection.svelte';
+	import SkillsSection from '$components/public/SkillsSection.svelte';
+	import PostsSection from '$components/public/PostsSection.svelte';
+	import TalksSection from '$components/public/TalksSection.svelte';
+
+	// Props from parent editor
+	export let profile: Profile | null = null;
+	export let heroHeadline: string = '';
+	export let heroSummary: string = '';
+	export let ctaText: string = '';
+	export let ctaUrl: string = '';
+
+	// Section configuration from editor
+	export let sections: Record<
+		string,
+		{
+			enabled: boolean;
+			items: string[];
+			layout: string;
+			itemConfig: Record<string, ItemConfig>;
+		}
+	> = {};
+
+	// Section order from drag-drop
+	export let sectionOrder: Array<{ id: string; key: string }> = [];
+
+	// Raw section data (all items)
+	export let sectionItems: Record<
+		string,
+		Array<{
+			id: string;
+			label: string;
+			visibility: string;
+			is_draft?: boolean;
+			data: Record<string, unknown>;
+		}>
+	> = {};
+
+	// Compute effective profile with hero overrides
+	$: effectiveProfile = profile
+		? {
+				...profile,
+				headline: heroHeadline || profile.headline,
+				summary: heroSummary || profile.summary
+			}
+		: null;
+
+	// Helper to get filtered and transformed items for a section
+	function getSectionData<T extends { id: string }>(
+		sectionKey: string
+	): T[] {
+		const config = sections[sectionKey];
+		const items = sectionItems[sectionKey] || [];
+
+		if (!config?.enabled || items.length === 0) {
+			return [];
+		}
+
+		// Filter to selected items (or all public/non-draft if no selection)
+		const filteredItems =
+			config.items.length > 0
+				? items.filter((item) => config.items.includes(item.id))
+				: items.filter((item) => item.visibility !== 'private' && !item.is_draft);
+
+		// Preserve order from config.items if specified
+		const orderedItems =
+			config.items.length > 0
+				? config.items
+						.map((id) => filteredItems.find((item) => item.id === id))
+						.filter(Boolean) as typeof filteredItems
+				: filteredItems;
+
+		// Apply overrides to items
+		return orderedItems.map((item) => {
+			const itemConfig = config.itemConfig?.[item.id];
+			const overrides = itemConfig?.overrides || {};
+
+			// Deep clone and apply overrides
+			const transformedData = { ...item.data };
+			for (const [field, value] of Object.entries(overrides)) {
+				if (value !== undefined && value !== null && value !== '') {
+					transformedData[field] = value;
+				}
+			}
+
+			return transformedData as T;
+		});
+	}
+
+	// Get layout for a section
+	function getSectionLayout(sectionKey: string): string {
+		return sections[sectionKey]?.layout || 'default';
+	}
+
+	// Check if a section should be shown
+	function shouldShowSection(sectionKey: string): boolean {
+		const config = sections[sectionKey];
+		if (!config?.enabled) return false;
+
+		const data = getSectionData(sectionKey);
+		return data.length > 0;
+	}
+</script>
+
+<div class="preview-container">
+	<!-- Mini Hero -->
+	{#if effectiveProfile}
+		<div class="preview-hero">
+			<ProfileHero profile={effectiveProfile} />
+		</div>
+	{:else}
+		<div class="preview-hero-placeholder">
+			<div class="flex flex-col items-center justify-center py-8 text-gray-400">
+				<svg class="w-12 h-12 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+				</svg>
+				<span class="text-sm">No profile data</span>
+			</div>
+		</div>
+	{/if}
+
+	<!-- CTA Banner Preview -->
+	{#if ctaText && ctaUrl}
+		<div class="bg-primary-600 text-white py-2 px-4">
+			<div class="flex items-center justify-between text-sm">
+				<span class="font-medium truncate">{ctaText}</span>
+				<span class="px-2 py-0.5 bg-white/20 rounded text-xs">CTA</span>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Sections Preview -->
+	<div class="preview-content">
+		{#each sectionOrder as { key: sectionKey } (sectionKey)}
+			{#if sectionKey === 'experience' && shouldShowSection('experience')}
+				<div class="preview-section">
+					<ExperienceSection
+						items={getSectionData('experience')}
+						layout={getSectionLayout('experience')}
+					/>
+				</div>
+			{:else if sectionKey === 'projects' && shouldShowSection('projects')}
+				<div class="preview-section">
+					<ProjectsSection
+						items={getSectionData('projects')}
+						layout={getSectionLayout('projects')}
+					/>
+				</div>
+			{:else if sectionKey === 'education' && shouldShowSection('education')}
+				<div class="preview-section">
+					<EducationSection
+						items={getSectionData('education')}
+						layout={getSectionLayout('education')}
+					/>
+				</div>
+			{:else if sectionKey === 'certifications' && shouldShowSection('certifications')}
+				<div class="preview-section">
+					<CertificationsSection
+						items={getSectionData('certifications')}
+						layout={getSectionLayout('certifications')}
+					/>
+				</div>
+			{:else if sectionKey === 'skills' && shouldShowSection('skills')}
+				<div class="preview-section">
+					<SkillsSection
+						items={getSectionData('skills')}
+						layout={getSectionLayout('skills')}
+					/>
+				</div>
+			{:else if sectionKey === 'posts' && shouldShowSection('posts')}
+				<div class="preview-section">
+					<PostsSection
+						items={getSectionData('posts')}
+						layout={getSectionLayout('posts')}
+					/>
+				</div>
+			{:else if sectionKey === 'talks' && shouldShowSection('talks')}
+				<div class="preview-section">
+					<TalksSection
+						items={getSectionData('talks')}
+						layout={getSectionLayout('talks')}
+					/>
+				</div>
+			{/if}
+		{/each}
+
+		{#if sectionOrder.filter(s => shouldShowSection(s.key)).length === 0}
+			<div class="flex flex-col items-center justify-center py-12 text-gray-400">
+				<svg class="w-12 h-12 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+				</svg>
+				<span class="text-sm">No sections enabled</span>
+				<span class="text-xs mt-1">Enable sections in the editor</span>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.preview-container {
+		background: var(--color-bg-primary, white);
+		border-radius: 0.5rem;
+		overflow: hidden;
+		box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+		max-height: calc(100vh - 200px);
+		overflow-y: auto;
+	}
+
+	:global(.dark) .preview-container {
+		background: rgb(17 24 39);
+	}
+
+	/* Scale down the hero for preview */
+	.preview-hero {
+		transform-origin: top left;
+	}
+
+	.preview-hero :global(header) {
+		padding-top: 2rem;
+		padding-bottom: 2rem;
+	}
+
+	.preview-hero :global(.py-16) {
+		padding-top: 2rem;
+		padding-bottom: 2rem;
+	}
+
+	.preview-hero :global(.sm\:py-24) {
+		padding-top: 2rem;
+		padding-bottom: 2rem;
+	}
+
+	.preview-hero :global(h1) {
+		font-size: 1.5rem;
+		line-height: 1.2;
+	}
+
+	.preview-hero :global(.sm\:text-4xl),
+	.preview-hero :global(.lg\:text-5xl) {
+		font-size: 1.5rem;
+	}
+
+	.preview-hero :global(.text-xl),
+	.preview-hero :global(.sm\:text-2xl) {
+		font-size: 1rem;
+	}
+
+	.preview-hero :global(.w-32),
+	.preview-hero :global(.sm\:w-40) {
+		width: 4rem;
+		height: 4rem;
+	}
+
+	.preview-hero :global(.h-32),
+	.preview-hero :global(.sm\:h-40) {
+		width: 4rem;
+		height: 4rem;
+	}
+
+	.preview-hero :global(.prose) {
+		font-size: 0.875rem;
+	}
+
+	.preview-hero-placeholder {
+		background: linear-gradient(to bottom right, rgb(17 24 39), rgb(31 41 55));
+		color: rgb(156 163 175);
+	}
+
+	.preview-content {
+		padding: 1rem;
+	}
+
+	/* Scale down sections for preview */
+	.preview-section {
+		margin-bottom: 1rem;
+	}
+
+	.preview-section :global(section) {
+		margin-bottom: 0;
+	}
+
+	.preview-section :global(.section-title) {
+		font-size: 1rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.preview-section :global(.card) {
+		padding: 0.75rem;
+	}
+
+	.preview-section :global(h3) {
+		font-size: 0.875rem;
+	}
+
+	.preview-section :global(p),
+	.preview-section :global(span),
+	.preview-section :global(li) {
+		font-size: 0.75rem;
+	}
+
+	.preview-section :global(.space-y-8) {
+		gap: 0.75rem;
+	}
+
+	.preview-section :global(.gap-4) {
+		gap: 0.5rem;
+	}
+
+	.preview-section :global(.gap-6) {
+		gap: 0.5rem;
+	}
+
+	/* Grid layouts */
+	.preview-section :global(.grid-cols-3) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.preview-section :global(.grid-cols-2) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+</style>

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -2,11 +2,12 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import { pb, type View, type ViewSection, type ItemConfig, OVERRIDABLE_FIELDS, VALID_LAYOUTS } from '$lib/pocketbase';
+	import { pb, type View, type ViewSection, type ItemConfig, type Profile, OVERRIDABLE_FIELDS, VALID_LAYOUTS } from '$lib/pocketbase';
 	import { toasts } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import { dndzone, TRIGGERS, SHADOW_PLACEHOLDER_ITEM_ID } from 'svelte-dnd-action';
 	import { flip } from 'svelte/animate';
+	import ViewPreview from '$components/admin/ViewPreview.svelte';
 
 	// Default section definitions - used to initialize and provide labels
 	const SECTION_DEFS: Record<string, { label: string; collection: string }> = {
@@ -25,6 +26,12 @@
 	let loading = true;
 	let saving = false;
 	let view: View | null = null;
+
+	// Profile data for preview
+	let profile: Profile | null = null;
+
+	// Preview panel state
+	let showPreview = true;
 
 	// Form fields
 	let name = '';
@@ -79,9 +86,31 @@
 			goto('/admin/views');
 			return;
 		}
-		await loadView();
-		await loadSectionItems();
+		await Promise.all([
+			loadView(),
+			loadSectionItems(),
+			loadProfile()
+		]);
 	});
+
+	async function loadProfile() {
+		try {
+			const records = await pb.collection('profile').getList(1, 1);
+			if (records.items.length > 0) {
+				const record = records.items[0] as unknown as Profile & { collectionId: string };
+				// Resolve avatar URL if exists
+				if (record.avatar) {
+					const avatarUrl = `/api/files/${record.collectionId}/${record.id}/${record.avatar}`;
+					profile = { ...record, avatar: avatarUrl };
+				} else {
+					profile = record;
+				}
+			}
+		} catch (err) {
+			console.error('Failed to load profile:', err);
+			// Profile is optional for preview, don't show error
+		}
+	}
 
 	async function loadView() {
 		if (!viewId) return;
@@ -435,24 +464,42 @@
 	<title>Edit View | Me.yaml</title>
 </svelte:head>
 
-<div class="max-w-4xl mx-auto">
+<div class="view-editor-container">
 	{#if loading}
-		<div class="card p-8 text-center">
+		<div class="card p-8 text-center max-w-4xl mx-auto">
 			<div class="animate-pulse">Loading view...</div>
 		</div>
 	{:else}
-		<div class="flex items-center justify-between mb-6">
+		<!-- Header -->
+		<div class="flex items-center justify-between mb-6 px-4">
 			<div class="flex items-center gap-4">
 				<a href="/admin/views" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
 					</svg>
 				</a>
 				<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Edit View</h1>
 			</div>
 			<div class="flex items-center gap-2">
+				<!-- Preview Toggle -->
+				<button
+					type="button"
+					class="btn btn-ghost flex items-center gap-2"
+					on:click={() => showPreview = !showPreview}
+					title={showPreview ? 'Hide preview' : 'Show preview'}
+				>
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+						{#if showPreview}
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+						{:else}
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+						{/if}
+					</svg>
+					<span class="hidden sm:inline">{showPreview ? 'Hide' : 'Show'} Preview</span>
+				</button>
 				<button type="button" class="btn btn-secondary" on:click={previewView}>
-					Preview
+					Open in Tab
 				</button>
 				<button type="button" class="btn btn-primary" on:click={handleSubmit} disabled={saving}>
 					{#if saving}
@@ -461,11 +508,15 @@
 							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
 						</svg>
 					{/if}
-					Save Changes
+					Save
 				</button>
 			</div>
 		</div>
 
+		<!-- Split Pane Layout -->
+		<div class="editor-layout" class:with-preview={showPreview}>
+			<!-- Editor Pane -->
+			<div class="editor-pane">
 		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
 			<!-- Basic Info -->
 			<div class="card p-6 space-y-4">
@@ -800,6 +851,30 @@
 			</div>
 
 		</form>
+			</div>
+
+			<!-- Preview Pane -->
+			{#if showPreview}
+				<div class="preview-pane">
+					<div class="sticky top-4">
+						<div class="flex items-center justify-between mb-3 px-1">
+							<h2 class="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">Live Preview</h2>
+							<span class="text-xs text-gray-400">Updates as you edit</span>
+						</div>
+						<ViewPreview
+							{profile}
+							{heroHeadline}
+							{heroSummary}
+							{ctaText}
+							{ctaUrl}
+							{sections}
+							{sectionOrder}
+							{sectionItems}
+						/>
+					</div>
+				</div>
+			{/if}
+		</div>
 	{/if}
 </div>
 
@@ -901,3 +976,62 @@
 		</div>
 	</div>
 {/if}
+
+<style>
+	.view-editor-container {
+		max-width: 100%;
+		padding: 0 1rem;
+	}
+
+	.editor-layout {
+		display: flex;
+		gap: 1.5rem;
+		align-items: flex-start;
+	}
+
+	.editor-pane {
+		flex: 1;
+		min-width: 0;
+		max-width: 48rem; /* max-w-3xl */
+	}
+
+	.editor-layout.with-preview .editor-pane {
+		flex: 3;
+		max-width: none;
+	}
+
+	.preview-pane {
+		flex: 2;
+		min-width: 320px;
+		max-width: 480px;
+	}
+
+	/* Hide preview on smaller screens */
+	@media (max-width: 1024px) {
+		.editor-layout {
+			flex-direction: column;
+		}
+
+		.editor-pane {
+			max-width: 100%;
+		}
+
+		.preview-pane {
+			width: 100%;
+			max-width: 100%;
+			order: -1; /* Show preview above editor on mobile */
+			margin-bottom: 1rem;
+		}
+	}
+
+	/* Large screens - show side by side */
+	@media (min-width: 1280px) {
+		.view-editor-container {
+			padding: 0 2rem;
+		}
+
+		.preview-pane {
+			max-width: 560px;
+		}
+	}
+</style>

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { pb, type ViewSection, VALID_LAYOUTS } from '$lib/pocketbase';
+	import { pb, type ViewSection, type Profile, VALID_LAYOUTS } from '$lib/pocketbase';
 	import { toasts } from '$lib/stores';
 	import { dndzone } from 'svelte-dnd-action';
 	import { flip } from 'svelte/animate';
+	import ViewPreview from '$components/admin/ViewPreview.svelte';
 
 	// Default section definitions - used to initialize and provide labels
 	const SECTION_DEFS: Record<string, { label: string; collection: string }> = {
@@ -23,6 +24,12 @@
 	let loading = true;
 	let saving = false;
 
+	// Profile data for preview
+	let profile: Profile | null = null;
+
+	// Preview panel state
+	let showPreview = true;
+
 	// Form fields
 	let name = '';
 	let slug = '';
@@ -35,28 +42,54 @@
 	let isActive = true;
 	let isDefault = false;
 
-	// Sections configuration with layout support
-	let sections: Record<string, { enabled: boolean; items: string[]; expanded: boolean; layout: string }> = {};
+	// Sections configuration with layout support (itemConfig empty for new views)
+	let sections: Record<string, { enabled: boolean; items: string[]; expanded: boolean; layout: string; itemConfig: Record<string, { overrides?: Record<string, string | string[]> }> }> = {};
 
 	// Section order for drag-drop
 	let sectionOrder: Array<{ id: string; key: string }> = [];
 	const flipDurationMs = 200;
 
-	// Available items for each section
-	let sectionItems: Record<string, Array<{ id: string; label: string; visibility: string; is_draft?: boolean }>> = {};
+	// Available items for each section (with full data for preview)
+	let sectionItems: Record<string, Array<{
+		id: string;
+		label: string;
+		visibility: string;
+		is_draft?: boolean;
+		data: Record<string, unknown>;
+	}>> = {};
 
 	// Simple pattern - admin layout handles auth
 	onMount(async () => {
 		initializeSections();
-		await loadSectionItems();
+		await Promise.all([
+			loadSectionItems(),
+			loadProfile()
+		]);
 		loading = false;
 	});
+
+	async function loadProfile() {
+		try {
+			const records = await pb.collection('profile').getList(1, 1);
+			if (records.items.length > 0) {
+				const record = records.items[0] as unknown as Profile & { collectionId: string };
+				if (record.avatar) {
+					const avatarUrl = `/api/files/${record.collectionId}/${record.id}/${record.avatar}`;
+					profile = { ...record, avatar: avatarUrl };
+				} else {
+					profile = record;
+				}
+			}
+		} catch (err) {
+			console.error('Failed to load profile:', err);
+		}
+	}
 
 	function initializeSections() {
 		// Start with all sections enabled by default for new views, with default layout
 		for (const key of DEFAULT_SECTION_ORDER) {
 			const defaultLayout = VALID_LAYOUTS[key]?.default || 'default';
-			sections[key] = { enabled: true, items: [], expanded: false, layout: defaultLayout };
+			sections[key] = { enabled: true, items: [], expanded: false, layout: defaultLayout, itemConfig: {} };
 		}
 		// Initialize section order
 		sectionOrder = DEFAULT_SECTION_ORDER.map(key => ({ id: `section-${key}`, key }));
@@ -74,7 +107,8 @@
 					id: item.id,
 					label: getItemLabel(key, item),
 					visibility: (item as Record<string, unknown>).visibility as string || 'public',
-					is_draft: (item as Record<string, unknown>).is_draft as boolean || false
+					is_draft: (item as Record<string, unknown>).is_draft as boolean || false,
+					data: item as Record<string, unknown>
 				}));
 			} catch (err) {
 				console.error(`Failed to load ${key} items:`, err);
@@ -156,12 +190,12 @@
 	}
 
 	// Drag-drop handlers for item reordering within a section
-	function handleItemDndConsider(sectionKey: string, e: CustomEvent<{ items: Array<{ id: string; label: string; visibility: string; is_draft?: boolean }> }>) {
+	function handleItemDndConsider(sectionKey: string, e: CustomEvent<{ items: Array<{ id: string; label: string; visibility: string; is_draft?: boolean; data: Record<string, unknown> }> }>) {
 		sectionItems[sectionKey] = e.detail.items;
 		updateItemsOrderFromDisplay(sectionKey);
 	}
 
-	function handleItemDndFinalize(sectionKey: string, e: CustomEvent<{ items: Array<{ id: string; label: string; visibility: string; is_draft?: boolean }> }>) {
+	function handleItemDndFinalize(sectionKey: string, e: CustomEvent<{ items: Array<{ id: string; label: string; visibility: string; is_draft?: boolean; data: Record<string, unknown> }> }>) {
 		sectionItems[sectionKey] = e.detail.items;
 		updateItemsOrderFromDisplay(sectionKey);
 	}
@@ -253,32 +287,56 @@
 	<title>Create View | Me.yaml</title>
 </svelte:head>
 
-<div class="max-w-4xl mx-auto">
+<div class="view-editor-container">
 	{#if loading}
-		<div class="card p-8 text-center">
+		<div class="card p-8 text-center max-w-4xl mx-auto">
 			<div class="animate-pulse">Loading...</div>
 		</div>
 	{:else}
-		<div class="flex items-center justify-between mb-6">
+		<!-- Header -->
+		<div class="flex items-center justify-between mb-6 px-4">
 			<div class="flex items-center gap-4">
 				<a href="/admin/views" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
 					</svg>
 				</a>
 				<h1 class="text-2xl font-bold text-gray-900 dark:text-white">Create View</h1>
 			</div>
-			<button type="button" class="btn btn-primary" on:click={handleSubmit} disabled={saving}>
-				{#if saving}
-					<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
-						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+			<div class="flex items-center gap-2">
+				<!-- Preview Toggle -->
+				<button
+					type="button"
+					class="btn btn-ghost flex items-center gap-2"
+					on:click={() => showPreview = !showPreview}
+					title={showPreview ? 'Hide preview' : 'Show preview'}
+				>
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+						{#if showPreview}
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+						{:else}
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+						{/if}
 					</svg>
-				{/if}
-				Create View
-			</button>
+					<span class="hidden sm:inline">{showPreview ? 'Hide' : 'Show'} Preview</span>
+				</button>
+				<button type="button" class="btn btn-primary" on:click={handleSubmit} disabled={saving}>
+					{#if saving}
+						<svg class="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+							<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+							<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+						</svg>
+					{/if}
+					Create View
+				</button>
+			</div>
 		</div>
 
+		<!-- Split Pane Layout -->
+		<div class="editor-layout" class:with-preview={showPreview}>
+			<!-- Editor Pane -->
+			<div class="editor-pane">
 		<form on:submit|preventDefault={handleSubmit} class="space-y-6">
 			<!-- Basic Info -->
 			<div class="card p-6 space-y-4">
@@ -595,5 +653,86 @@
 			</div>
 
 			</form>
+			</div>
+
+			<!-- Preview Pane -->
+			{#if showPreview}
+				<div class="preview-pane">
+					<div class="sticky top-4">
+						<div class="flex items-center justify-between mb-3 px-1">
+							<h2 class="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">Live Preview</h2>
+							<span class="text-xs text-gray-400">Updates as you edit</span>
+						</div>
+						<ViewPreview
+							{profile}
+							{heroHeadline}
+							{heroSummary}
+							{ctaText}
+							{ctaUrl}
+							{sections}
+							{sectionOrder}
+							{sectionItems}
+						/>
+					</div>
+				</div>
+			{/if}
+		</div>
 	{/if}
 </div>
+
+<style>
+	.view-editor-container {
+		max-width: 100%;
+		padding: 0 1rem;
+	}
+
+	.editor-layout {
+		display: flex;
+		gap: 1.5rem;
+		align-items: flex-start;
+	}
+
+	.editor-pane {
+		flex: 1;
+		min-width: 0;
+		max-width: 48rem;
+	}
+
+	.editor-layout.with-preview .editor-pane {
+		flex: 3;
+		max-width: none;
+	}
+
+	.preview-pane {
+		flex: 2;
+		min-width: 320px;
+		max-width: 480px;
+	}
+
+	@media (max-width: 1024px) {
+		.editor-layout {
+			flex-direction: column;
+		}
+
+		.editor-pane {
+			max-width: 100%;
+		}
+
+		.preview-pane {
+			width: 100%;
+			max-width: 100%;
+			order: -1;
+			margin-bottom: 1rem;
+		}
+	}
+
+	@media (min-width: 1280px) {
+		.view-editor-container {
+			padding: 0 2rem;
+		}
+
+		.preview-pane {
+			max-width: 560px;
+		}
+	}
+</style>


### PR DESCRIPTION
Add side-by-side live preview in the view editor for immediate visual feedback when customizing views.

Features:
- Split-pane layout: editor (~60%) and preview (~40%)
- Preview updates reactively on any editor change
- Toggle button to hide/show preview for more editor space
- Responsive layout: side-by-side on desktop, stacked on mobile
- Profile data and hero overrides shown in preview
- CTA banner displayed when configured
- Section layouts applied in real-time
- Item-level overrides reflected in preview

Implementation:
- New ViewPreview.svelte component reuses public section components
- Preview filters items and applies overrides from editor state
- CSS scales down components for compact preview display
- Added to both view editor (/admin/views/[id]) and create (/admin/views/new)

Closes Phase 6.2 from ROADMAP.md