### PR TITLE
feat: Implement Phase 6.6 per-view accent color theming

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -206,7 +206,7 @@
 | 10. Documentation | 🟡 Partial | Core docs done |
 | 11. Testing | 🟡 Partial | Backend tests exist |
 | 12. Print & Export | 🟡 Partial | Print stylesheet + data export complete, AI print deferred |
-| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) + Section widths (6.3) + Accent color (6.5) complete |
+| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) + Section widths (6.3) + Accent color (6.5) + Per-view theming (6.6) complete |
 
 ---
 
@@ -836,3 +836,69 @@ Users can now select an accent color from the Admin Settings page. The color app
 - Admin settings page dispatches `accent-color-changed` event for instant updates
 - All 6 colors have full Tailwind-style scales (50-950) for consistent theming
 - Works correctly in both light and dark modes
+
+---
+
+## Phase 6.6: Per-View Theming ✅ Complete
+
+This phase enables different views to have different accent colors, allowing users to tailor each view's visual style to its audience.
+
+### Overview
+Each view can optionally override the global accent color. This enables:
+- **Recruiter view** → Indigo (professional, corporate)
+- **Speaking view** → Rose (energetic, memorable)
+- **Portfolio view** → Emerald (creative, fresh)
+- **Default view** → Uses global profile setting
+
+### Implementation
+
+#### Backend Changes
+- [x] Migration `1735600007_add_view_accent_color.go` adds optional `accent_color` field to views collection
+- [x] `/api/view/{slug}/data` endpoint includes `accent_color` in response (null = inherit)
+
+#### Frontend Type Changes
+- [x] Added `accent_color` field to `View` interface in `pocketbase.ts`
+
+#### View Editor UI
+- [x] Accent color selector in Settings section of view editor
+- [x] "Use global" option to inherit from profile setting
+- [x] Color swatches for override selection
+- [x] Visual feedback showing current selection
+- [x] Descriptive text indicating inheritance vs override
+
+#### Public View Rendering
+- [x] `+page.svelte` (homepage) applies view accent color if present
+- [x] `[slug=slug]/+page.svelte` applies view accent color if present
+- [x] View accent color takes priority over profile accent color
+
+#### Preview Pane
+- [x] ViewPreview component accepts accentColor prop
+- [x] Preview applies view-specific accent color via CSS custom properties
+- [x] Real-time updates as user changes accent color in editor
+
+### Files Added
+- `backend/migrations/1735600007_add_view_accent_color.go`
+
+### Files Modified
+- `backend/hooks/view.go` - Added accent_color to view data response
+- `frontend/src/lib/pocketbase.ts` - Added accent_color to View interface
+- `frontend/src/routes/+page.server.ts` - Added accent_color to view data
+- `frontend/src/routes/[slug=slug]/+page.server.ts` - Added accent_color to view data
+- `frontend/src/routes/+page.svelte` - Apply view accent color on homepage
+- `frontend/src/routes/[slug=slug]/+page.svelte` - Apply view accent color on public views
+- `frontend/src/routes/admin/views/[id]/+page.svelte` - Added accent color selector UI
+- `frontend/src/components/admin/ViewPreview.svelte` - Added accent color preview support
+
+### Usage
+1. Navigate to Admin > Views > [Edit View]
+2. Find "Accent Color" in the Settings section
+3. Click "Use global" to inherit from profile, or select a color to override
+4. Preview pane shows the accent color in real-time
+5. Save the view - accent color applies on public view
+6. Each view can have its own accent color independent of others
+
+### Technical Details
+- View accent color stored as nullable field (null = inherit from profile)
+- Priority: View accent color > Profile accent color > Default (sky)
+- CSS custom properties applied via inline styles in preview
+- Public pages apply accent color via onMount() hook

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -774,7 +774,7 @@ interface SiteSettings {
 - ❌ Freeform color picker (guardrails philosophy)
 - ❌ Custom font selection (deferred)
 
-#### 6.6 Per-View Theming & Presets
+#### 6.6 Per-View Theming & Presets ✅ Complete
 
 Enable different views to have different visual styles. A recruiter view might use professional Indigo, while a speaking/conference view uses energetic Rose.
 
@@ -816,11 +816,11 @@ interface View {
 
 **Implementation Tasks:**
 
-- [ ] Add `accent_color` field to views collection (migration)
-- [ ] Add accent color selector to view editor
-- [ ] Update view data API to include accent color
-- [ ] Frontend applies view accent color when rendering public view
-- [ ] Preview pane reflects view-specific accent color
+- [x] Add `accent_color` field to views collection (migration)
+- [x] Add accent color selector to view editor
+- [x] Update view data API to include accent color
+- [x] Frontend applies view accent color when rendering public view
+- [x] Preview pane reflects view-specific accent color
 
 **Theme Presets (Future):**
 
@@ -1156,6 +1156,7 @@ GITHUB_CLIENT_SECRET=your-client-secret
 | 2026-01-01 | Phase 4.4 data export complete | JSON and YAML export via /api/export endpoint. Admin-only, downloads full profile data for backup/migration. Media files and import deferred. |
 | 2026-01-01 | Phase 6.5 accent color design finalized | Curated palette approach (6 colors) instead of freeform picker. Maintains design guardrails while enabling personalization. Colors: Sky, Indigo, Emerald, Rose, Amber, Slate. Uses CSS custom properties for runtime theming. |
 | 2026-01-01 | Phase 6.5 accent color implementation complete | Full implementation: migration, color constants, Admin Settings UI with color swatches, live preview, CSS custom properties injection. Works in light/dark modes. |
+| 2026-01-01 | Phase 6.6 per-view theming complete | Views can now override global accent color. View editor has color selector with "Use global" option. Preview pane reflects view-specific color in real-time. |
 
 ---
 

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -213,6 +213,11 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 				response["cta_url"] = ctaURL
 			}
 
+			// Include view-specific accent color (null/empty means inherit from profile)
+			if accentColor := view.GetString("accent_color"); accentColor != "" {
+				response["accent_color"] = accentColor
+			}
+
 			// Get sections configuration
 			sectionsJSON := view.GetString("sections")
 			var sections []map[string]interface{}

--- a/backend/migrations/1735600007_add_view_accent_color.go
+++ b/backend/migrations/1735600007_add_view_accent_color.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		// Find the views collection
+		viewsCollection, err := app.FindCollectionByNameOrId("views")
+		if err != nil {
+			// Collection doesn't exist, nothing to do
+			return nil
+		}
+
+		// Check if accent_color field already exists
+		if viewsCollection.Fields.GetByName("accent_color") != nil {
+			return nil
+		}
+
+		// Add accent_color field with curated palette values
+		// null/empty = inherit from global profile setting
+		viewsCollection.Fields.Add(&core.SelectField{
+			Name:      "accent_color",
+			Values:    []string{"sky", "indigo", "emerald", "rose", "amber", "slate"},
+			MaxSelect: 1,
+		})
+
+		return app.Save(viewsCollection)
+	}, func(app core.App) error {
+		// Rollback: remove accent_color field from views collection
+		viewsCollection, err := app.FindCollectionByNameOrId("views")
+		if err != nil {
+			return nil
+		}
+
+		accentField := viewsCollection.Fields.GetByName("accent_color")
+		if accentField != nil {
+			viewsCollection.Fields.RemoveById(accentField.GetId())
+		}
+
+		return app.Save(viewsCollection)
+	})
+}

--- a/frontend/src/components/admin/ViewPreview.svelte
+++ b/frontend/src/components/admin/ViewPreview.svelte
@@ -31,9 +31,11 @@
 	import SkillsSection from '$components/public/SkillsSection.svelte';
 	import PostsSection from '$components/public/PostsSection.svelte';
 	import TalksSection from '$components/public/TalksSection.svelte';
+	import { ACCENT_COLORS, type AccentColor } from '$lib/colors';
 
 	// Props from parent editor
 	export let profile: Profile | null = null;
+	export let accentColor: AccentColor | null = null; // View-specific accent color
 	export let heroHeadline: string = '';
 	export let heroSummary: string = '';
 	export let ctaText: string = '';
@@ -154,9 +156,31 @@
 
 	// Reactive count of visible sections for empty state check
 	$: visibleSectionCount = sectionOrder.filter(s => computedSections[s.key]?.visible).length;
+
+	// Compute effective accent color (view override or profile default)
+	$: effectiveAccentColor = accentColor || (profile?.accent_color as AccentColor) || null;
+
+	// Generate inline styles for accent color preview
+	$: accentStyles = effectiveAccentColor ? (() => {
+		const color = ACCENT_COLORS[effectiveAccentColor];
+		if (!color) return '';
+		return `
+			--color-primary-50: ${color.scale[50]};
+			--color-primary-100: ${color.scale[100]};
+			--color-primary-200: ${color.scale[200]};
+			--color-primary-300: ${color.scale[300]};
+			--color-primary-400: ${color.scale[400]};
+			--color-primary-500: ${color.scale[500]};
+			--color-primary-600: ${color.scale[600]};
+			--color-primary-700: ${color.scale[700]};
+			--color-primary-800: ${color.scale[800]};
+			--color-primary-900: ${color.scale[900]};
+			--color-primary-950: ${color.scale[950]};
+		`;
+	})() : '';
 </script>
 
-<div class="preview-container">
+<div class="preview-container" style={accentStyles}>
 	<!-- Mini Hero -->
 	{#if effectiveProfile}
 		<div class="preview-hero">

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -157,6 +157,7 @@ export interface View {
 	sections?: ViewSection[];
 	is_active: boolean;
 	is_default?: boolean;
+	accent_color?: 'sky' | 'indigo' | 'emerald' | 'rose' | 'amber' | 'slate' | null;
 }
 
 export interface ItemConfig {

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -68,7 +68,8 @@ export const load: PageServerLoad = async ({ fetch }) => {
 							hero_headline: viewData.hero_headline,
 							hero_summary: viewData.hero_summary,
 							cta_text: viewData.cta_text,
-							cta_url: viewData.cta_url
+							cta_url: viewData.cta_url,
+							accent_color: viewData.accent_color || null
 						},
 						// Profile with resolved file URLs
 						profile: profile

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import ProfileHero from '$components/public/ProfileHero.svelte';
 	import ProfileNav from '$components/public/ProfileNav.svelte';
 	import ExperienceSection from '$components/public/ExperienceSection.svelte';
@@ -11,12 +13,43 @@
 	import TalksSection from '$components/public/TalksSection.svelte';
 	import Footer from '$components/public/Footer.svelte';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
+	import { ACCENT_COLORS, type AccentColor } from '$lib/colors';
 
 	export let data: PageData;
 
 	// Get headline and summary - use view overrides if this is a default view
 	$: headline = data.view?.hero_headline || data.profile?.headline;
 	$: summary = data.view?.hero_summary || data.profile?.summary;
+
+	// Apply view-specific accent color if default view has one
+	function applyAccentColor(colorName: AccentColor) {
+		if (!browser) return;
+
+		const color = ACCENT_COLORS[colorName];
+		if (!color) return;
+
+		const root = document.documentElement;
+		root.style.setProperty('--color-primary-50', color.scale[50]);
+		root.style.setProperty('--color-primary-100', color.scale[100]);
+		root.style.setProperty('--color-primary-200', color.scale[200]);
+		root.style.setProperty('--color-primary-300', color.scale[300]);
+		root.style.setProperty('--color-primary-400', color.scale[400]);
+		root.style.setProperty('--color-primary-500', color.scale[500]);
+		root.style.setProperty('--color-primary-600', color.scale[600]);
+		root.style.setProperty('--color-primary-700', color.scale[700]);
+		root.style.setProperty('--color-primary-800', color.scale[800]);
+		root.style.setProperty('--color-primary-900', color.scale[900]);
+		root.style.setProperty('--color-primary-950', color.scale[950]);
+	}
+
+	onMount(() => {
+		// View accent color takes priority over profile accent color
+		// (default view may have its own accent color override)
+		const accentColor = data.view?.accent_color || data.profile?.accent_color;
+		if (accentColor) {
+			applyAccentColor(accentColor as AccentColor);
+		}
+	});
 </script>
 
 <svelte:head>

--- a/frontend/src/routes/[slug=slug]/+page.server.ts
+++ b/frontend/src/routes/[slug=slug]/+page.server.ts
@@ -119,7 +119,8 @@ export const load: PageServerLoad = async ({ params, cookies, url, fetch }) => {
 				hero_headline: viewData.hero_headline,
 				hero_summary: viewData.hero_summary,
 				cta_text: viewData.cta_text,
-				cta_url: viewData.cta_url
+				cta_url: viewData.cta_url,
+				accent_color: viewData.accent_color || null
 			},
 			profile: profile ? {
 				...profile,

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -2,6 +2,8 @@
 	import type { PageData } from './$types';
 	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import ProfileHero from '$components/public/ProfileHero.svelte';
 	import ExperienceSection from '$components/public/ExperienceSection.svelte';
 	import ProjectsSection from '$components/public/ProjectsSection.svelte';
@@ -13,8 +15,38 @@
 	import Footer from '$components/public/Footer.svelte';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
 	import PasswordPrompt from '$components/public/PasswordPrompt.svelte';
+	import { ACCENT_COLORS, type AccentColor } from '$lib/colors';
 
 	export let data: PageData;
+
+	// Apply view-specific accent color (or profile default)
+	function applyAccentColor(colorName: AccentColor) {
+		if (!browser) return;
+
+		const color = ACCENT_COLORS[colorName];
+		if (!color) return;
+
+		const root = document.documentElement;
+		root.style.setProperty('--color-primary-50', color.scale[50]);
+		root.style.setProperty('--color-primary-100', color.scale[100]);
+		root.style.setProperty('--color-primary-200', color.scale[200]);
+		root.style.setProperty('--color-primary-300', color.scale[300]);
+		root.style.setProperty('--color-primary-400', color.scale[400]);
+		root.style.setProperty('--color-primary-500', color.scale[500]);
+		root.style.setProperty('--color-primary-600', color.scale[600]);
+		root.style.setProperty('--color-primary-700', color.scale[700]);
+		root.style.setProperty('--color-primary-800', color.scale[800]);
+		root.style.setProperty('--color-primary-900', color.scale[900]);
+		root.style.setProperty('--color-primary-950', color.scale[950]);
+	}
+
+	onMount(() => {
+		// View accent color takes priority over profile accent color
+		const accentColor = data.view?.accent_color || data.profile?.accent_color;
+		if (accentColor) {
+			applyAccentColor(accentColor as AccentColor);
+		}
+	});
 
 	// Default section order (fallback when no custom order is specified)
 	const DEFAULT_SECTION_ORDER = ['experience', 'projects', 'education', 'certifications', 'skills', 'posts', 'talks'];

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -6,6 +6,7 @@
 	import { toasts } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import { dndzone, TRIGGERS, SHADOW_PLACEHOLDER_ITEM_ID } from 'svelte-dnd-action';
+	import { ACCENT_COLORS, ACCENT_COLOR_LIST, type AccentColor } from '$lib/colors';
 	import { flip } from 'svelte/animate';
 	import ViewPreview from '$components/admin/ViewPreview.svelte';
 
@@ -44,6 +45,7 @@
 	let ctaUrl = '';
 	let isActive = true;
 	let isDefault = false;
+	let accentColor: AccentColor | null = null; // null = inherit from global
 
 	// Sections configuration with itemConfig, layout, and width support
 	let sections: Record<string, {
@@ -136,6 +138,9 @@
 				filter: 'is_default = true'
 			});
 			isDefault = defaultViews.items.length > 0 && defaultViews.items[0].id === viewId;
+
+			// Load accent color (null = inherit from global)
+			accentColor = (view.accent_color as AccentColor) || null;
 
 			// Initialize sections from view data
 			initializeSections(view.sections);
@@ -327,7 +332,8 @@
 				cta_text: ctaText.trim() || null,
 				cta_url: ctaUrl.trim() || null,
 				is_active: isActive,
-				sections: sectionsData
+				sections: sectionsData,
+				accent_color: accentColor || null
 			};
 
 			await pb.collection('views').update(viewId, data);
@@ -686,6 +692,64 @@
 					</div>
 				</div>
 
+				<!-- Accent Color Override -->
+				<div class="pt-2">
+					<span class="label mb-3 block">Accent Color</span>
+					<div class="flex flex-wrap items-center gap-3" role="group" aria-label="Select accent color">
+						<!-- Use Global Option -->
+						<button
+							type="button"
+							class="flex items-center gap-2 px-3 py-2 rounded-lg border transition-all
+								{accentColor === null
+								? 'border-gray-900 dark:border-white bg-gray-100 dark:bg-gray-800'
+								: 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'}"
+							on:click={() => accentColor = null}
+						>
+							<div class="w-5 h-5 rounded-full bg-gradient-to-r from-primary-400 to-primary-600 border-2 border-white shadow-sm"></div>
+							<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Use global</span>
+							{#if accentColor === null}
+								<svg class="w-4 h-4 text-gray-900 dark:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+								</svg>
+							{/if}
+						</button>
+
+						<!-- Color Swatches -->
+						{#each ACCENT_COLOR_LIST as color}
+							{@const colorInfo = ACCENT_COLORS[color]}
+							<button
+								type="button"
+								class="relative group"
+								on:click={() => accentColor = color}
+								title="{colorInfo.label} - {colorInfo.description}"
+							>
+								<div
+									class="w-10 h-10 rounded-lg transition-all duration-200 ring-offset-2 ring-offset-white dark:ring-offset-gray-900
+										{accentColor === color
+										? 'ring-2 ring-gray-900 dark:ring-white scale-110'
+										: 'hover:scale-105'}"
+									style="background-color: {colorInfo.scale[500]}"
+								>
+									{#if accentColor === color}
+										<div class="absolute inset-0 flex items-center justify-center">
+											<svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+												<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+											</svg>
+										</div>
+									{/if}
+								</div>
+							</button>
+						{/each}
+					</div>
+					<p class="text-xs text-gray-500 mt-2">
+						{#if accentColor}
+							Using <strong>{ACCENT_COLORS[accentColor].label}</strong> for this view
+						{:else}
+							Inherits from global profile setting
+						{/if}
+					</p>
+				</div>
+
 				<div class="flex flex-col gap-3 pt-2">
 					<label class="flex items-center gap-3">
 						<input
@@ -950,6 +1014,7 @@
 							{sections}
 							{sectionOrder}
 							{sectionItems}
+							{accentColor}
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
Enable each view to override the global accent color for different audiences:
- Recruiter view → Indigo (professional)
- Speaking view → Rose (energetic)
- Portfolio view → Emerald (creative)

Backend:
- Add migration for optional accent_color field on views collection
- Include accent_color in /api/view/{slug}/data response

View Editor:
- Add accent color selector in Settings section
- "Use global" option to inherit from profile
- Color swatches matching global palette
- Real-time preview updates

Public Pages:
- Apply view accent color on homepage (for default view)
- Apply view accent color on /[slug] routes
- Priority: View > Profile > Default (sky)

Preview:
- ViewPreview component accepts accentColor prop
- Preview shows view-specific color via inline CSS variables