### PR TITLE
docs: Add seed mode documentation and make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Me.yaml Makefile
 # Common commands for development and deployment
 
-.PHONY: help dev dev-up dev-down dev-logs dev-reset build test clean docker-build docker-run
+.PHONY: help dev dev-up dev-down dev-logs dev-reset build test clean docker-build docker-run seed-demo seed-dev seed-clear
 
 # Default target
 help:
@@ -13,6 +13,11 @@ help:
 	@echo "  make dev-down     Stop Docker Compose services"
 	@echo "  make dev-logs     View Docker Compose logs"
 	@echo "  make dev-reset    Clear caches and force reinstall"
+	@echo ""
+	@echo "Seed Data (switch demo profiles):"
+	@echo "  make seed-demo    Reset & start with Merlin (fun wizard demo)"
+	@echo "  make seed-dev     Reset & start with Jedidiah (real-world dev)"
+	@echo "  make seed-clear   Clear database only (no restart)"
 	@echo ""
 	@echo "Individual Services:"
 	@echo "  make backend      Start backend only (with hot reload)"
@@ -64,6 +69,27 @@ dev-reset:
 	rm -rf tmp
 	rm -rf frontend/.svelte-kit
 	@echo "Caches cleared. Run 'make dev' to reinstall."
+
+# =============================================================================
+# Seed Data Switching
+# =============================================================================
+
+# Switch to demo profile (Merlin Ambrosius - fun Arthurian wizard)
+seed-demo:
+	@echo "Switching to demo seed (Merlin Ambrosius)..."
+	rm -rf pb_data
+	SEED_DATA=demo ./scripts/start-dev.sh
+
+# Switch to dev profile (Jedidiah Esposito - real-world example)
+seed-dev:
+	@echo "Switching to dev seed (Jedidiah Esposito)..."
+	rm -rf pb_data
+	SEED_DATA=dev ./scripts/start-dev.sh
+
+# Just clear database (no restart)
+seed-clear:
+	rm -rf pb_data
+	@echo "Database cleared. Run 'make dev', 'make seed-demo', or 'make seed-dev' to restart."
 
 # =============================================================================
 # Building

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ One port exposed. One volume to backup.
 | `ADMIN_EMAILS` | No | - | Comma-separated allowlist |
 | `ADMIN_ENABLED` | No | `false` | Enable PocketBase admin at `/_/` |
 | `DATA_PATH` | No | `./data` | Database and uploads |
+| `SEED_DATA` | No | - | Seed mode: `demo` (fun demo), `dev` (test data) |
 
 ### Unraid + Cloudflare Tunnel
 
@@ -178,6 +179,23 @@ Development uses separate ports for hot reload:
 - API calls proxy to backend automatically
 
 Production uses single port 8080 for everything.
+
+### Demo Data
+
+Me.yaml includes two seed profiles for development:
+
+| Command | Profile |
+|---------|---------|
+| `make seed-demo` | Merlin Ambrosius (fun Arthurian wizard) |
+| `make seed-dev` | Jedidiah Esposito (real-world example) |
+
+Switch between them anytime:
+```bash
+make seed-demo  # Reset & start with wizard demo
+make seed-dev   # Reset & start with real-world profile
+```
+
+See [docs/DEV.md](docs/DEV.md#seed-data-modes) for full details.
 
 ### Default Credentials (Development Only)
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -379,9 +379,67 @@ Key variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ENCRYPTION_KEY` | (required in prod) | AES-256-GCM key for AI tokens |
-| `SEED_DATA` | `true` in dev | Load demo data on startup |
+| `SEED_DATA` | — | Seed mode: `demo`, `dev`, or unset (see below) |
 | `DATA_DIR` | `./pb_data` | PocketBase data directory |
 | `LOG_LEVEL` | `info` | Logging verbosity |
+
+## Seed Data Modes
+
+Me.yaml supports two seed data profiles for development and demonstration:
+
+| `SEED_DATA` Value | Profile | Use Case |
+|-------------------|---------|----------|
+| `demo` or `true` | **Merlin Ambrosius** | Fun Arthurian-themed demo for new users |
+| `dev` | **Jedidiah Esposito** | Real development/testing data |
+| (unset) | None | Production—no seeding |
+
+### Demo Profile (Merlin Ambrosius)
+
+A whimsical Arthurian-themed profile demonstrating all features:
+
+- **Role**: Chief Wizard & Staff Engineer at Court of Camelot
+- **Projects**: The Round Table (distributed consensus), Excalibur Auth (stone-based 2FA), Crystal Ball Observability
+- **Skills**: Prophecy, Transmutation, Distributed Systems, Python (familiar)
+- **View**: `/kingdoms` with "Send Raven" CTA
+
+### Development Profile (Jedidiah Esposito)
+
+Real-world profile for development and testing:
+
+- **Role**: Front-End Lead | Product Engineering Lead
+- **Experience**: NZ Police, Ryman Healthcare, Okta, Amazon, ChefSteps
+- **Projects**: Me.yaml, MCP Servers, Voice Assistant, Home Infrastructure
+- **Skills**: SvelteKit, TypeScript, MCP, LLMs, Agile
+- **View**: `/front-end-lead` with LinkedIn CTA
+
+### Switching Between Seed Modes
+
+Seed data only loads when the database is empty. Use make targets to switch:
+
+```bash
+# Switch to Demo (Merlin Ambrosius - fun wizard)
+make seed-demo
+
+# Switch to Dev (Jedidiah Esposito - real-world)
+make seed-dev
+
+# Just clear database (no restart)
+make seed-clear
+```
+
+These commands clear the database and restart with the selected profile.
+
+### Manual Switching (alternative)
+
+If you prefer manual control:
+
+```bash
+# Clear and restart with specific seed
+rm -rf pb_data && SEED_DATA=demo make dev
+rm -rf pb_data && SEED_DATA=dev make dev
+```
+
+**Note:** Switching modes clears all database data. Export any work you want to keep first.
 
 ## Architecture Overview
 


### PR DESCRIPTION
Added easy-to-use make targets for switching between seed profiles:
- `make seed-demo` - Reset & start with Merlin Ambrosius
- `make seed-dev` - Reset & start with Jedidiah Esposito
- `make seed-clear` - Clear database only

Documentation updates:
- README.md: Added Demo Data section with make commands
- README.md: Added SEED_DATA to configuration table
- docs/DEV.md: New "Seed Data Modes" section with full details
- Makefile: Updated help output with seed commands