### PR TITLE
fix: Ensure posts/talks always show on profile + fix proposal auth

### DIFF
--- a/frontend/src/routes/admin/review/[id]/+page.svelte
+++ b/frontend/src/routes/admin/review/[id]/+page.svelte
@@ -99,7 +99,7 @@
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					Authorization: pb.authStore.token
+					Authorization: `Bearer ${pb.authStore.token}`
 				},
 				body: JSON.stringify({
 					applied_fields: appliedFields,
@@ -128,7 +128,7 @@
 			const response = await fetch(`/api/proposals/${$page.params.id}/reject`, {
 				method: 'POST',
 				headers: {
-					Authorization: pb.authStore.token
+					Authorization: `Bearer ${pb.authStore.token}`
 				}
 			});
 


### PR DESCRIPTION
- Homepage now fetches posts/talks from /api/homepage when view sections don't include them, ensuring content is always visible
- Fixed Authorization header format in proposal apply/reject to use proper "Bearer <token>" format