### PR TITLE
feat: Add layout-aware width restrictions for sections

### DIFF
--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -263,6 +263,49 @@ export function getSectionLayout(section: string, layout?: string): string {
 	return config.default;
 }
 
+// Layout-to-width restrictions: which layouts only work at full width
+// Layouts not listed here support all widths (full, half, third)
+export const FULL_WIDTH_ONLY_LAYOUTS: Record<string, string[]> = {
+	experience: ['timeline'],      // Timeline visual needs horizontal space
+	education: ['timeline'],       // Timeline visual needs horizontal space
+	certifications: ['timeline'],  // Timeline visual needs horizontal space
+	projects: ['featured'],        // Featured item takes full width
+	posts: ['featured'],           // Featured item takes full width
+	skills: ['cloud', 'bars'],     // Cloud/bars need space to look good
+	talks: []                      // All talks layouts work at any width
+};
+
+// Get valid widths for a given section and layout
+export function getValidWidthsForLayout(
+	sectionKey: string,
+	layout: string
+): { value: SectionWidth; label: string }[] {
+	const fullOnlyLayouts = FULL_WIDTH_ONLY_LAYOUTS[sectionKey] || [];
+
+	if (fullOnlyLayouts.includes(layout)) {
+		// Only full width is valid for this layout
+		return [{ value: 'full', label: 'Full Width' }];
+	}
+
+	// All widths are valid
+	return VALID_WIDTHS;
+}
+
+// Check if a width is valid for a given section and layout
+export function isWidthValidForLayout(
+	sectionKey: string,
+	layout: string,
+	width: SectionWidth
+): boolean {
+	const fullOnlyLayouts = FULL_WIDTH_ONLY_LAYOUTS[sectionKey] || [];
+
+	if (fullOnlyLayouts.includes(layout)) {
+		return width === 'full';
+	}
+
+	return true;
+}
+
 // Define which fields can be overridden per collection
 export const OVERRIDABLE_FIELDS: Record<string, string[]> = {
 	experience: ['title', 'description', 'bullets'],

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { pb, type ViewSection, type Profile, type SectionWidth, VALID_LAYOUTS, VALID_WIDTHS } from '$lib/pocketbase';
+	import { pb, type ViewSection, type Profile, type SectionWidth, VALID_LAYOUTS, VALID_WIDTHS, getValidWidthsForLayout, isWidthValidForLayout } from '$lib/pocketbase';
 	import { toasts } from '$lib/stores';
 	import { dndzone } from 'svelte-dnd-action';
 	import { flip } from 'svelte/animate';
@@ -180,6 +180,10 @@
 
 	function updateSectionLayout(sectionKey: string, layout: string) {
 		sections[sectionKey].layout = layout;
+		// Auto-reset width to 'full' if current width is not valid for new layout
+		if (!isWidthValidForLayout(sectionKey, layout, sections[sectionKey].width)) {
+			sections[sectionKey].width = 'full';
+		}
 		updateSections();
 	}
 
@@ -560,31 +564,34 @@
 								<div class="flex items-center gap-2">
 									<!-- Width Selector with visual indicator -->
 									{#if sectionConfig.enabled}
-										<div class="flex items-center gap-1" title="Section width - controls side-by-side layout">
-											<!-- Width icon indicator -->
-											<div class="flex gap-0.5">
-												{#if sectionConfig.width === 'half'}
-													<div class="w-2 h-4 bg-primary-500 rounded-sm"></div>
-													<div class="w-2 h-4 bg-gray-300 dark:bg-gray-600 rounded-sm"></div>
-												{:else if sectionConfig.width === 'third'}
-													<div class="w-1.5 h-4 bg-primary-500 rounded-sm"></div>
-													<div class="w-1.5 h-4 bg-gray-300 dark:bg-gray-600 rounded-sm"></div>
-													<div class="w-1.5 h-4 bg-gray-300 dark:bg-gray-600 rounded-sm"></div>
-												{:else}
-													<div class="w-5 h-4 bg-primary-500 rounded-sm"></div>
-												{/if}
+										{@const validWidths = getValidWidthsForLayout(sectionKey, sectionConfig.layout)}
+										{#if validWidths.length > 1}
+											<div class="flex items-center gap-1" title="Section width - controls side-by-side layout">
+												<!-- Width icon indicator -->
+												<div class="flex gap-0.5">
+													{#if sectionConfig.width === 'half'}
+														<div class="w-2 h-4 bg-primary-500 rounded-sm"></div>
+														<div class="w-2 h-4 bg-gray-300 dark:bg-gray-600 rounded-sm"></div>
+													{:else if sectionConfig.width === 'third'}
+														<div class="w-1.5 h-4 bg-primary-500 rounded-sm"></div>
+														<div class="w-1.5 h-4 bg-gray-300 dark:bg-gray-600 rounded-sm"></div>
+														<div class="w-1.5 h-4 bg-gray-300 dark:bg-gray-600 rounded-sm"></div>
+													{:else}
+														<div class="w-5 h-4 bg-primary-500 rounded-sm"></div>
+													{/if}
+												</div>
+												<select
+													class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+													value={sectionConfig.width}
+													on:change={(e) => updateSectionWidth(sectionKey, e.currentTarget.value)}
+													on:click|stopPropagation
+												>
+													{#each validWidths as widthOption}
+														<option value={widthOption.value}>{widthOption.label}</option>
+													{/each}
+												</select>
 											</div>
-											<select
-												class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-												value={sectionConfig.width}
-												on:change={(e) => updateSectionWidth(sectionKey, e.currentTarget.value)}
-												on:click|stopPropagation
-											>
-												{#each VALID_WIDTHS as widthOption}
-													<option value={widthOption.value}>{widthOption.label}</option>
-												{/each}
-											</select>
-										</div>
+										{/if}
 									{/if}
 
 									<!-- Layout Selector -->


### PR DESCRIPTION
Certain layouts don't work well at reduced widths (e.g., Timeline needs full horizontal space). This change restricts the width dropdown based on the selected layout.

Changes:
- Add FULL_WIDTH_ONLY_LAYOUTS config mapping layouts that require full width
- Add getValidWidthsForLayout() and isWidthValidForLayout() helpers
- Width dropdown only appears when multiple widths are valid for the layout
- Auto-reset width to 'full' when switching to a layout that requires it

Layouts restricted to full width only:
- experience/education/certifications: timeline
- projects/posts: featured
- skills: cloud, bars

All other layouts support full/half/third widths for flexible side-by-side arrangements.