### PR TITLE
docs: Update documentation to match current codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,9 +28,10 @@
 │  │                     │    │                                      ││
 │  │  Public Pages:      │    │  Collections:                        ││
 │  │  ├── /              │◄───┤  ├── profile                         ││
-│  │  ├── /v/:slug       │    │  ├── experience                      ││
+│  │  ├── /:slug         │    │  ├── experience                      ││
 │  │  ├── /s/:token      │    │  ├── projects                        ││
-│  │  └── /p/:project    │    │  ├── education                       ││
+│  │  ├── /projects/:slug│    │  ├── education                       ││
+│  │  └── /posts/:slug   │    │                                      ││
 │  │                     │    │  ├── certifications                  ││
 │  │  Admin Pages:       │    │  ├── skills                          ││
 │  │  ├── /admin         │───►│  ├── posts                           ││
@@ -315,12 +316,12 @@ import_proposals {
 
 | Route | Description | Auth |
 |-------|-------------|------|
-| `GET /` | Main public profile | Based on profile.visibility |
-| `GET /v/:slug` | View by slug | Based on view.visibility |
-| `GET /s/:token` | Share token access | Token validation |
-| `GET /p/:slug` | Project detail page | Based on project.visibility |
-| `GET /post/:slug` | Blog post page | Based on post.visibility |
-| `POST /api/password-check` | Validate password for protected content | None |
+| `GET /` | Default public view | Based on view.visibility |
+| `GET /:slug` | Named view (canonical) | Based on view.visibility |
+| `GET /v/:slug` | Legacy view route | 301 redirect to `/:slug` |
+| `GET /s/:token` | Share token access | Token validation, redirects to `/:slug` |
+| `GET /projects/:slug` | Project detail page | Based on project.visibility |
+| `GET /posts/:slug` | Blog post page | Based on post.visibility |
 
 #### Admin Routes (SvelteKit)
 
@@ -336,12 +337,13 @@ import_proposals {
 | `GET /admin/posts` | Manage posts | OAuth required |
 | `GET /admin/talks` | Manage talks | OAuth required |
 | `GET /admin/views` | Manage views | OAuth required |
+| `GET /admin/views/new` | Create new view | OAuth required |
 | `GET /admin/views/:id` | Edit specific view | OAuth required |
-| `GET /admin/sources` | Manage import sources | OAuth required |
+| `GET /admin/tokens` | Manage share tokens | OAuth required |
 | `GET /admin/import` | GitHub import wizard | OAuth required |
 | `GET /admin/review/:id` | Review import proposal | OAuth required |
 | `GET /admin/settings` | AI providers, app settings | OAuth required |
-| `GET /admin/media` | Media library | OAuth required |
+| `GET /admin/login` | Admin login | None |
 
 #### API Routes (PocketBase + Custom Hooks)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -475,7 +475,8 @@ Me.yaml uses **LinkedIn-style canonical URLs**:
 These slugs cannot be used for views (enforced at frontend and backend):
 
 ```
-admin, api, s, v, _app, _, assets, static,
+admin, api, s, v, projects, posts, talks,
+_app, _, assets, static,
 favicon.ico, robots.txt, sitemap.xml,
 health, healthz, ready, login, logout,
 auth, oauth, callback, home, index, default, profile
@@ -1011,7 +1012,7 @@ These export features are planned for future phases:
 | `ADMIN_EMAILS` | No | — | Comma-separated admin allowlist |
 | `ADMIN_ENABLED` | No | `false` | Enable PocketBase admin UI |
 | `DATA_PATH` | No | `./data` | Database and uploads path |
-| `SEED_DATA` | No | `true` (dev) | Create demo data on start |
+| `SEED_DATA` | No | — | Seed mode: `dev` for dev profile, unset for none |
 | `LOG_LEVEL` | No | `info` | Logging verbosity |
 
 ---

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Me.yaml/
 ## Tech Stack
 
 **Backend:**
+- Go 1.23 — backend language
 - [PocketBase](https://pocketbase.io/) v0.23.4 — Go-based backend framework
 - SQLite — embedded database
 - AES-256-GCM — encryption for sensitive data

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
       # DEV ONLY: This key is for local development. Never use in production.
       # Production requires a unique key: openssl rand -hex 32
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-dev-only-key-do-not-use-in-production!!}
-      - SEED_DATA=true
+      - SEED_DATA=${SEED_DATA:-dev}  # 'dev' for dev profile, unset for no seeding
       - LOG_LEVEL=debug
     command: /app/scripts/dev-backend.sh
     healthcheck:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build Go backend
 # ============================================
-FROM golang:1.22-alpine AS backend-builder
+FROM golang:1.23-alpine AS backend-builder
 
 WORKDIR /build
 RUN apk add --no-cache gcc musl-dev

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -117,7 +117,8 @@ Only one view can be marked as default at a time (enforced by backend hook).
 These slugs are protected and cannot be used for views:
 
 ```
-admin, api, s, v, _app, _, assets, static,
+admin, api, s, v, projects, posts, talks,
+_app, _, assets, static,
 favicon.ico, robots.txt, sitemap.xml,
 health, healthz, ready,
 login, logout, auth, oauth, callback,
@@ -379,7 +380,7 @@ Key variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ENCRYPTION_KEY` | (required in prod) | AES-256-GCM key for AI tokens |
-| `SEED_DATA` | — | Seed mode: `demo`, `dev`, or unset (see below) |
+| `SEED_DATA` | — | Seed mode: `dev` for dev profile, unset for no seeding |
 | `DATA_DIR` | `./pb_data` | PocketBase data directory |
 | `LOG_LEVEL` | `info` | Logging verbosity |
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -58,7 +58,8 @@ Me.yaml uses LinkedIn-style canonical URLs:
 View slugs cannot collide with system routes. These are protected:
 
 ```
-admin, api, s, v, _app, _, assets, static,
+admin, api, s, v, projects, posts, talks,
+_app, _, assets, static,
 favicon.ico, robots.txt, sitemap.xml,
 health, healthz, ready, login, logout,
 auth, oauth, callback, home, index, default, profile

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -177,9 +177,9 @@ labels:
 
 ### "Connection refused" errors
 
-Check that PocketBase started:
+Check that the container started:
 ```bash
-docker-compose logs ownprofile
+docker-compose logs me-yaml
 ```
 
 ### OAuth redirects failing

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -91,7 +91,7 @@ PocketBase handles schema migrations automatically. When you upgrade:
 If you need to run migrations manually:
 
 ```bash
-docker-compose exec ownprofile ./ownprofile migrate up
+docker-compose exec me-yaml ./me-yaml migrate up
 ```
 
 ---


### PR DESCRIPTION
Version and configuration fixes:
- docker/Dockerfile: Update Go version from 1.22 to 1.23 to match go.mod
- docker-compose.dev.yml: Fix SEED_DATA value to use 'dev' instead of 'true'
- README.md: Add Go 1.23 to tech stack versions

Route documentation updates:
- ARCHITECTURE.md: Fix public routes (/p/:slug -> /projects/:slug, /post/:slug -> /posts/:slug), add /:slug canonical route, update admin routes to include /tokens, /views/new, /login
- All docs: Update reserved slugs list to include projects, posts, talks

Container name fixes:
- docs/SETUP.md: Change 'ownprofile' to 'me-yaml' in docker logs command
- docs/UPGRADE.md: Change 'ownprofile' to 'me-yaml' in migration command

Environment variable fixes:
- docs/DEV.md: Remove outdated 'demo' from SEED_DATA description
- DESIGN.md: Fix SEED_DATA description and default value