### PR TITLE
fix: Align post/talk visibility filters and improve back navigation

### DIFF
--- a/frontend/src/components/public/PostsSection.svelte
+++ b/frontend/src/components/public/PostsSection.svelte
@@ -4,6 +4,15 @@
 
 	export let items: Post[];
 	export let layout: string = 'grid-3';
+	export let viewSlug: string = '';
+
+	// Build the post URL with optional from parameter for back navigation
+	function getPostUrl(slug: string): string {
+		if (viewSlug) {
+			return `/posts/${slug}?from=${encodeURIComponent(viewSlug)}`;
+		}
+		return `/posts/${slug}`;
+	}
 </script>
 
 <section id="posts" class="mb-16">
@@ -32,7 +41,7 @@
 					<div class="flex items-start justify-between gap-2">
 						<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
 							{#if post.slug}
-								<a href="/posts/{post.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+								<a href={getPostUrl(post.slug)} class="hover:text-primary-600 dark:hover:text-primary-400">
 									{post.title}
 								</a>
 							{:else}
@@ -71,7 +80,7 @@
 					{#if post.slug}
 						<div class="mt-4">
 							<a
-								href="/posts/{post.slug}"
+								href={getPostUrl(post.slug)}
 								class="inline-flex items-center gap-1.5 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
 							>
 								Read more

--- a/frontend/src/components/public/TalksSection.svelte
+++ b/frontend/src/components/public/TalksSection.svelte
@@ -4,6 +4,15 @@
 
 	export let items: Talk[];
 	export let layout: string = 'default';
+	export let viewSlug: string = '';
+
+	// Build the talk URL with optional from parameter for back navigation
+	function getTalkUrl(slug: string): string {
+		if (viewSlug) {
+			return `/talks/${slug}?from=${encodeURIComponent(viewSlug)}`;
+		}
+		return `/talks/${slug}`;
+	}
 
 	// Extract YouTube video ID from various URL formats
 	function getYouTubeId(url: string): string | null {

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -197,11 +197,11 @@
 						</div>
 					{:else if sectionKey === 'posts' && data.sections?.posts?.length > 0}
 						<div class={getWidthClass(getSectionWidth('posts'))}>
-							<PostsSection items={data.sections.posts} layout={getSectionLayout('posts')} />
+							<PostsSection items={data.sections.posts} layout={getSectionLayout('posts')} viewSlug={data.view?.slug || ''} />
 						</div>
 					{:else if sectionKey === 'talks' && data.sections?.talks?.length > 0}
 						<div class={getWidthClass(getSectionWidth('talks'))}>
-							<TalksSection items={data.sections.talks} layout={getSectionLayout('talks')} />
+							<TalksSection items={data.sections.talks} layout={getSectionLayout('talks')} viewSlug={data.view?.slug || ''} />
 						</div>
 					{/if}
 				{/each}

--- a/frontend/src/routes/posts/+page.server.ts
+++ b/frontend/src/routes/posts/+page.server.ts
@@ -1,8 +1,8 @@
 /**
  * Posts index route: /posts
  *
- * Lists all public, non-draft posts with tag filtering.
- * Private/unlisted/draft posts are excluded.
+ * Lists all non-private, non-draft posts with tag filtering.
+ * Only private and draft posts are excluded.
  */
 
 import type { PageServerLoad } from './$types';
@@ -12,8 +12,8 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 	const tag = url.searchParams.get('tag');
 
 	try {
-		// Build filter for public, non-draft posts
-		let filter = "visibility = 'public' && is_draft = false";
+		// Build filter for non-private, non-draft posts (matches profile behavior)
+		let filter = "visibility != 'private' && is_draft = false";
 
 		// Fetch posts from PocketBase
 		const postsResponse = await fetch(

--- a/frontend/src/routes/posts/[slug]/+page.server.ts
+++ b/frontend/src/routes/posts/[slug]/+page.server.ts
@@ -9,9 +9,10 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
+export const load: PageServerLoad = async ({ params, fetch, url }) => {
 	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
 	const { slug } = params;
+	const fromView = url.searchParams.get('from');
 
 	try {
 		const response = await fetch(`${pbUrl}/api/post/${slug}`);
@@ -37,7 +38,8 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			},
 			profile: post.profile || null,
 			prev_post: post.prev_post || null,
-			next_post: post.next_post || null
+			next_post: post.next_post || null,
+			fromView: fromView || null
 		};
 	} catch (err) {
 		if ((err as { status?: number }).status === 404) {

--- a/frontend/src/routes/posts/[slug]/+page.svelte
+++ b/frontend/src/routes/posts/[slug]/+page.svelte
@@ -8,6 +8,10 @@
 
 	// Format the published date
 	$: publishedDate = data.post.published_at ? formatDate(data.post.published_at) : null;
+
+	// Determine back navigation URL and label
+	$: backUrl = data.fromView ? `/${data.fromView}` : '/';
+	$: backLabel = data.fromView ? 'Back to Profile' : 'Back to Profile';
 </script>
 
 <svelte:head>
@@ -48,13 +52,13 @@
 		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
 			<!-- Back navigation -->
 			<a
-				href="/"
+				href={backUrl}
 				class="inline-flex items-center gap-2 text-gray-300 hover:text-white mb-6 transition-colors"
 			>
 				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
 				</svg>
-				<span>Back to Profile</span>
+				<span>{backLabel}</span>
 			</a>
 
 			<!-- Post title -->

--- a/frontend/src/routes/talks/+page.server.ts
+++ b/frontend/src/routes/talks/+page.server.ts
@@ -1,8 +1,8 @@
 /**
  * Talks index route: /talks
  *
- * Lists all public, non-draft talks with year filtering.
- * Private/unlisted/draft talks are excluded.
+ * Lists all non-private, non-draft talks with year filtering.
+ * Only private and draft talks are excluded.
  */
 
 import type { PageServerLoad } from './$types';
@@ -12,8 +12,8 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 	const year = url.searchParams.get('year');
 
 	try {
-		// Build filter for public, non-draft talks
-		const filter = "visibility = 'public' && is_draft = false";
+		// Build filter for non-private, non-draft talks (matches profile behavior)
+		const filter = "visibility != 'private' && is_draft = false";
 
 		// Fetch talks from PocketBase
 		const talksResponse = await fetch(

--- a/frontend/src/routes/talks/[slug]/+page.server.ts
+++ b/frontend/src/routes/talks/[slug]/+page.server.ts
@@ -9,9 +9,10 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
+export const load: PageServerLoad = async ({ params, fetch, url }) => {
 	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
 	const { slug } = params;
+	const fromView = url.searchParams.get('from');
 
 	try {
 		const response = await fetch(`${pbUrl}/api/talk/${slug}`);
@@ -39,7 +40,8 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			},
 			profile: talk.profile || null,
 			prev_talk: talk.prev_talk || null,
-			next_talk: talk.next_talk || null
+			next_talk: talk.next_talk || null,
+			fromView: fromView || null
 		};
 	} catch (err) {
 		if ((err as { status?: number }).status === 404) {

--- a/frontend/src/routes/talks/[slug]/+page.svelte
+++ b/frontend/src/routes/talks/[slug]/+page.svelte
@@ -38,6 +38,10 @@
 
 	$: videoEmbed = data.talk.video_url ? getVideoEmbed(data.talk.video_url) : null;
 	$: formattedDate = data.talk.date ? formatDate(data.talk.date, { month: 'long', day: 'numeric', year: 'numeric' }) : null;
+
+	// Determine back navigation URL and label
+	$: backUrl = data.fromView ? `/${data.fromView}` : '/talks';
+	$: backLabel = data.fromView ? 'Back to Profile' : 'All Talks';
 </script>
 
 <svelte:head>
@@ -76,13 +80,13 @@
 		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
 			<!-- Back navigation -->
 			<a
-				href="/talks"
+				href={backUrl}
 				class="inline-flex items-center gap-2 text-gray-300 hover:text-white mb-6 transition-colors"
 			>
 				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
 				</svg>
-				<span>All Talks</span>
+				<span>{backLabel}</span>
 			</a>
 
 			<!-- Talk title -->


### PR DESCRIPTION
- Update posts index page to use visibility != 'private' filter (matches profile behavior, allows unlisted items to appear)
- Update talks index page with same visibility filter fix
- Add viewSlug prop to PostsSection and TalksSection components
- Pass viewSlug from view pages to section components
- Add ?from= query parameter to post/talk links from views
- Update individual post/talk pages to read from parameter
- Back buttons now route correctly to source view