### PR TITLE
feat: Move demo data to admin UI toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Me.yaml Makefile
 # Common commands for development and deployment
 
-.PHONY: help dev dev-up dev-down dev-logs dev-reset build test clean docker-build docker-run seed-demo seed-dev seed-clear kill stop
+.PHONY: help dev dev-up dev-down dev-logs dev-reset build test clean docker-build docker-run seed-dev seed-clear kill stop
 
 # Default target
 help:
@@ -14,9 +14,8 @@ help:
 	@echo "  make dev-logs     View Docker Compose logs"
 	@echo "  make dev-reset    Clear caches and force reinstall"
 	@echo ""
-	@echo "Seed Data (switch demo profiles):"
-	@echo "  make seed-demo    Stop, reset & start with Merlin (wizard demo)"
-	@echo "  make seed-dev     Stop, reset & start with Jedidiah (real-world)"
+	@echo "Seed Data (development only):"
+	@echo "  make seed-dev     Stop, reset & start with dev data (Jedidiah)"
 	@echo "  make seed-clear   Stop & clear database (no restart)"
 	@echo "  make stop         Stop all running dev processes"
 	@echo ""
@@ -92,13 +91,8 @@ kill:
 
 stop: kill
 
-# Switch to demo profile (Merlin Ambrosius - fun Arthurian wizard)
-seed-demo: kill
-	@echo "Switching to demo seed (Merlin Ambrosius)..."
-	rm -rf pb_data
-	SEED_DATA=demo ./scripts/start-dev.sh
-
-# Switch to dev profile (Jedidiah Esposito - real-world example)
+# Switch to dev profile (Jedidiah Esposito - for development/testing)
+# Demo data (Merlin) is available via Admin > Settings > Demo Data
 seed-dev: kill
 	@echo "Switching to dev seed (Jedidiah Esposito)..."
 	rm -rf pb_data

--- a/README.md
+++ b/README.md
@@ -182,20 +182,12 @@ Production uses single port 8080 for everything.
 
 ### Demo Data
 
-Me.yaml includes two seed profiles for development:
+For development, use `make seed-dev` to load test profile data.
 
-| Command | Profile |
-|---------|---------|
-| `make seed-demo` | Merlin Ambrosius (fun Arthurian wizard) |
-| `make seed-dev` | Jedidiah Esposito (real-world example) |
+New users can load demo data via **Admin > Settings > Demo Data** to see what a
+complete profile looks like (Merlin Ambrosius, a fun Arthurian-themed wizard profile).
 
-Switch between them anytime:
-```bash
-make seed-demo  # Reset & start with wizard demo
-make seed-dev   # Reset & start with real-world profile
-```
-
-See [docs/DEV.md](docs/DEV.md#seed-data-modes) for full details.
+See [docs/DEV.md](docs/DEV.md#seed-data) for details.
 
 ### Default Credentials (Development Only)
 

--- a/backend/hooks/admin.go
+++ b/backend/hooks/admin.go
@@ -1,0 +1,70 @@
+package hooks
+
+import (
+	"net/http"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// RegisterAdminHooks registers admin-only API endpoints
+func RegisterAdminHooks(app *pocketbase.PocketBase) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		// Load demo data (Merlin Ambrosius)
+		// POST /api/admin/demo/load
+		se.Router.POST("/api/admin/demo/load", func(e *core.RequestEvent) error {
+			// Check if profile data already exists
+			count, _ := app.CountRecords("profile")
+			if count > 0 {
+				return e.JSON(http.StatusBadRequest, map[string]string{
+					"error": "Profile data already exists. Clear data first.",
+				})
+			}
+
+			// Seed demo data
+			if err := SeedDemoData(app); err != nil {
+				return e.JSON(http.StatusInternalServerError, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			return e.JSON(http.StatusOK, map[string]interface{}{
+				"success": true,
+				"message": "Demo data loaded (Merlin Ambrosius)",
+			})
+		}).Bind(apis.RequireAuth())
+
+		// Clear all data
+		// POST /api/admin/demo/clear
+		se.Router.POST("/api/admin/demo/clear", func(e *core.RequestEvent) error {
+			if err := ClearAllData(app); err != nil {
+				return e.JSON(http.StatusInternalServerError, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			return e.JSON(http.StatusOK, map[string]interface{}{
+				"success": true,
+				"message": "All data cleared",
+			})
+		}).Bind(apis.RequireAuth())
+
+		// Check if profile has data (for UI state)
+		// GET /api/admin/demo/status
+		se.Router.GET("/api/admin/demo/status", func(e *core.RequestEvent) error {
+			profileCount, _ := app.CountRecords("profile")
+			experienceCount, _ := app.CountRecords("experience")
+			projectsCount, _ := app.CountRecords("projects")
+
+			return e.JSON(http.StatusOK, map[string]interface{}{
+				"has_data":    profileCount > 0,
+				"profile":     profileCount,
+				"experience":  experienceCount,
+				"projects":    projectsCount,
+			})
+		}).Bind(apis.RequireAuth())
+
+		return se.Next()
+	})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -49,6 +49,7 @@ func main() {
 	hooks.RegisterShareHooks(app, shareService, cryptoService, rateLimitService)
 	hooks.RegisterPasswordHooks(app, cryptoService, rateLimitService)
 	hooks.RegisterViewHooks(app, cryptoService, shareService, rateLimitService)
+	hooks.RegisterAdminHooks(app)
 	hooks.RegisterSeedHook(app)
 
 	// Note: Trusted proxy headers are handled by Caddy in the Docker setup.

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -383,28 +383,13 @@ Key variables:
 | `DATA_DIR` | `./pb_data` | PocketBase data directory |
 | `LOG_LEVEL` | `info` | Logging verbosity |
 
-## Seed Data Modes
+## Seed Data
 
-Me.yaml supports two seed data profiles for development and demonstration:
+Me.yaml has two ways to load sample data:
 
-| `SEED_DATA` Value | Profile | Use Case |
-|-------------------|---------|----------|
-| `demo` or `true` | **Merlin Ambrosius** | Fun Arthurian-themed demo for new users |
-| `dev` | **Jedidiah Esposito** | Real development/testing data |
-| (unset) | None | Production—no seeding |
+### Development Seed (Jedidiah Esposito)
 
-### Demo Profile (Merlin Ambrosius)
-
-A whimsical Arthurian-themed profile demonstrating all features:
-
-- **Role**: Chief Wizard & Staff Engineer at Court of Camelot
-- **Projects**: The Round Table (distributed consensus), Excalibur Auth (stone-based 2FA), Crystal Ball Observability
-- **Skills**: Prophecy, Transmutation, Distributed Systems, Python (familiar)
-- **View**: `/kingdoms` with "Send Raven" CTA
-
-### Development Profile (Jedidiah Esposito)
-
-Real-world profile for development and testing:
+For development and testing, use `make seed-dev` to load real-world profile data:
 
 - **Role**: Front-End Lead | Product Engineering Lead
 - **Experience**: NZ Police, Ryman Healthcare, Okta, Amazon, ChefSteps
@@ -412,34 +397,31 @@ Real-world profile for development and testing:
 - **Skills**: SvelteKit, TypeScript, MCP, LLMs, Agile
 - **View**: `/front-end-lead` with LinkedIn CTA
 
-### Switching Between Seed Modes
-
-Seed data only loads when the database is empty. Use make targets to switch:
-
 ```bash
-# Switch to Demo (Merlin Ambrosius - fun wizard)
-make seed-demo
-
-# Switch to Dev (Jedidiah Esposito - real-world)
+# Load dev seed data
 make seed-dev
 
 # Just clear database (no restart)
 make seed-clear
 ```
 
-These commands clear the database and restart with the selected profile.
+### Demo Data (Admin UI)
 
-### Manual Switching (alternative)
+New users can load demo data via **Admin > Settings > Demo Data**. This loads a fun
+Arthurian-themed profile (Merlin Ambrosius, Chief Wizard) to demonstrate all features.
 
-If you prefer manual control:
+The demo data can be loaded and cleared at any time from the admin settings page.
+This is useful for:
+- Seeing what a complete profile looks like
+- Testing views and layouts
+- Demonstrating the platform to others
 
-```bash
-# Clear and restart with specific seed
-rm -rf pb_data && SEED_DATA=demo make dev
-rm -rf pb_data && SEED_DATA=dev make dev
-```
+| `SEED_DATA` env | Behavior |
+|-----------------|----------|
+| `dev` | Auto-seeds Jedidiah Esposito profile (development) |
+| (unset) | No auto-seeding (production default) |
 
-**Note:** Switching modes clears all database data. Export any work you want to keep first.
+**Note:** The `SEED_DATA=demo` option has been removed. Demo data is now managed via the admin UI.
 
 ## Architecture Overview
 

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -9,6 +9,11 @@
 	let showAddForm = false;
 	let testing: string | null = null;
 
+	// Demo data state
+	let demoLoading = false;
+	let demoStatus = { has_data: false, profile: 0, experience: 0, projects: 0 };
+	$: hasData = demoStatus.has_data;
+
 	// New provider form
 	let newProvider = {
 		name: '',
@@ -30,8 +35,69 @@
 	$: newProvider.model = newProvider.model || defaultModels[newProvider.type] || '';
 
 	onMount(async () => {
-		await loadProviders();
+		await Promise.all([loadProviders(), loadDemoStatus()]);
 	});
+
+	async function loadDemoStatus() {
+		try {
+			const response = await fetch('/api/admin/demo/status', {
+				headers: { Authorization: pb.authStore.token }
+			});
+			if (response.ok) {
+				demoStatus = await response.json();
+			}
+		} catch (err) {
+			console.error('Failed to load demo status:', err);
+		}
+	}
+
+	async function handleLoadDemo() {
+		if (!confirm('This will load demo data (Merlin Ambrosius profile). Continue?')) return;
+
+		demoLoading = true;
+		try {
+			const response = await fetch('/api/admin/demo/load', {
+				method: 'POST',
+				headers: { Authorization: pb.authStore.token }
+			});
+			const result = await response.json();
+
+			if (response.ok) {
+				toasts.add('success', 'Demo data loaded! Refresh to see changes.');
+				await loadDemoStatus();
+			} else {
+				toasts.add('error', result.error || 'Failed to load demo data');
+			}
+		} catch (err) {
+			toasts.add('error', 'Failed to load demo data');
+		} finally {
+			demoLoading = false;
+		}
+	}
+
+	async function handleClearData() {
+		if (!confirm('This will delete ALL your profile data. This cannot be undone. Continue?')) return;
+
+		demoLoading = true;
+		try {
+			const response = await fetch('/api/admin/demo/clear', {
+				method: 'POST',
+				headers: { Authorization: pb.authStore.token }
+			});
+			const result = await response.json();
+
+			if (response.ok) {
+				toasts.add('success', 'All data cleared');
+				await loadDemoStatus();
+			} else {
+				toasts.add('error', result.error || 'Failed to clear data');
+			}
+		} catch (err) {
+			toasts.add('error', 'Failed to clear data');
+		} finally {
+			demoLoading = false;
+		}
+	}
 
 	async function loadProviders() {
 		try {
@@ -309,6 +375,47 @@
 					</div>
 				{/each}
 			</div>
+		{/if}
+	</div>
+
+	<!-- Demo Data Section -->
+	<div class="card p-6 mt-6">
+		<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Demo Data</h2>
+		<p class="text-gray-600 dark:text-gray-400 text-sm mb-4">
+			Load sample data to see what a complete profile looks like. This creates a fun Arthurian-themed
+			profile (Merlin Ambrosius, Chief Wizard) with experience, projects, skills, and more.
+		</p>
+
+		{#if demoLoading}
+			<div class="flex items-center gap-2 text-gray-500">
+				<svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+					<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+					<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+				</svg>
+				Loading...
+			</div>
+		{:else if hasData}
+			<div class="flex items-center gap-4">
+				<span class="text-sm text-gray-600 dark:text-gray-400">
+					Profile has data ({demoStatus.experience} experiences, {demoStatus.projects} projects)
+				</span>
+				<button
+					class="btn btn-danger-ghost btn-sm"
+					on:click={handleClearData}
+					disabled={demoLoading}
+				>
+					{@html icon('trash')}
+					Clear All Data
+				</button>
+			</div>
+		{:else}
+			<button
+				class="btn btn-secondary"
+				on:click={handleLoadDemo}
+				disabled={demoLoading}
+			>
+				Load Demo Data
+			</button>
 		{/if}
 	</div>
 


### PR DESCRIPTION
- Add admin-only API endpoints for demo data management:
  - POST /api/admin/demo/load - Load Merlin demo data
  - POST /api/admin/demo/clear - Clear all profile data
  - GET /api/admin/demo/status - Check data status
- Export SeedDemoData() and ClearAllData() for admin API
- Add Demo Data section to admin settings page with load/clear buttons
- Remove auto-seeding for demo mode (only dev mode auto-seeds)
- Update Makefile to only have seed-dev target
- Update documentation to reflect new demo data approach

Demo data is now managed via Admin > Settings > Demo Data instead of environment variables, making it easier for new users to see a complete profile example.