### PR TITLE
docs: Mark OAuth config via env vars as coming soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Open `http://localhost:8080` — you're live.
 | Environment | Email | Password |
 |-------------|-------|----------|
 | Development | `admin@example.com` | `changeme123` |
-| Production | Configure via OAuth | — |
+| Production | Your email in `ADMIN_EMAILS` | Your password |
 
-**Production recommendation:** Use OAuth (Google/GitHub) for admin access. See [Setup Guide](docs/SETUP.md) for configuration.
+**Coming soon:** OAuth login via environment variables. See [Setup Guide](docs/SETUP.md) for current options.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -703,10 +703,41 @@ Full drag-and-drop editing directly in the preview pane.
 These are ideas that may be explored after the core roadmap is complete:
 
 ### Self-Hosting Improvements
-- One-line install script
-- Docker Compose with Caddy reverse proxy
-- Kubernetes Helm chart
-- Unraid app template
+
+#### OAuth via Environment Variables (Priority)
+
+Enable OAuth configuration without accessing PocketBase admin UI:
+
+```env
+# Google OAuth
+GOOGLE_CLIENT_ID=your-client-id
+GOOGLE_CLIENT_SECRET=your-client-secret
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your-client-id
+GITHUB_CLIENT_SECRET=your-client-secret
+```
+
+**Implementation:**
+- [ ] Read OAuth credentials from environment variables on startup
+- [ ] Programmatically configure PocketBase auth providers
+- [ ] Add `/api/auth/providers` endpoint to expose enabled methods
+- [ ] Update login page to fetch available providers dynamically
+- [ ] Only show OAuth buttons for configured providers
+- [ ] Show password login as primary when no OAuth configured
+- [ ] Add to `.env.example` with documentation
+
+**Benefits:**
+- End users never need to access PocketBase admin UI
+- All configuration via environment variables / docker-compose
+- Enables Unraid template with OAuth fields
+- Clean "Me.yaml" branded experience throughout
+
+#### Distribution & Templates
+- [ ] One-line install script
+- [ ] Docker Compose with Caddy reverse proxy
+- [ ] Kubernetes Helm chart
+- [ ] Unraid Community Apps template
 
 ### Integrations
 - Webhook notifications
@@ -745,6 +776,7 @@ These are ideas that may be explored after the core roadmap is complete:
 | 2026-01-01 | Phase 2.2 drag-drop reordering complete | svelte-dnd-action integrated for section and item reordering; section order preserved in view config and respected in public rendering |
 | 2026-01-01 | Phase 6 redesigned as Visual Layout System | Phased approach: (A) per-section layout presets, (B) live preview, (C) section widths/columns, (D) WYSIWYG. Curated layouts prevent bad design; inspired by SharePoint but simpler. |
 | 2026-01-01 | Phase 4 redesigned as two-tier Export & Print | Simple Print (browser, works now) + AI Print (sends view to AI, returns optimized markdown, Pandoc converts to DOCX/PDF). Stored in view_exports collection. |
+| 2026-01-01 | OAuth config via env vars prioritized | End users should never see PocketBase; all config via environment variables. Login page should dynamically show only configured auth methods. Enables Unraid template distribution. |
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -5,7 +5,7 @@ This guide walks you through setting up Me.yaml for the first time.
 ## Prerequisites
 
 - Docker and Docker Compose
-- A domain (optional, but recommended for OAuth)
+- A domain (optional, recommended for production)
 - ~512MB RAM
 
 ## Quick Start
@@ -13,7 +13,7 @@ This guide walks you through setting up Me.yaml for the first time.
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/yourusername/me.yaml.git
+git clone https://github.com/jesposito/me.yaml.git
 cd me.yaml
 ```
 
@@ -28,6 +28,9 @@ Edit `.env` and set at minimum:
 ```env
 # Generate this with: openssl rand -hex 32
 ENCRYPTION_KEY=your-32-byte-hex-key-here
+
+# Your admin email (for login)
+ADMIN_EMAILS=you@example.com
 ```
 
 ### 3. Start the Container
@@ -36,64 +39,79 @@ ENCRYPTION_KEY=your-32-byte-hex-key-here
 docker-compose up -d
 ```
 
-### 4. Create Admin Account
+### 4. Access Me.yaml
 
-First, enable the PocketBase admin UI:
+- **Public profile**: `http://localhost:8080`
+- **Admin dashboard**: `http://localhost:8080/admin`
 
-```bash
-# Add to your .env
-ADMIN_ENABLED=true
-```
+### 5. First Login
 
-Then restart and access the setup:
+For development, a default admin account is created automatically:
 
-1. Open `http://localhost:8080/_/` in your browser
-2. You'll see the PocketBase installer
-3. Create your superuser account (this is your admin login)
+| Email | Password |
+|-------|----------|
+| `admin@example.com` | `changeme123` |
 
-After setup, you can disable the admin UI for security:
-```bash
-ADMIN_ENABLED=false
-```
-
-### 5. Configure OAuth (Recommended)
-
-For secure admin login, set up OAuth:
-
-1. Ensure `ADMIN_ENABLED=true` in your .env
-2. Go to `http://localhost:8080/_/` -> Settings -> Auth providers
-3. Enable Google and/or GitHub
-4. Enter your OAuth credentials (see below for how to get them)
-
-### 6. Access Your Profile
-
-- Public profile: `http://localhost:8080`
-- Admin dashboard: `http://localhost:8080/admin`
-- PocketBase admin: `http://localhost:8080/_/` (when ADMIN_ENABLED=true)
+**Important**: Change this password or set up your own authentication for production.
 
 ---
 
-## Getting OAuth Credentials
+## Authentication Options
 
-### Google OAuth
+### Password Login (Default)
 
+Password authentication works out of the box. Add your email to `ADMIN_EMAILS` to authorize your account:
+
+```env
+ADMIN_EMAILS=you@example.com
+```
+
+### OAuth Login (Coming Soon)
+
+OAuth configuration via environment variables is planned for a future release. This will allow you to configure Google and/or GitHub login without any manual setup:
+
+```env
+# Coming soon - not yet implemented
+# GOOGLE_CLIENT_ID=your-client-id
+# GOOGLE_CLIENT_SECRET=your-client-secret
+# GITHUB_CLIENT_ID=your-client-id
+# GITHUB_CLIENT_SECRET=your-client-secret
+```
+
+When implemented, the login screen will automatically show only the authentication methods you've configured.
+
+#### Getting OAuth Credentials (For Future Use)
+
+**Google OAuth:**
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
 2. Create a new project (or select existing)
 3. Go to APIs & Services → Credentials
 4. Click "Create Credentials" → "OAuth 2.0 Client ID"
 5. Choose "Web application"
 6. Add authorized redirect URI: `https://yourdomain.com/api/oauth2-redirect`
-7. Copy Client ID and Client Secret to PocketBase
+7. Save your Client ID and Client Secret
 
-### GitHub OAuth
-
+**GitHub OAuth:**
 1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
 2. Click "New OAuth App"
 3. Fill in:
    - Application name: Me.yaml
    - Homepage URL: https://yourdomain.com
    - Authorization callback URL: `https://yourdomain.com/api/oauth2-redirect`
-4. Copy Client ID and Client Secret to PocketBase
+4. Save your Client ID and Client Secret
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ENCRYPTION_KEY` | Yes | — | 32-byte hex key (`openssl rand -hex 32`) |
+| `PORT` | No | `8080` | Public port |
+| `APP_URL` | No | `http://localhost:8080` | Your public URL |
+| `TRUST_PROXY` | No | `false` | Set `true` behind reverse proxy |
+| `ADMIN_EMAILS` | No | — | Comma-separated email allowlist |
+| `DATA_PATH` | No | `./data` | Database and uploads directory |
 
 ---
 
@@ -138,28 +156,22 @@ labels:
 
 ## Unraid Setup
 
-### Using Docker Template
-
-1. Go to Docker -> Add Container
-2. Set:
-   - Name: me-yaml
-   - Repository: ghcr.io/yourusername/me-yaml:latest
-   - Port Mappings: 8080 -> 8080 (single port)
-   - Path: /mnt/user/appdata/me-yaml -> /data
-   - Variable: ENCRYPTION_KEY -> (your key)
-   - Variable: APP_URL -> https://meyaml.yourdomain.com
-   - Variable: TRUST_PROXY -> true
-
 ### Using Docker Compose
 
 1. Place files in `/mnt/user/appdata/me-yaml/`
 2. Edit `.env`:
    ```env
+   ENCRYPTION_KEY=your-key-here
    DATA_PATH=/mnt/user/appdata/me-yaml/data
    TRUST_PROXY=true
    APP_URL=https://profile.yourdomain.com
+   ADMIN_EMAILS=you@gmail.com
    ```
 3. Run: `docker-compose up -d`
+
+### Community App (Coming Soon)
+
+An Unraid Community App template is planned for easier installation.
 
 ---
 
@@ -170,6 +182,19 @@ labels:
 3. **Import projects**: Admin → Import → Enter GitHub repo
 4. **Create views**: Admin → Views → Create view for specific audiences
 5. **Generate share links**: Admin → Views → (select view) → Share Tokens
+
+---
+
+## Backup
+
+Everything lives in one directory:
+
+```bash
+# Stop, backup, restart
+docker-compose down
+tar -czvf me-yaml-backup-$(date +%Y%m%d).tar.gz ./data
+docker-compose up -d
+```
 
 ---
 


### PR DESCRIPTION
Setup changes:
- Remove PocketBase admin UI instructions from SETUP.md
- Mark OAuth login as "Coming Soon" with future env var syntax
- Keep OAuth credential generation instructions for reference
- Focus on password login as the current default
- Add Unraid Community App as "Coming Soon"

README changes:
- Update first login table for production (password-based)
- Note OAuth via env vars is coming soon

Roadmap additions (Future Considerations):
- Add detailed OAuth env var implementation plan:
  - GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
  - GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET
  - /api/auth/providers endpoint for dynamic login UI
  - Login page fetches available providers
- Benefits: end users never see PocketBase branding
- Enables Unraid template with OAuth fields
- Add decision log entry for this architectural choice