### PR TITLE
fix: Resolve live preview reactivity for view editor

### DIFF
--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -222,14 +222,19 @@
 		}
 	}
 
+	// Helper to trigger reactivity by creating a new object reference
+	function updateSections() {
+		sections = { ...sections };
+	}
+
 	function toggleSection(key: string) {
 		sections[key].enabled = !sections[key].enabled;
-		sections = sections; // Trigger reactivity
+		updateSections();
 	}
 
 	function toggleSectionExpand(key: string) {
 		sections[key].expanded = !sections[key].expanded;
-		sections = sections;
+		updateSections();
 	}
 
 	function toggleItem(sectionKey: string, itemId: string) {
@@ -239,17 +244,27 @@
 		} else {
 			sections[sectionKey].items.splice(idx, 1);
 		}
-		sections = sections;
+		updateSections();
 	}
 
 	function selectAllItems(sectionKey: string) {
 		sections[sectionKey].items = sectionItems[sectionKey]?.map((i) => i.id) || [];
-		sections = sections;
+		updateSections();
 	}
 
 	function clearAllItems(sectionKey: string) {
 		sections[sectionKey].items = [];
-		sections = sections;
+		updateSections();
+	}
+
+	function updateSectionWidth(sectionKey: string, width: string) {
+		sections[sectionKey].width = width as SectionWidth;
+		updateSections();
+	}
+
+	function updateSectionLayout(sectionKey: string, layout: string) {
+		sections[sectionKey].layout = layout;
+		updateSections();
 	}
 
 	function generateSlug(value: string): string {
@@ -389,7 +404,7 @@
 			delete sections[sectionKey].itemConfig[itemId];
 		}
 
-		sections = sections; // Trigger reactivity
+		updateSections();
 		closeOverrideEditor();
 		toasts.add('success', 'Overrides saved');
 	}
@@ -459,7 +474,7 @@
 		const selectedSet = new Set(sections[sectionKey].items);
 		// Reorder selected items to match display order
 		sections[sectionKey].items = displayOrder.filter(id => selectedSet.has(id));
-		sections = sections; // Trigger reactivity
+		updateSections();
 	}
 </script>
 
@@ -775,7 +790,8 @@
 											</div>
 											<select
 												class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-												bind:value={sections[sectionKey].width}
+												value={sectionConfig.width}
+												on:change={(e) => updateSectionWidth(sectionKey, e.currentTarget.value)}
 												on:click|stopPropagation
 											>
 												{#each VALID_WIDTHS as widthOption}
@@ -790,7 +806,8 @@
 										{@const layoutConfig = VALID_LAYOUTS[sectionKey]}
 										<select
 											class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-											bind:value={sections[sectionKey].layout}
+											value={sectionConfig.layout}
+											on:change={(e) => updateSectionLayout(sectionKey, e.currentTarget.value)}
 											on:click|stopPropagation
 											title="Section layout"
 										>

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -138,14 +138,19 @@
 		}
 	}
 
+	// Helper to trigger reactivity by creating a new object reference
+	function updateSections() {
+		sections = { ...sections };
+	}
+
 	function toggleSection(key: string) {
 		sections[key].enabled = !sections[key].enabled;
-		sections = sections;
+		updateSections();
 	}
 
 	function toggleSectionExpand(key: string) {
 		sections[key].expanded = !sections[key].expanded;
-		sections = sections;
+		updateSections();
 	}
 
 	function toggleItem(sectionKey: string, itemId: string) {
@@ -155,17 +160,27 @@
 		} else {
 			sections[sectionKey].items.splice(idx, 1);
 		}
-		sections = sections;
+		updateSections();
 	}
 
 	function selectAllItems(sectionKey: string) {
 		sections[sectionKey].items = sectionItems[sectionKey]?.map((i) => i.id) || [];
-		sections = sections;
+		updateSections();
 	}
 
 	function clearAllItems(sectionKey: string) {
 		sections[sectionKey].items = [];
-		sections = sections;
+		updateSections();
+	}
+
+	function updateSectionWidth(sectionKey: string, width: string) {
+		sections[sectionKey].width = width as SectionWidth;
+		updateSections();
+	}
+
+	function updateSectionLayout(sectionKey: string, layout: string) {
+		sections[sectionKey].layout = layout;
+		updateSections();
 	}
 
 	function generateSlug(value: string): string {
@@ -204,7 +219,7 @@
 		const displayOrder = sectionItems[sectionKey]?.map(i => i.id) || [];
 		const selectedSet = new Set(sections[sectionKey].items);
 		sections[sectionKey].items = displayOrder.filter(id => selectedSet.has(id));
-		sections = sections;
+		updateSections();
 	}
 
 	async function handleSubmit() {
@@ -561,7 +576,8 @@
 											</div>
 											<select
 												class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-												bind:value={sections[sectionKey].width}
+												value={sectionConfig.width}
+												on:change={(e) => updateSectionWidth(sectionKey, e.currentTarget.value)}
 												on:click|stopPropagation
 											>
 												{#each VALID_WIDTHS as widthOption}
@@ -576,7 +592,8 @@
 										{@const layoutConfig = VALID_LAYOUTS[sectionKey]}
 										<select
 											class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-											bind:value={sections[sectionKey].layout}
+											value={sectionConfig.layout}
+											on:change={(e) => updateSectionLayout(sectionKey, e.currentTarget.value)}
 											on:click|stopPropagation
 											title="Section layout"
 										>


### PR DESCRIPTION
Fixed issues where the live preview panel wasn't updating when:
- Clicking checkboxes to select/deselect items in content sections
- Changing width dropdown (Full/Half/Third)
- Changing layout/style dropdown

Root cause: Svelte's reactivity wasn't triggered properly because:
1. bind:value on nested object properties didn't reassign the parent
2. Same object reference was passed to child components

Solution:
- Added updateSections() helper that creates a new object reference
- Changed width/layout selects to use on:change handlers
- Refactored ViewPreview to use reactive statements ($:) for computing section data instead of imperative function calls
- All section updates now properly propagate to the preview

Files modified:
- ViewPreview.svelte: Use reactive $: statements for computed data
- [id]/+page.svelte: Add updateSections() and event handlers
- new/+page.svelte: Same reactivity fixes as edit page