### PR TITLE
fix: Add e.Next() to AI provider hooks to persist records

### DIFF
--- a/backend/hooks/ai.go
+++ b/backend/hooks/ai.go
@@ -198,12 +198,19 @@ func RegisterAIHooks(app *pocketbase.PocketBase, ai *services.AIService, crypto 
 	})
 
 	// Hook to encrypt API keys before saving
+	// NOTE: Must call e.Next() to continue the hook chain in PocketBase v0.23+
 	app.OnRecordCreate("ai_providers").BindFunc(func(e *core.RecordEvent) error {
-		return encryptProviderKey(e.Record, crypto)
+		if err := encryptProviderKey(e.Record, crypto); err != nil {
+			return err
+		}
+		return e.Next()
 	})
 
 	app.OnRecordUpdate("ai_providers").BindFunc(func(e *core.RecordEvent) error {
-		return encryptProviderKey(e.Record, crypto)
+		if err := encryptProviderKey(e.Record, crypto); err != nil {
+			return err
+		}
+		return e.Next()
 	})
 }
 


### PR DESCRIPTION
The OnRecordCreate and OnRecordUpdate hooks for ai_providers were missing the required e.Next() call. In PocketBase v0.23+, hooks using BindFunc must explicitly call e.Next() to continue the hook chain, otherwise the record modification silently aborts.

This caused AI providers added via Settings to appear saved but not actually persist to the database.

Also adds documentation about this PocketBase v0.23 gotcha to DEV.md.