### PR TITLE
feat: Implement Phase 4.4 data export (JSON/YAML)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -205,7 +205,7 @@
 | 9. Docker | ✅ Complete | Production-ready |
 | 10. Documentation | 🟡 Partial | Core docs done |
 | 11. Testing | 🟡 Partial | Backend tests exist |
-| 12. Print & Export | 🟡 Partial | Print stylesheet complete, data export deferred |
+| 12. Print & Export | 🟡 Partial | Print stylesheet + data export complete, AI print deferred |
 | 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) complete |
 
 ---
@@ -226,7 +226,7 @@
 6. AI provider mock tests
 7. Integration tests
 8. View access log / audit logging (Phase 8)
-9. Data export (JSON/YAML) - Phase 4.4
+9. ~~Data export (JSON/YAML) - Phase 4.4~~ ✅ Complete
 10. Section width & columns (Phase 6.3)
 11. Mobile preview mode (Phase 6.2.2)
 
@@ -594,3 +594,68 @@ Users can now see how their view will look while editing, without needing to sav
 4. See changes reflected immediately in preview
 5. Click "Hide/Show Preview" button to toggle preview visibility
 6. Click "Open in Tab" to see full-size public view in new tab
+
+---
+
+## Phase 4.4: Data Export ✅ Complete
+
+This phase enables users to export their complete profile data for backup or migration.
+
+### Overview
+Users can download their entire profile in JSON or YAML format from the admin settings page. The export includes all content (profile, experience, projects, education, certifications, skills, posts, talks, and views) but excludes sensitive data like password hashes and internal IDs.
+
+### Features
+- [x] Export all profile data as JSON
+- [x] Export all profile data as YAML
+- [x] Download as file with timestamp filename
+- [x] Admin-only access (requires authentication)
+- [x] Metadata includes version and export timestamp
+
+### Backend Implementation
+- `GET /api/export?format=json` - Returns JSON export file
+- `GET /api/export?format=yaml` - Returns YAML export file
+- Requires authentication via `apis.RequireAuth()` middleware
+
+### Export Schema
+```json
+{
+  "meta": {
+    "version": "1.0.0",
+    "exported_at": "2026-01-01T12:00:00Z",
+    "app": "Me.yaml"
+  },
+  "profile": { ... },
+  "experience": [ ... ],
+  "projects": [ ... ],
+  "education": [ ... ],
+  "certifications": [ ... ],
+  "skills": [ ... ],
+  "posts": [ ... ],
+  "talks": [ ... ],
+  "views": [ ... ]
+}
+```
+
+### Files Added/Modified
+- `backend/hooks/export.go` (new) - Export endpoint and data collection
+- `backend/hooks/export_test.go` (new) - Unit tests for export functionality
+- `backend/main.go` - Register export hooks
+- `backend/go.mod` - Added gopkg.in/yaml.v3 dependency
+- `frontend/src/routes/admin/settings/+page.svelte` - Export buttons UI
+
+### Security Considerations
+- Export requires admin authentication
+- Password hashes are stripped from view exports
+- Internal record IDs are included for reference but not sensitive
+- Files are served with proper Content-Disposition headers for download
+
+### Usage
+1. Navigate to Admin > Settings
+2. Scroll to "Data Export" section
+3. Click "Download YAML" or "Download JSON"
+4. File downloads with timestamped filename (e.g., `me-yaml-export-2026-01-01.yaml`)
+
+### Future Enhancements (Deferred)
+- [ ] Include uploaded media files in ZIP archive
+- [ ] Import/restore from backup file
+- [ ] Export specific views only

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -451,14 +451,14 @@ Pre-designed templates for consistent, professional output.
 - Pandoc uses `--reference-doc` flag to apply template styling
 - Templates stored in `backend/templates/` directory
 
-#### 4.4 Data Export
+#### 4.4 Data Export ✅ Complete
 
 Export all data for backup or migration.
 
-- [ ] Export all data as JSON
-- [ ] Export as YAML (human-readable backup)
-- [ ] Include uploaded files in ZIP archive
-- [ ] Import from backup (restore)
+- [x] Export all data as JSON
+- [x] Export as YAML (human-readable backup)
+- [ ] Include uploaded files in ZIP archive — Deferred
+- [ ] Import from backup (restore) — Deferred
 
 #### 4.5 Static Snapshot
 
@@ -1012,6 +1012,7 @@ GITHUB_CLIENT_SECRET=your-client-secret
 | 2026-01-01 | Phase 4 redesigned as two-tier Export & Print | Simple Print (browser, works now) + AI Print (sends view to AI, returns optimized markdown, Pandoc converts to DOCX/PDF). Stored in view_exports collection. |
 | 2026-01-01 | OAuth config via env vars prioritized | End users should never see PocketBase; all config via environment variables. Login page should dynamically show only configured auth methods. Enables Unraid template distribution. |
 | 2026-01-01 | Phase 1.5 added for content discovery | Posts and talks are buried at bottom of profile with no navigation. Adding: profile nav tabs, index pages (/posts, /talks), and individual talk pages (/talks/[slug]). View limiting already works via sections config. |
+| 2026-01-01 | Phase 4.4 data export complete | JSON and YAML export via /api/export endpoint. Admin-only, downloads full profile data for backup/migration. Media files and import deferred. |
 
 ---
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pocketbase/pocketbase v0.23.4
 	golang.org/x/crypto v0.29.0
 	golang.org/x/time v0.8.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -317,6 +317,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
 google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/hooks/export.go
+++ b/backend/hooks/export.go
@@ -1,0 +1,212 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+	"gopkg.in/yaml.v3"
+)
+
+// ExportMeta contains metadata about the export
+type ExportMeta struct {
+	Version    string `json:"version" yaml:"version"`
+	ExportedAt string `json:"exported_at" yaml:"exported_at"`
+	App        string `json:"app" yaml:"app"`
+}
+
+// ExportData contains all exportable profile data
+type ExportData struct {
+	Meta           ExportMeta               `json:"meta" yaml:"meta"`
+	Profile        map[string]interface{}   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	Experience     []map[string]interface{} `json:"experience,omitempty" yaml:"experience,omitempty"`
+	Projects       []map[string]interface{} `json:"projects,omitempty" yaml:"projects,omitempty"`
+	Education      []map[string]interface{} `json:"education,omitempty" yaml:"education,omitempty"`
+	Certifications []map[string]interface{} `json:"certifications,omitempty" yaml:"certifications,omitempty"`
+	Skills         []map[string]interface{} `json:"skills,omitempty" yaml:"skills,omitempty"`
+	Posts          []map[string]interface{} `json:"posts,omitempty" yaml:"posts,omitempty"`
+	Talks          []map[string]interface{} `json:"talks,omitempty" yaml:"talks,omitempty"`
+	Views          []map[string]interface{} `json:"views,omitempty" yaml:"views,omitempty"`
+}
+
+// RegisterExportHooks registers data export API endpoints
+func RegisterExportHooks(app *pocketbase.PocketBase) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		// Export all data
+		// GET /api/export?format=json|yaml
+		se.Router.GET("/api/export", func(e *core.RequestEvent) error {
+			format := e.Request.URL.Query().Get("format")
+			if format == "" {
+				format = "json"
+			}
+
+			if format != "json" && format != "yaml" {
+				return e.JSON(http.StatusBadRequest, map[string]string{
+					"error": "Invalid format. Use 'json' or 'yaml'.",
+				})
+			}
+
+			// Collect all data
+			exportData, err := collectExportData(app)
+			if err != nil {
+				return e.JSON(http.StatusInternalServerError, map[string]string{
+					"error": fmt.Sprintf("Failed to collect data: %v", err),
+				})
+			}
+
+			// Generate filename with timestamp
+			timestamp := time.Now().Format("2006-01-02")
+			filename := fmt.Sprintf("me-yaml-export-%s.%s", timestamp, format)
+
+			if format == "yaml" {
+				return serveYAML(e, exportData, filename)
+			}
+			return serveJSON(e, exportData, filename)
+		}).Bind(apis.RequireAuth())
+
+		return se.Next()
+	})
+}
+
+// collectExportData gathers all exportable data from the database
+func collectExportData(app *pocketbase.PocketBase) (*ExportData, error) {
+	export := &ExportData{
+		Meta: ExportMeta{
+			Version:    "1.0.0",
+			ExportedAt: time.Now().UTC().Format(time.RFC3339),
+			App:        "Me.yaml",
+		},
+	}
+
+	// Profile (singleton)
+	profileRecords, err := app.FindRecordsByFilter("profile", "", "", 1, 0, nil)
+	if err == nil && len(profileRecords) > 0 {
+		export.Profile = sanitizeRecord(profileRecords[0])
+	}
+
+	// Experience
+	experienceRecords, err := app.FindRecordsByFilter("experience", "", "-sort_order,-start_date", 0, 0, nil)
+	if err == nil {
+		export.Experience = sanitizeRecords(experienceRecords)
+	}
+
+	// Projects
+	projectRecords, err := app.FindRecordsByFilter("projects", "", "-is_featured,-sort_order", 0, 0, nil)
+	if err == nil {
+		export.Projects = sanitizeRecords(projectRecords)
+	}
+
+	// Education
+	educationRecords, err := app.FindRecordsByFilter("education", "", "-sort_order,-end_date", 0, 0, nil)
+	if err == nil {
+		export.Education = sanitizeRecords(educationRecords)
+	}
+
+	// Certifications
+	certRecords, err := app.FindRecordsByFilter("certifications", "", "issuer,sort_order,-issue_date", 0, 0, nil)
+	if err == nil {
+		export.Certifications = sanitizeRecords(certRecords)
+	}
+
+	// Skills
+	skillRecords, err := app.FindRecordsByFilter("skills", "", "category,sort_order", 0, 0, nil)
+	if err == nil {
+		export.Skills = sanitizeRecords(skillRecords)
+	}
+
+	// Posts
+	postRecords, err := app.FindRecordsByFilter("posts", "", "-published_at", 0, 0, nil)
+	if err == nil {
+		export.Posts = sanitizeRecords(postRecords)
+	}
+
+	// Talks
+	talkRecords, err := app.FindRecordsByFilter("talks", "", "-sort_order,-date", 0, 0, nil)
+	if err == nil {
+		export.Talks = sanitizeRecords(talkRecords)
+	}
+
+	// Views (exclude password hashes)
+	viewRecords, err := app.FindRecordsByFilter("views", "", "name", 0, 0, nil)
+	if err == nil {
+		export.Views = sanitizeViewRecords(viewRecords)
+	}
+
+	return export, nil
+}
+
+// sanitizeRecord converts a PocketBase record to a map, removing internal fields
+func sanitizeRecord(record *core.Record) map[string]interface{} {
+	data := make(map[string]interface{})
+
+	// Get all field values
+	for key, value := range record.FieldsData() {
+		// Skip internal PocketBase fields
+		if key == "collectionId" || key == "collectionName" {
+			continue
+		}
+		data[key] = value
+	}
+
+	// Add the record ID (useful for references)
+	data["id"] = record.Id
+
+	return data
+}
+
+// sanitizeRecords converts multiple records to maps
+func sanitizeRecords(records []*core.Record) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		result = append(result, sanitizeRecord(record))
+	}
+	return result
+}
+
+// sanitizeViewRecords converts view records, removing sensitive fields like password_hash
+func sanitizeViewRecords(records []*core.Record) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		data := sanitizeRecord(record)
+		// Remove password hash - user must re-set password after import
+		delete(data, "password_hash")
+		result = append(result, data)
+	}
+	return result
+}
+
+// serveJSON sends the export as a JSON file download
+func serveJSON(e *core.RequestEvent, data *ExportData, filename string) error {
+	jsonBytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return e.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("Failed to serialize JSON: %v", err),
+		})
+	}
+
+	e.Response.Header().Set("Content-Type", "application/json")
+	e.Response.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	e.Response.WriteHeader(http.StatusOK)
+	e.Response.Write(jsonBytes)
+	return nil
+}
+
+// serveYAML sends the export as a YAML file download
+func serveYAML(e *core.RequestEvent, data *ExportData, filename string) error {
+	yamlBytes, err := yaml.Marshal(data)
+	if err != nil {
+		return e.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("Failed to serialize YAML: %v", err),
+		})
+	}
+
+	e.Response.Header().Set("Content-Type", "application/x-yaml")
+	e.Response.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	e.Response.WriteHeader(http.StatusOK)
+	e.Response.Write(yamlBytes)
+	return nil
+}

--- a/backend/hooks/export_test.go
+++ b/backend/hooks/export_test.go
@@ -1,0 +1,146 @@
+package hooks
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestExportMeta(t *testing.T) {
+	meta := ExportMeta{
+		Version:    "1.0.0",
+		ExportedAt: "2026-01-01T00:00:00Z",
+		App:        "Me.yaml",
+	}
+
+	// Test JSON marshaling
+	jsonBytes, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("Failed to marshal ExportMeta to JSON: %v", err)
+	}
+
+	var jsonMeta ExportMeta
+	if err := json.Unmarshal(jsonBytes, &jsonMeta); err != nil {
+		t.Fatalf("Failed to unmarshal ExportMeta from JSON: %v", err)
+	}
+
+	if jsonMeta.Version != meta.Version {
+		t.Errorf("Version mismatch: got %s, want %s", jsonMeta.Version, meta.Version)
+	}
+	if jsonMeta.App != meta.App {
+		t.Errorf("App mismatch: got %s, want %s", jsonMeta.App, meta.App)
+	}
+
+	// Test YAML marshaling
+	yamlBytes, err := yaml.Marshal(meta)
+	if err != nil {
+		t.Fatalf("Failed to marshal ExportMeta to YAML: %v", err)
+	}
+
+	var yamlMeta ExportMeta
+	if err := yaml.Unmarshal(yamlBytes, &yamlMeta); err != nil {
+		t.Fatalf("Failed to unmarshal ExportMeta from YAML: %v", err)
+	}
+
+	if yamlMeta.Version != meta.Version {
+		t.Errorf("Version mismatch: got %s, want %s", yamlMeta.Version, meta.Version)
+	}
+	if yamlMeta.App != meta.App {
+		t.Errorf("App mismatch: got %s, want %s", yamlMeta.App, meta.App)
+	}
+}
+
+func TestExportDataStructure(t *testing.T) {
+	export := &ExportData{
+		Meta: ExportMeta{
+			Version:    "1.0.0",
+			ExportedAt: "2026-01-01T00:00:00Z",
+			App:        "Me.yaml",
+		},
+		Profile: map[string]interface{}{
+			"name":     "Test User",
+			"headline": "Software Engineer",
+		},
+		Experience: []map[string]interface{}{
+			{"company": "Test Corp", "title": "Developer"},
+		},
+		Projects: []map[string]interface{}{
+			{"title": "Test Project", "summary": "A test project"},
+		},
+	}
+
+	// Test JSON marshaling
+	jsonBytes, err := json.MarshalIndent(export, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal ExportData to JSON: %v", err)
+	}
+
+	var jsonExport ExportData
+	if err := json.Unmarshal(jsonBytes, &jsonExport); err != nil {
+		t.Fatalf("Failed to unmarshal ExportData from JSON: %v", err)
+	}
+
+	if jsonExport.Meta.App != "Me.yaml" {
+		t.Errorf("Meta.App mismatch")
+	}
+	if jsonExport.Profile["name"] != "Test User" {
+		t.Errorf("Profile.name mismatch")
+	}
+	if len(jsonExport.Experience) != 1 {
+		t.Errorf("Experience length mismatch: got %d, want 1", len(jsonExport.Experience))
+	}
+	if len(jsonExport.Projects) != 1 {
+		t.Errorf("Projects length mismatch: got %d, want 1", len(jsonExport.Projects))
+	}
+
+	// Test YAML marshaling
+	yamlBytes, err := yaml.Marshal(export)
+	if err != nil {
+		t.Fatalf("Failed to marshal ExportData to YAML: %v", err)
+	}
+
+	var yamlExport ExportData
+	if err := yaml.Unmarshal(yamlBytes, &yamlExport); err != nil {
+		t.Fatalf("Failed to unmarshal ExportData from YAML: %v", err)
+	}
+
+	if yamlExport.Meta.App != "Me.yaml" {
+		t.Errorf("Meta.App mismatch in YAML")
+	}
+}
+
+func TestExportDataOmitEmpty(t *testing.T) {
+	// Test that empty slices are omitted from JSON output
+	export := &ExportData{
+		Meta: ExportMeta{
+			Version:    "1.0.0",
+			ExportedAt: "2026-01-01T00:00:00Z",
+			App:        "Me.yaml",
+		},
+		// All other fields empty
+	}
+
+	jsonBytes, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	jsonStr := string(jsonBytes)
+	// Empty slices should not appear in output due to omitempty
+	if stringContains(jsonStr, `"experience"`) {
+		t.Errorf("Empty experience should be omitted")
+	}
+	if stringContains(jsonStr, `"projects"`) {
+		t.Errorf("Empty projects should be omitted")
+	}
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -50,6 +50,7 @@ func main() {
 	hooks.RegisterPasswordHooks(app, cryptoService, rateLimitService)
 	hooks.RegisterViewHooks(app, cryptoService, shareService, rateLimitService)
 	hooks.RegisterAdminHooks(app)
+	hooks.RegisterExportHooks(app)
 	hooks.RegisterSeedHook(app)
 
 	// Note: Trusted proxy headers are handled by Caddy in the Docker setup.


### PR DESCRIPTION
Add /api/export endpoint for authenticated data export:
- Export all profile data as JSON or YAML format
- Download with timestamped filename
- Admin-only access via RequireAuth middleware
- Excludes sensitive data (password hashes)

Frontend updates:
- Export buttons in Admin > Settings page
- Download YAML or JSON with loading states
- Proper blob download handling

Documentation:
- Updated IMPLEMENTATION_PLAN.md with phase details
- Updated ROADMAP.md marking 4.4 complete
- Added decision log entry