### PR TITLE
docs: Restructure README for end users and developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,133 +4,126 @@
 
 Own your profile. Structure your story. Share it on your terms.
 
-A self-hosted profile and portfolio. One container, one port, one volume.
+A self-hosted, privacy-respecting personal profile platform. Think LinkedIn profile, but you own everything: the data, the hosting, the rules.
 
 ---
 
-## What is this?
+## Why Me.yaml?
 
-Own your professional identity. Experience, projects, skills, and story stored as data you control.
+| Problem | Me.yaml Solution |
+|---------|------------------|
+| LinkedIn owns your professional identity | **You own everything** — data lives in SQLite you control |
+| One profile for all audiences | **Views** — curated versions for recruiters, clients, conferences |
+| No control over who sees what | **Privacy controls** — public, unlisted, or password-protected |
+| Can't import your work easily | **GitHub import** — pull in projects with one click |
+| Platform tracks everything | **Zero tracking** — no analytics, no engagement metrics |
 
-```
-+--------------------------------------------------+
-|                    Me.yaml                       |
-+--------------------------------------------------+
-|  Public Profile    |    Admin Dashboard         |
-|  ----------------  |    --------------------    |
-|  - Experience      |    - Edit everything       |
-|  - Projects        |    - Import from GitHub    |
-|  - Education       |    - Create Views          |
-|  - Skills          |    - Generate share links  |
-+--------------------------------------------------+
-```
+**One container. One port. One volume to backup.**
 
 ---
+
+## Quick Links
+
+| I want to... | Go here |
+|--------------|---------|
+| **Try it out** | [Quick Start](#quick-start) |
+| **Learn what it does** | [Features](#features) |
+| **Self-host it** | [Setup Guide](docs/SETUP.md) |
+| **Contribute or develop** | [Developer Guide](#for-developers) |
+| **Understand the architecture** | [Architecture](ARCHITECTURE.md) |
+| **Read the design philosophy** | [Design Document](DESIGN.md) |
+
+---
+
+# For Users
+
+Everything you need to run your own Me.yaml instance.
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/yourusername/me.yaml.git
+# Clone the repository
+git clone https://github.com/jesposito/me.yaml.git
 cd me.yaml
 
-# Generate encryption key
+# Generate encryption key (required)
 openssl rand -hex 32
 
 # Configure
 cp .env.example .env
-# Edit .env: set ENCRYPTION_KEY
+# Edit .env: add your ENCRYPTION_KEY
 
 # Run
 docker-compose up -d
 ```
 
-Visit `http://localhost:8080`
+Open `http://localhost:8080` — you're live.
 
 ### First Login
 
 | Environment | Email | Password |
 |-------------|-------|----------|
 | Development | `admin@example.com` | `changeme123` |
-| Production | Set via OAuth or `ADMIN_EMAILS` | — |
+| Production | Configure via OAuth | — |
 
-In development mode, a demo admin account is created automatically.
-**Change the password immediately** if deploying beyond localhost.
-
-OAuth (Google/GitHub) is the recommended authentication method for production.
+**Production recommendation:** Use OAuth (Google/GitHub) for admin access. See [Setup Guide](docs/SETUP.md) for configuration.
 
 ---
 
 ## Features
 
-### Available Now
+### Your Profile, Your Way
 
-**Public Profile**
-- Experience, projects, education, skills sections
-- Clean, fast, accessible pages
-- Responsive design
+- **Experience, projects, education, skills** — all the professional sections you'd expect
+- **Posts & talks** — share your writing and speaking engagements
+- **Certifications** — with expiry tracking and verification links
+- **Markdown everywhere** — rich content without a heavy editor
 
-**Views**
-- Create curated versions for different audiences
-- Override headline and summary per view
-- Show/hide sections
-- Visibility: public, unlisted, password-protected
+### Views: Different Faces for Different Audiences
 
-**Share Tokens**
-- Generate private links (`/s/abc123...`)
+Create tailored versions of your profile:
+
+- **Recruiter view** — emphasize employment history and skills
+- **Conference view** — highlight talks and projects
+- **Consulting view** — focus on case studies and expertise
+- **Personal view** — the stuff your friends care about
+
+Each view can:
+- Show/hide sections and specific items
+- Override your headline and summary
+- Include a custom call-to-action button
+- Have different visibility settings
+
+### Privacy Controls
+
+| Visibility | Who can access |
+|------------|----------------|
+| **Public** | Anyone |
+| **Unlisted** | Only people with a share link |
+| **Password** | Anyone who knows the password |
+| **Private** | Only you (admin) |
+
+### Share Links
+
+Generate private URLs for specific views:
 - Set expiration dates
 - Limit total uses
 - Revoke instantly
+- Clean URLs (token never visible in address bar)
 
-**GitHub Import**
-- Fetch repo metadata (description, languages, topics)
+### Import & Enrichment
+
+**GitHub Import:**
+- Fetch repository metadata, languages, and README
 - Preview before importing
-- Review changes field-by-field
 - Lock fields you've customized
+- Refresh anytime
 
-**AI Enrichment** (optional)
+**AI Enrichment (optional):**
 - OpenAI, Anthropic, or Ollama
-- Generates summaries from README
-- Never auto-publishes (you review first)
-- Keys encrypted at rest
-
-**Security**
-- Admin email allowlist
-- HMAC-secured share tokens
-- Single public port (8080)
-- PocketBase admin disabled by default
-
-### Planned
-
-- [ ] Scheduled GitHub sync
-- [ ] Me.yaml export/import
-- [ ] Theme customization
-- [ ] Resume PDF export
-
----
-
-## Architecture
-
-Single container with internal Caddy reverse proxy:
-
-```
-+--------------------------------------------+
-|              Docker Container              |
-|                                            |
-|   :8080 -> Caddy -+-> /api/*  -> PocketBase|
-|                   |                        |
-|                   +-> /*      -> SvelteKit |
-|                                            |
-|   Internal only:                           |
-|   - PocketBase :8090 (localhost)           |
-|   - SvelteKit  :3000 (localhost)           |
-|                                            |
-|   +------------------------------------+   |
-|   |   SQLite + Uploads (/data)         |   |
-|   +------------------------------------+   |
-+--------------------------------------------+
-```
-
-One port exposed. One volume to backup.
+- Generates summaries from READMEs
+- You review everything before publishing
+- Your API keys, encrypted at rest
 
 ---
 
@@ -138,89 +131,243 @@ One port exposed. One volume to backup.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ENCRYPTION_KEY` | Yes | - | 32-byte hex key (`openssl rand -hex 32`) |
+| `ENCRYPTION_KEY` | Yes | — | 32-byte hex key (`openssl rand -hex 32`) |
 | `PORT` | No | `8080` | Public port |
-| `APP_URL` | No | `http://localhost:8080` | Your public URL |
+| `APP_URL` | No | `http://localhost:8080` | Your public URL (for OAuth callbacks) |
 | `TRUST_PROXY` | No | `false` | Set `true` behind reverse proxy |
-| `ADMIN_EMAILS` | No | - | Comma-separated allowlist |
+| `ADMIN_EMAILS` | No | — | Comma-separated email allowlist for OAuth |
 | `ADMIN_ENABLED` | No | `false` | Enable PocketBase admin at `/_/` |
-| `DATA_PATH` | No | `./data` | Database and uploads |
-| `SEED_DATA` | No | - | Seed mode: `demo` (fun demo), `dev` (test data) |
+| `DATA_PATH` | No | `./data` | Database and uploads directory |
 
-### Unraid + Cloudflare Tunnel
-
-```env
-PORT=8080
-DATA_PATH=/mnt/user/appdata/me-yaml
-APP_URL=https://me.yourdomain.com
-TRUST_PROXY=true
-ADMIN_EMAILS=you@gmail.com
-ADMIN_ENABLED=false
-```
-
-Point Cloudflare Tunnel to `http://container-ip:8080`.
+For detailed setup instructions including OAuth, reverse proxy, and Unraid configuration, see the **[Setup Guide](docs/SETUP.md)**.
 
 ---
 
-## Development
+## Backup & Restore
 
-### Codespaces (One-Click)
-
-Open in GitHub Codespaces. Includes demo profile and admin account.
-
-### Local
+Everything lives in one directory:
 
 ```bash
-make dev
+# Backup
+docker-compose down
+tar -czvf backup.tar.gz ./data
+docker-compose up -d
+
+# Restore
+tar -xzvf backup.tar.gz
+docker-compose up -d
 ```
 
-Development uses separate ports for hot reload:
-- http://localhost:5173 (Vite dev server with HMR)
-- API calls proxy to backend automatically
+For upgrade procedures, see **[Upgrade Guide](docs/UPGRADE.md)**.
 
-Production uses single port 8080 for everything.
+---
 
-### Demo Data
+## Architecture Overview
 
-For development, use `make seed-dev` to load test profile data.
+```
++--------------------------------------------+
+|              Docker Container              |
+|                                            |
+|   :8080 -> Caddy -+-> /api/*  -> PocketBase|
+|                   +-> /*      -> SvelteKit |
+|                                            |
+|   +------------------------------------+   |
+|   |   SQLite + Uploads (/data)         |   |
++--------------------------------------------+
+```
 
-New users can load demo data via **Admin > Settings > Demo Data** to see what a
-complete profile looks like (Merlin Ambrosius, a fun Arthurian-themed wizard profile).
+- **Single port** exposed (8080)
+- **Single volume** to backup (`/data`)
+- **Caddy** routes requests internally
+- **PocketBase** handles API and auth
+- **SvelteKit** serves the frontend
 
-See [docs/DEV.md](docs/DEV.md#seed-data) for details.
+For complete technical details, see **[Architecture](ARCHITECTURE.md)**.
+
+---
+
+# For Developers
+
+Everything you need to contribute to Me.yaml.
+
+## Development Setup
+
+### Option 1: Codespaces (Fastest)
+
+1. Click "Open in Codespaces" from GitHub
+2. Wait for devcontainer to build (~2 min first time)
+3. Services start automatically
+4. Frontend: http://localhost:5173
+5. API: http://localhost:8090
+
+### Option 2: Local Development
+
+**Prerequisites:**
+- Go 1.23+
+- Node.js 20+
+- [Air](https://github.com/air-verse/air) for Go hot reload
+
+```bash
+# Install air
+go install github.com/air-verse/air@v1.61.7
+
+# Start everything with hot reload
+make dev
+
+# Or start services individually
+make backend   # Backend with air
+make frontend  # Frontend with Vite HMR
+```
+
+### Option 3: Docker Compose
+
+```bash
+make dev-docker   # Start development environment
+make dev-logs     # View logs
+make dev-down     # Stop
+```
+
+### Development Ports
+
+| Service | Port | URL |
+|---------|------|-----|
+| Frontend (Vite) | 5173 | http://localhost:5173 |
+| Backend API | 8090 | http://localhost:8090 |
+| PocketBase Admin | 8090 | http://localhost:8090/_/ |
 
 ### Default Credentials (Development Only)
 
-| Login | Email | Password |
+| Panel | Email | Password |
 |-------|-------|----------|
 | Me.yaml Admin | `admin@example.com` | `changeme123` |
 | PocketBase Admin | `admin@localhost.dev` | `admin123` |
 
-The PocketBase admin panel (`/_/`) is disabled by default in production.
-Set `ADMIN_ENABLED=true` only for debugging.
+For complete development documentation, see **[Development Guide](docs/DEV.md)**.
 
 ---
 
-## Backup
+## Project Structure
 
-```bash
-docker-compose down
-tar -czvf backup.tar.gz ./data
-docker-compose up -d
+```
+Me.yaml/
+├── backend/                 # Go + PocketBase
+│   ├── hooks/               # Custom event handlers
+│   ├── services/            # Business logic
+│   ├── migrations/          # Database schema
+│   └── main.go              # Entry point
+│
+├── frontend/                # SvelteKit + TypeScript
+│   ├── src/routes/          # Page routes
+│   ├── src/components/      # UI components
+│   └── src/lib/             # Shared utilities
+│
+├── docker/                  # Production Docker config
+├── scripts/                 # Development scripts
+└── docs/                    # Documentation
 ```
 
 ---
 
-## Documentation
+## Tech Stack
+
+**Backend:**
+- [PocketBase](https://pocketbase.io/) v0.23.4 — Go-based backend framework
+- SQLite — embedded database
+- AES-256-GCM — encryption for sensitive data
+
+**Frontend:**
+- [SvelteKit](https://kit.svelte.dev/) v2.0 — full-stack web framework
+- [Tailwind CSS](https://tailwindcss.com/) v3.4 — utility-first styling
+- TypeScript — type safety
+
+**Infrastructure:**
+- Docker — containerization
+- Caddy — internal reverse proxy
+- Multi-stage builds — optimized production images
+
+---
+
+## Common Tasks
+
+```bash
+make dev          # Start development environment
+make test         # Run all tests
+make build        # Build production Docker image
+make lint         # Run linters
+make fmt          # Format code
+make seed-dev     # Load development seed data
+make dev-reset    # Clear caches and restart
+```
+
+---
+
+## Seed Data
+
+**For development:** Use `make seed-dev` to load a real-world test profile.
+
+**For demos:** New users can load demo data via **Admin > Settings > Demo Data** (Merlin Ambrosius, a fun Arthurian-themed wizard profile).
+
+---
+
+## URL Routing
+
+| Route | Purpose |
+|-------|---------|
+| `/` | Default public view |
+| `/<slug>` | Named view (e.g., `/recruiter`) |
+| `/s/<token>` | Share link entry point |
+| `/projects/<slug>` | Project detail page |
+| `/posts/<slug>` | Blog post page |
+| `/admin/*` | Admin dashboard |
+
+---
+
+## Security Model
+
+- **AES-256-GCM** encryption for API keys and tokens
+- **HMAC-SHA256** share tokens (raw tokens never stored)
+- **JWT** for password-protected views
+- **Rate limiting** on sensitive endpoints
+- **Deny-by-default** collection access
+
+For complete security documentation, see **[Security Guide](docs/SECURITY.md)**.
+
+---
+
+# Documentation
 
 | Document | Description |
 |----------|-------------|
-| [README.md](README.md) | Quick start and overview (this file) |
-| [DESIGN.md](DESIGN.md) | Complete design document and architecture |
-| [ROADMAP.md](ROADMAP.md) | Feature roadmap and development phases |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture details |
-| [docs/DEV.md](docs/DEV.md) | Development setup and guidelines |
-| [docs/SECURITY.md](docs/SECURITY.md) | Security model and practices |
+| **[Setup Guide](docs/SETUP.md)** | Installation, OAuth, reverse proxy, Unraid |
+| **[Development Guide](docs/DEV.md)** | Local setup, project structure, troubleshooting |
+| **[Security Guide](docs/SECURITY.md)** | Encryption, auth flows, rate limiting |
+| **[Upgrade Guide](docs/UPGRADE.md)** | Upgrade and rollback procedures |
+| **[Architecture](ARCHITECTURE.md)** | Technical system design and data model |
+| **[Design Document](DESIGN.md)** | Vision, principles, and detailed specifications |
+| **[Roadmap](ROADMAP.md)** | Feature development phases |
+
+---
+
+## Roadmap Highlights
+
+**Complete:**
+- Core profile and content management
+- Views with custom ordering and overrides
+- Share token management
+- GitHub import with AI enrichment
+- Print-optimized CSS for resume export
+
+**In Progress:**
+- Per-section layout presets
+- Live preview in view editor
+
+**Planned:**
+- AI-powered PDF resume generation
+- Scheduled GitHub sync
+- Theme customization
+- Media library
+
+See **[Roadmap](ROADMAP.md)** for the full development plan.
 
 ---
 


### PR DESCRIPTION
Reorganize the README into clear sections:
- "For Users" with quick start, features, configuration, and backup
- "For Developers" with setup options, project structure, and common tasks
- Comprehensive documentation links table with all guides
- Why Me.yaml comparison table highlighting key value propositions
- Quick links section for easy navigation to relevant content
- Updated roadmap highlights showing current project status

All existing documentation files are now prominently linked:
- Setup Guide (docs/SETUP.md)
- Development Guide (docs/DEV.md)
- Security Guide (docs/SECURITY.md)
- Upgrade Guide (docs/UPGRADE.md)
- Architecture (ARCHITECTURE.md)
- Design Document (DESIGN.md)
- Roadmap (ROADMAP.md)