### PR TITLE
feat: Implement Phase 6.3 section width & columns

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -206,7 +206,7 @@
 | 10. Documentation | 🟡 Partial | Core docs done |
 | 11. Testing | 🟡 Partial | Backend tests exist |
 | 12. Print & Export | 🟡 Partial | Print stylesheet + data export complete, AI print deferred |
-| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) complete |
+| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) + Section widths (6.3) complete |
 
 ---
 
@@ -227,7 +227,7 @@
 7. Integration tests
 8. View access log / audit logging (Phase 8)
 9. ~~Data export (JSON/YAML) - Phase 4.4~~ ✅ Complete
-10. Section width & columns (Phase 6.3)
+10. ~~Section width & columns (Phase 6.3)~~ ✅ Complete
 11. Mobile preview mode (Phase 6.2.2)
 
 ---
@@ -659,3 +659,90 @@ Users can download their entire profile in JSON or YAML format from the admin se
 - [ ] Include uploaded media files in ZIP archive
 - [ ] Import/restore from backup file
 - [ ] Export specific views only
+
+---
+
+## Phase 6.3: Section Width & Columns ✅ Complete
+
+This phase enables sections to share horizontal space, allowing side-by-side layouts for more compact and professional presentations.
+
+### Overview
+Users can now set each section's width (full, half, or third) in the view editor. Consecutive sections with compatible widths render side-by-side on desktop, automatically stacking on mobile for responsive design.
+
+### Features
+- [x] Width selector dropdown in view editor (both create and edit)
+- [x] Visual width indicator icons (column preview)
+- [x] CSS Grid layout on public view pages
+- [x] Responsive collapse to full-width on mobile (< 768px)
+- [x] Live preview reflects width settings in real-time
+- [x] Print stylesheet supports side-by-side layout
+
+### Width Options
+| Width | Grid Span | Use Case |
+|-------|-----------|----------|
+| Full | 6 columns | Default - section takes entire row |
+| Half | 3 columns | Side-by-side pairs (Skills + Certifications) |
+| Third | 2 columns | Triplets (rarely needed) |
+
+### Implementation
+
+#### Type Changes
+- `ViewSection.width?: 'full' | 'half' | 'third'` added to interface
+- `VALID_WIDTHS` constant with labels for dropdown
+- `SectionWidth` type alias for width values
+
+#### Backend Changes
+- Extract `width` from sections JSON in view data endpoint
+- Return `section_widths` map in API response
+- Default to `"full"` when width not specified
+
+#### View Editor Changes
+- Width dropdown appears next to layout dropdown (when section enabled)
+- Visual column indicator shows current width setting
+- Width saved in sections configuration
+
+#### Public View Changes
+- Grid container with 6-column layout
+- Sections wrapped in divs with width classes
+- CSS handles column spanning and responsive collapse
+
+#### ViewPreview Changes
+- Same grid layout as public view
+- Width classes applied in real-time preview
+
+### Files Changed
+- `frontend/src/lib/pocketbase.ts` - Added SectionWidth type, VALID_WIDTHS
+- `frontend/src/routes/admin/views/[id]/+page.svelte` - Width dropdown + indicator
+- `frontend/src/routes/admin/views/new/+page.svelte` - Width dropdown + indicator
+- `frontend/src/routes/[slug=slug]/+page.svelte` - Grid layout + width classes
+- `frontend/src/routes/[slug=slug]/+page.server.ts` - Pass sectionWidths
+- `frontend/src/components/admin/ViewPreview.svelte` - Grid layout support
+- `backend/hooks/view.go` - Extract and return section_widths
+
+### CSS Grid Structure
+```css
+.sections-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1.5rem;
+}
+
+.section-full { grid-column: span 6; }
+.section-half { grid-column: span 3; }
+.section-third { grid-column: span 2; }
+
+@media (max-width: 768px) {
+  .section-half, .section-third {
+    grid-column: span 6; /* Stack on mobile */
+  }
+}
+```
+
+### Usage
+1. Navigate to View Editor (/admin/views/[id])
+2. Enable desired sections
+3. Select width from dropdown (Full/Half/Third)
+4. Observe visual indicator showing column layout
+5. Preview pane shows sections side-by-side
+6. Save view - layout applies on public page
+7. Example: Set Skills to "Half" and Certifications to "Half" for side-by-side display

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -639,7 +639,7 @@ Add side-by-side preview in the view editor for immediate visual feedback.
 - Responsive layout: side-by-side on desktop, stacked on mobile
 - Preview scales down content for compact display
 
-#### 6.3 Section Width & Columns (Phase C - Advanced)
+#### 6.3 Section Width & Columns (Phase C - Complete) ✅
 
 Enable sections to share horizontal space (side-by-side layouts).
 
@@ -648,16 +648,19 @@ Enable sections to share horizontal space (side-by-side layouts).
 - `half` - 50% width (pairs with another half)
 - `third` - 33% width (triplets)
 
-**Behavior:**
-- Consecutive sections with compatible widths render side-by-side
-- CSS Grid handles responsive collapse (side-by-side on desktop, stacked on mobile)
-- Visual indicator in editor shows which sections will pair
+**Implementation:**
+- [x] Width dropdown in view editor (both create and edit pages)
+- [x] Visual column indicator icons showing layout
+- [x] CSS Grid with 6-column structure on public view
+- [x] Responsive collapse to full-width on mobile (< 768px)
+- [x] Live preview reflects width settings in real-time
+- [x] Backend returns `section_widths` map in API response
 
 **Schema Addition:**
 ```typescript
 interface ViewSection {
   // ... existing fields
-  width?: 'full' | 'half' | 'third';  // NEW
+  width?: 'full' | 'half' | 'third';  // Added
 }
 ```
 

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -226,6 +226,8 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 			var sectionOrder []string
 			// Track layouts for each section
 			sectionLayouts := make(map[string]string)
+			// Track widths for each section (Phase 6.3)
+			sectionWidths := make(map[string]string)
 
 			for _, section := range sections {
 				sectionName, ok := section["section"].(string)
@@ -244,6 +246,13 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 					sectionLayouts[sectionName] = layout
 				} else {
 					sectionLayouts[sectionName] = getDefaultLayout(sectionName)
+				}
+
+				// Extract width (default to "full" if not specified)
+				if width, ok := section["width"].(string); ok && width != "" {
+					sectionWidths[sectionName] = width
+				} else {
+					sectionWidths[sectionName] = "full"
 				}
 
 				items, ok := section["items"].([]interface{})
@@ -293,6 +302,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 			response["sections"] = sectionData
 			response["section_order"] = sectionOrder
 			response["section_layouts"] = sectionLayouts
+			response["section_widths"] = sectionWidths
 
 			// Fetch profile data for the view
 			profileRecords, err := app.FindRecordsByFilter(

--- a/frontend/src/components/admin/ViewPreview.svelte
+++ b/frontend/src/components/admin/ViewPreview.svelte
@@ -39,13 +39,14 @@
 	export let ctaText: string = '';
 	export let ctaUrl: string = '';
 
-	// Section configuration from editor
+	// Section configuration from editor (with width support for Phase 6.3)
 	export let sections: Record<
 		string,
 		{
 			enabled: boolean;
 			items: string[];
 			layout: string;
+			width?: 'full' | 'half' | 'third';
 			itemConfig: Record<string, ItemConfig>;
 		}
 	> = {};
@@ -121,6 +122,21 @@
 		return sections[sectionKey]?.layout || 'default';
 	}
 
+	// Get width for a section (Phase 6.3)
+	function getSectionWidth(sectionKey: string): string {
+		return sections[sectionKey]?.width || 'full';
+	}
+
+	// Get CSS class for section width
+	function getWidthClass(sectionKey: string): string {
+		const width = getSectionWidth(sectionKey);
+		switch (width) {
+			case 'half': return 'preview-section section-half';
+			case 'third': return 'preview-section section-third';
+			default: return 'preview-section section-full';
+		}
+	}
+
 	// Check if a section should be shown
 	function shouldShowSection(sectionKey: string): boolean {
 		const config = sections[sectionKey];
@@ -158,60 +174,62 @@
 		</div>
 	{/if}
 
-	<!-- Sections Preview -->
+	<!-- Sections Preview (with grid layout for Phase 6.3) -->
 	<div class="preview-content">
-		{#each sectionOrder as { key: sectionKey } (sectionKey)}
-			{#if sectionKey === 'experience' && shouldShowSection('experience')}
-				<div class="preview-section">
-					<ExperienceSection
-						items={getSectionData('experience')}
-						layout={getSectionLayout('experience')}
-					/>
-				</div>
-			{:else if sectionKey === 'projects' && shouldShowSection('projects')}
-				<div class="preview-section">
-					<ProjectsSection
-						items={getSectionData('projects')}
-						layout={getSectionLayout('projects')}
-					/>
-				</div>
-			{:else if sectionKey === 'education' && shouldShowSection('education')}
-				<div class="preview-section">
-					<EducationSection
-						items={getSectionData('education')}
-						layout={getSectionLayout('education')}
-					/>
-				</div>
-			{:else if sectionKey === 'certifications' && shouldShowSection('certifications')}
-				<div class="preview-section">
-					<CertificationsSection
-						items={getSectionData('certifications')}
-						layout={getSectionLayout('certifications')}
-					/>
-				</div>
-			{:else if sectionKey === 'skills' && shouldShowSection('skills')}
-				<div class="preview-section">
-					<SkillsSection
-						items={getSectionData('skills')}
-						layout={getSectionLayout('skills')}
-					/>
-				</div>
-			{:else if sectionKey === 'posts' && shouldShowSection('posts')}
-				<div class="preview-section">
-					<PostsSection
-						items={getSectionData('posts')}
-						layout={getSectionLayout('posts')}
-					/>
-				</div>
-			{:else if sectionKey === 'talks' && shouldShowSection('talks')}
-				<div class="preview-section">
-					<TalksSection
-						items={getSectionData('talks')}
-						layout={getSectionLayout('talks')}
-					/>
-				</div>
-			{/if}
-		{/each}
+		<div class="preview-sections-grid">
+			{#each sectionOrder as { key: sectionKey } (sectionKey)}
+				{#if sectionKey === 'experience' && shouldShowSection('experience')}
+					<div class={getWidthClass('experience')}>
+						<ExperienceSection
+							items={getSectionData('experience')}
+							layout={getSectionLayout('experience')}
+						/>
+					</div>
+				{:else if sectionKey === 'projects' && shouldShowSection('projects')}
+					<div class={getWidthClass('projects')}>
+						<ProjectsSection
+							items={getSectionData('projects')}
+							layout={getSectionLayout('projects')}
+						/>
+					</div>
+				{:else if sectionKey === 'education' && shouldShowSection('education')}
+					<div class={getWidthClass('education')}>
+						<EducationSection
+							items={getSectionData('education')}
+							layout={getSectionLayout('education')}
+						/>
+					</div>
+				{:else if sectionKey === 'certifications' && shouldShowSection('certifications')}
+					<div class={getWidthClass('certifications')}>
+						<CertificationsSection
+							items={getSectionData('certifications')}
+							layout={getSectionLayout('certifications')}
+						/>
+					</div>
+				{:else if sectionKey === 'skills' && shouldShowSection('skills')}
+					<div class={getWidthClass('skills')}>
+						<SkillsSection
+							items={getSectionData('skills')}
+							layout={getSectionLayout('skills')}
+						/>
+					</div>
+				{:else if sectionKey === 'posts' && shouldShowSection('posts')}
+					<div class={getWidthClass('posts')}>
+						<PostsSection
+							items={getSectionData('posts')}
+							layout={getSectionLayout('posts')}
+						/>
+					</div>
+				{:else if sectionKey === 'talks' && shouldShowSection('talks')}
+					<div class={getWidthClass('talks')}>
+						<TalksSection
+							items={getSectionData('talks')}
+							layout={getSectionLayout('talks')}
+						/>
+					</div>
+				{/if}
+			{/each}
+		</div>
 
 		{#if sectionOrder.filter(s => shouldShowSection(s.key)).length === 0}
 			<div class="flex flex-col items-center justify-center py-12 text-gray-400">
@@ -299,9 +317,31 @@
 		padding: 1rem;
 	}
 
+	/* Grid layout for section widths (Phase 6.3) */
+	.preview-sections-grid {
+		display: grid;
+		grid-template-columns: repeat(6, 1fr);
+		gap: 0.75rem;
+	}
+
+	/* Full width: spans all 6 columns */
+	.section-full {
+		grid-column: span 6;
+	}
+
+	/* Half width: spans 3 columns (50%) */
+	.section-half {
+		grid-column: span 3;
+	}
+
+	/* Third width: spans 2 columns (33%) */
+	.section-third {
+		grid-column: span 2;
+	}
+
 	/* Scale down sections for preview */
 	.preview-section {
-		margin-bottom: 1rem;
+		margin-bottom: 0;
 	}
 
 	.preview-section :global(section) {

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -166,14 +166,25 @@ export interface ItemConfig {
 // Layout types for each section
 export type SectionLayout = string;
 
+// Width options for sections (Phase 6.3)
+export type SectionWidth = 'full' | 'half' | 'third';
+
 export interface ViewSection {
 	section: string;
 	enabled: boolean;
 	items?: string[];
 	order?: number;
 	layout?: SectionLayout;
+	width?: SectionWidth;
 	itemConfig?: Record<string, ItemConfig>;
 }
+
+// Valid width options with labels
+export const VALID_WIDTHS: { value: SectionWidth; label: string }[] = [
+	{ value: 'full', label: 'Full Width' },
+	{ value: 'half', label: 'Half Width' },
+	{ value: 'third', label: 'Third Width' }
+];
 
 // Valid layouts per section type (curated presets)
 export const VALID_LAYOUTS: Record<string, { layouts: string[]; default: string; labels: Record<string, string> }> = {

--- a/frontend/src/routes/[slug=slug]/+page.server.ts
+++ b/frontend/src/routes/[slug=slug]/+page.server.ts
@@ -130,6 +130,7 @@ export const load: PageServerLoad = async ({ params, cookies, url, fetch }) => {
 			sections: viewData.sections || {},
 			sectionOrder: viewData.section_order || [],
 			sectionLayouts: viewData.section_layouts || {},
+			sectionWidths: viewData.section_widths || {},
 			requiresPassword: false
 		};
 	} catch (err) {

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -29,6 +29,20 @@
 		return data.sectionLayouts?.[sectionKey] || 'default';
 	}
 
+	// Get width for a section (from API response or default)
+	function getSectionWidth(sectionKey: string): string {
+		return data.sectionWidths?.[sectionKey] || 'full';
+	}
+
+	// Get CSS class for section width (using 6-column grid)
+	function getWidthClass(width: string): string {
+		switch (width) {
+			case 'half': return 'section-half';
+			case 'third': return 'section-third';
+			default: return 'section-full';
+		}
+	}
+
 	// Hidden form ref for setting password token cookie
 	let passwordForm: HTMLFormElement;
 	let tokenInput: HTMLInputElement;
@@ -127,25 +141,80 @@
 		{/if}
 
 		<main id="main-content" class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-			{#each effectiveSectionOrder as sectionKey}
-				{#if sectionKey === 'experience' && data.sections?.experience?.length > 0}
-					<ExperienceSection items={data.sections.experience} layout={getSectionLayout('experience')} />
-				{:else if sectionKey === 'projects' && data.sections?.projects?.length > 0}
-					<ProjectsSection items={data.sections.projects} layout={getSectionLayout('projects')} />
-				{:else if sectionKey === 'education' && data.sections?.education?.length > 0}
-					<EducationSection items={data.sections.education} layout={getSectionLayout('education')} />
-				{:else if sectionKey === 'certifications' && data.sections?.certifications?.length > 0}
-					<CertificationsSection items={data.sections.certifications} layout={getSectionLayout('certifications')} />
-				{:else if sectionKey === 'skills' && data.sections?.skills?.length > 0}
-					<SkillsSection items={data.sections.skills} layout={getSectionLayout('skills')} />
-				{:else if sectionKey === 'posts' && data.sections?.posts?.length > 0}
-					<PostsSection items={data.sections.posts} layout={getSectionLayout('posts')} />
-				{:else if sectionKey === 'talks' && data.sections?.talks?.length > 0}
-					<TalksSection items={data.sections.talks} layout={getSectionLayout('talks')} />
-				{/if}
-			{/each}
+			<div class="sections-grid">
+				{#each effectiveSectionOrder as sectionKey}
+					{#if sectionKey === 'experience' && data.sections?.experience?.length > 0}
+						<div class={getWidthClass(getSectionWidth('experience'))}>
+							<ExperienceSection items={data.sections.experience} layout={getSectionLayout('experience')} />
+						</div>
+					{:else if sectionKey === 'projects' && data.sections?.projects?.length > 0}
+						<div class={getWidthClass(getSectionWidth('projects'))}>
+							<ProjectsSection items={data.sections.projects} layout={getSectionLayout('projects')} />
+						</div>
+					{:else if sectionKey === 'education' && data.sections?.education?.length > 0}
+						<div class={getWidthClass(getSectionWidth('education'))}>
+							<EducationSection items={data.sections.education} layout={getSectionLayout('education')} />
+						</div>
+					{:else if sectionKey === 'certifications' && data.sections?.certifications?.length > 0}
+						<div class={getWidthClass(getSectionWidth('certifications'))}>
+							<CertificationsSection items={data.sections.certifications} layout={getSectionLayout('certifications')} />
+						</div>
+					{:else if sectionKey === 'skills' && data.sections?.skills?.length > 0}
+						<div class={getWidthClass(getSectionWidth('skills'))}>
+							<SkillsSection items={data.sections.skills} layout={getSectionLayout('skills')} />
+						</div>
+					{:else if sectionKey === 'posts' && data.sections?.posts?.length > 0}
+						<div class={getWidthClass(getSectionWidth('posts'))}>
+							<PostsSection items={data.sections.posts} layout={getSectionLayout('posts')} />
+						</div>
+					{:else if sectionKey === 'talks' && data.sections?.talks?.length > 0}
+						<div class={getWidthClass(getSectionWidth('talks'))}>
+							<TalksSection items={data.sections.talks} layout={getSectionLayout('talks')} />
+						</div>
+					{/if}
+				{/each}
+			</div>
 		</main>
 
 		<Footer profile={data.profile} />
 	</div>
 {/if}
+
+<style>
+	/* Section grid layout (Phase 6.3) */
+	.sections-grid {
+		display: grid;
+		grid-template-columns: repeat(6, 1fr);
+		gap: 1.5rem;
+	}
+
+	/* Full width: spans all 6 columns */
+	.sections-grid :global(.section-full) {
+		grid-column: span 6;
+	}
+
+	/* Half width: spans 3 columns (50%) */
+	.sections-grid :global(.section-half) {
+		grid-column: span 3;
+	}
+
+	/* Third width: spans 2 columns (33%) */
+	.sections-grid :global(.section-third) {
+		grid-column: span 2;
+	}
+
+	/* Responsive: collapse to full width on mobile */
+	@media (max-width: 768px) {
+		.sections-grid :global(.section-half),
+		.sections-grid :global(.section-third) {
+			grid-column: span 6;
+		}
+	}
+
+	/* Print: allow side-by-side on wider paper */
+	@media print {
+		.sections-grid {
+			gap: 1rem;
+		}
+	}
+</style>


### PR DESCRIPTION
Add support for side-by-side section layouts in views, enabling more compact and professional profile presentations.

Changes:
- Add width field ('full' | 'half' | 'third') to ViewSection type
- Width dropdown with visual column indicator in view editors
- Backend returns section_widths map in view data API
- CSS Grid layout on public view (6-column structure)
- Responsive collapse to full-width on mobile (< 768px)
- ViewPreview reflects width settings in real-time
- Documentation updated in IMPLEMENTATION_PLAN.md and ROADMAP.md

Example usage: Set Skills to "Half" and Certifications to "Half" to display them side-by-side on desktop screens.