### PR TITLE
feat: Complete rebrand and add mobile preview mode (Phase 6.2.2)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Me.yaml",
+  "name": "Facet",
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".."
@@ -38,18 +38,18 @@
   },
 
   "mounts": [
-    "source=meyaml-node-modules,target=${containerWorkspaceFolder}/frontend/node_modules,type=volume",
-    "source=meyaml-go-cache,target=/go/pkg/mod,type=volume"
+    "source=facet-node-modules,target=${containerWorkspaceFolder}/frontend/node_modules,type=volume",
+    "source=facet-go-cache,target=/go/pkg/mod,type=volume"
   ],
 
   "forwardPorts": [5173, 8090],
   "portsAttributes": {
     "5173": {
-      "label": "Me.yaml (Frontend)",
+      "label": "Facet (Frontend)",
       "onAutoForward": "openBrowser"
     },
     "8090": {
-      "label": "Me.yaml API",
+      "label": "Facet API",
       "onAutoForward": "silent"
     }
   },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -113,7 +113,7 @@
     {
       "label": "build:docker",
       "type": "shell",
-      "command": "docker build -t me-yaml:latest -f docker/Dockerfile .",
+      "command": "docker build -t facet:latest -f docker/Dockerfile .",
       "group": "build",
       "presentation": {
         "reveal": "always"

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -206,7 +206,7 @@
 | 10. Documentation | 🟡 Partial | Core docs done |
 | 11. Testing | 🟡 Partial | Backend tests exist |
 | 12. Print & Export | 🟡 Partial | Print stylesheet + data export complete, AI print deferred |
-| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) + Section widths (6.3) + Accent color (6.5) + Per-view theming (6.6) complete |
+| 13. Visual Layout | 🟡 Partial | Layout presets (6.1) + Live preview (6.2) + Mobile preview (6.2.2) + Section widths (6.3) + Accent color (6.5) + Per-view theming (6.6) complete |
 
 ---
 
@@ -228,7 +228,7 @@
 8. View access log / audit logging (Phase 8)
 9. ~~Data export (JSON/YAML) - Phase 4.4~~ ✅ Complete
 10. ~~Section width & columns (Phase 6.3)~~ ✅ Complete
-11. Mobile preview mode (Phase 6.2.2)
+11. ~~Mobile preview mode (Phase 6.2.2)~~ ✅ Complete
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1073,7 +1073,7 @@ Add side-by-side preview in the view editor for immediate visual feedback.
 - [x] Preview updates on any change (reactive Svelte bindings)
 - [x] Preview uses actual section components (not mockups)
 - [x] Toggle button to hide preview for more editor space
-- [ ] Mobile preview mode (preview shown at mobile width) — Deferred
+- [x] Mobile preview mode (preview shown at mobile width) — Complete (Phase 6.2.2)
 
 **Implementation Details:**
 - `ViewPreview.svelte` component reuses public section components
@@ -1081,6 +1081,9 @@ Add side-by-side preview in the view editor for immediate visual feedback.
 - Preview rendered in same page (not iframe) for simplicity
 - Responsive layout: side-by-side on desktop, stacked on mobile
 - Preview scales down content for compact display
+- Desktop/Mobile toggle buttons in preview header (Phase 6.2.2)
+- Mobile preview constrains to 375px with phone frame styling
+- Section widths collapse to full-width in mobile mode
 
 #### 6.3 Section Width & Columns (Phase C - Complete) ✅
 

--- a/backend/hooks/export.go
+++ b/backend/hooks/export.go
@@ -60,7 +60,7 @@ func RegisterExportHooks(app *pocketbase.PocketBase) {
 
 			// Generate filename with timestamp
 			timestamp := time.Now().Format("2006-01-02")
-			filename := fmt.Sprintf("me-yaml-export-%s.%s", timestamp, format)
+			filename := fmt.Sprintf("facet-export-%s.%s", timestamp, format)
 
 			if format == "yaml" {
 				return serveYAML(e, exportData, filename)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "me-yaml-frontend",
+  "name": "facet-frontend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "me-yaml-frontend",
+      "name": "facet-frontend",
       "version": "1.0.0",
       "dependencies": {
         "dompurify": "^3.0.0",

--- a/frontend/src/components/admin/ViewPreview.svelte
+++ b/frontend/src/components/admin/ViewPreview.svelte
@@ -11,6 +11,7 @@
 	 * - Filters items based on selection
 	 * - Respects section order and layouts
 	 * - Scaled-down for side-by-side editing
+	 * - Desktop/Mobile preview mode toggle (Phase 6.2.2)
 	 */
 	import type {
 		Profile,
@@ -40,6 +41,7 @@
 	export let heroSummary: string = '';
 	export let ctaText: string = '';
 	export let ctaUrl: string = '';
+	export let previewMode: 'desktop' | 'mobile' = 'desktop'; // Phase 6.2.2: Desktop or mobile preview
 
 	// Section configuration from editor (with width support for Phase 6.3)
 	export let sections: Record<
@@ -180,7 +182,7 @@
 	})() : '';
 </script>
 
-<div class="preview-container" style={accentStyles}>
+<div class="preview-container" class:preview-mobile={previewMode === 'mobile'} style={accentStyles}>
 	<!-- Mini Hero -->
 	{#if effectiveProfile}
 		<div class="preview-hero">
@@ -285,10 +287,41 @@
 		box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
 		max-height: calc(100vh - 200px);
 		overflow-y: auto;
+		transition: max-width 0.2s ease-in-out;
+	}
+
+	/* Phase 6.2.2: Mobile preview mode */
+	.preview-container.preview-mobile {
+		max-width: 375px;
+		margin-left: auto;
+		margin-right: auto;
+		border: 2px solid rgb(107 114 128); /* gray-500 */
+		border-radius: 1.5rem;
+		padding-top: 1rem;
+		padding-bottom: 0.5rem;
+	}
+
+	/* Phone notch simulation for mobile preview */
+	.preview-container.preview-mobile::before {
+		content: '';
+		display: block;
+		width: 120px;
+		height: 24px;
+		margin: 0 auto 0.5rem;
+		background: rgb(17 24 39);
+		border-radius: 12px;
 	}
 
 	:global(.dark) .preview-container {
 		background: rgb(17 24 39);
+	}
+
+	:global(.dark) .preview-container.preview-mobile {
+		border-color: rgb(75 85 99); /* gray-600 */
+	}
+
+	:global(.dark) .preview-container.preview-mobile::before {
+		background: rgb(31 41 55);
 	}
 
 	/* Scale down the hero for preview */
@@ -371,6 +404,23 @@
 	/* Third width: spans 2 columns (33%) */
 	.section-third {
 		grid-column: span 2;
+	}
+
+	/* Phase 6.2.2: Mobile preview forces all sections to full width */
+	.preview-mobile .section-half,
+	.preview-mobile .section-third {
+		grid-column: span 6;
+	}
+
+	/* Mobile preview: single-column grid layout */
+	.preview-mobile .preview-sections-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.preview-mobile .section-full,
+	.preview-mobile .section-half,
+	.preview-mobile .section-third {
+		grid-column: span 1;
 	}
 
 	/* Scale down sections for preview */

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -250,7 +250,7 @@
 
 			// Get filename from Content-Disposition header or use default
 			const disposition = response.headers.get('Content-Disposition');
-			let filename = `me-yaml-export.${format}`;
+			let filename = `facet-export.${format}`;
 			if (disposition) {
 				const match = disposition.match(/filename="?([^"]+)"?/);
 				if (match) filename = match[1];

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -33,6 +33,7 @@
 
 	// Preview panel state
 	let showPreview = true;
+	let previewMode: 'desktop' | 'mobile' = 'desktop'; // Phase 6.2.2
 
 	// Form fields
 	let name = '';
@@ -1010,7 +1011,29 @@
 					<div class="sticky top-4">
 						<div class="flex items-center justify-between mb-3 px-1">
 							<h2 class="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">Live Preview</h2>
-							<span class="text-xs text-gray-400">Updates as you edit</span>
+							<!-- Phase 6.2.2: Desktop/Mobile toggle -->
+							<div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-0.5">
+								<button
+									type="button"
+									class="px-2 py-1 text-xs rounded-md transition-colors {previewMode === 'desktop' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+									on:click={() => previewMode = 'desktop'}
+									title="Desktop preview"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+									</svg>
+								</button>
+								<button
+									type="button"
+									class="px-2 py-1 text-xs rounded-md transition-colors {previewMode === 'mobile' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+									on:click={() => previewMode = 'mobile'}
+									title="Mobile preview"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+									</svg>
+								</button>
+							</div>
 						</div>
 						<ViewPreview
 							{profile}
@@ -1022,6 +1045,7 @@
 							{sectionOrder}
 							{sectionItems}
 							{accentColor}
+							{previewMode}
 						/>
 					</div>
 				</div>

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -29,6 +29,7 @@
 
 	// Preview panel state
 	let showPreview = true;
+	let previewMode: 'desktop' | 'mobile' = 'desktop'; // Phase 6.2.2
 
 	// Form fields
 	let name = '';
@@ -714,7 +715,29 @@
 					<div class="sticky top-4">
 						<div class="flex items-center justify-between mb-3 px-1">
 							<h2 class="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">Live Preview</h2>
-							<span class="text-xs text-gray-400">Updates as you edit</span>
+							<!-- Phase 6.2.2: Desktop/Mobile toggle -->
+							<div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-0.5">
+								<button
+									type="button"
+									class="px-2 py-1 text-xs rounded-md transition-colors {previewMode === 'desktop' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+									on:click={() => previewMode = 'desktop'}
+									title="Desktop preview"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+									</svg>
+								</button>
+								<button
+									type="button"
+									class="px-2 py-1 text-xs rounded-md transition-colors {previewMode === 'mobile' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+									on:click={() => previewMode = 'mobile'}
+									title="Mobile preview"
+								>
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+									</svg>
+								</button>
+							</div>
 						</div>
 						<ViewPreview
 							{profile}
@@ -725,6 +748,7 @@
 							{sections}
 							{sectionOrder}
 							{sectionItems}
+							{previewMode}
 						/>
 					</div>
 				</div>

--- a/scripts/dev-backend.sh
+++ b/scripts/dev-backend.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Me.yaml Backend Development Script
+# Facet Backend Development Script
 # Optimized startup: only runs go mod tidy when go.mod/go.sum change
 #
 # Usage: ./scripts/dev-backend.sh
@@ -102,7 +102,7 @@ fi
 # This prevents stale compiled code from being used
 if [[ "$FIRST_RUN" == "true" ]]; then
     echo "[backend] First run detected - cleaning build cache for fresh compilation..."
-    rm -rf "$PROJECT_ROOT/tmp/me-yaml" 2>/dev/null || true
+    rm -rf "$PROJECT_ROOT/tmp/facet" 2>/dev/null || true
     go clean -cache 2>/dev/null || true
 fi
 
@@ -116,7 +116,7 @@ fi
 echo "[backend] Starting air with hot reload..."
 echo "[backend] Config: $PROJECT_ROOT/.air.toml"
 echo "[backend] Watching: $BACKEND_DIR"
-echo "[backend] Build output: $PROJECT_ROOT/tmp/me-yaml"
+echo "[backend] Build output: $PROJECT_ROOT/tmp/facet"
 echo "[backend] PocketBase data: $DATA_DIR"
 echo ""
 

--- a/scripts/dev-frontend.sh
+++ b/scripts/dev-frontend.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Me.yaml Frontend Development Script
+# Facet Frontend Development Script
 # Optimized startup: only installs dependencies when lockfile changes
 #
 # Usage: ./scripts/dev-frontend.sh


### PR DESCRIPTION
Rebrand completion:
- Update export filenames from me-yaml to facet
- Update devcontainer name and volume names to Facet
- Update dev scripts comments and paths
- Update Docker build tag to facet:latest

Mobile Preview Mode (Phase 6.2.2):
- Add Desktop/Mobile toggle in live preview header
- Mobile mode constrains preview to 375px with phone frame styling
- Section widths collapse to full-width in mobile mode
- Smooth transition animation between modes