### PR TITLE
fix: Remove Hidden flag from api_key field to allow API requests

### DIFF
--- a/backend/migrations/1735600000_init.go
+++ b/backend/migrations/1735600000_init.go
@@ -263,7 +263,7 @@ func init() {
 			aiCollection := core.NewBaseCollection("ai_providers")
 			aiCollection.Fields.Add(&core.TextField{Name: "name", Required: true, Max: 200})
 			aiCollection.Fields.Add(&core.SelectField{Name: "type", Values: []string{"openai", "anthropic", "ollama", "custom"}, Required: true, MaxSelect: 1})
-			aiCollection.Fields.Add(&core.TextField{Name: "api_key", Hidden: true})
+			aiCollection.Fields.Add(&core.TextField{Name: "api_key"}) // NOT hidden - needs to be received in requests
 			aiCollection.Fields.Add(&core.TextField{Name: "api_key_encrypted", Hidden: true})
 			aiCollection.Fields.Add(&core.URLField{Name: "base_url"})
 			aiCollection.Fields.Add(&core.TextField{Name: "model", Max: 100})

--- a/backend/migrations/1735600008_fix_api_key_hidden.go
+++ b/backend/migrations/1735600008_fix_api_key_hidden.go
@@ -1,0 +1,43 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("ai_providers")
+		if err != nil {
+			return nil // Collection doesn't exist yet, skip
+		}
+
+		// Find and update the api_key field to not be hidden
+		// Hidden fields can't be received in API requests, which breaks our encryption flow
+		for _, field := range collection.Fields {
+			if field.GetName() == "api_key" {
+				if textField, ok := field.(*core.TextField); ok {
+					textField.Hidden = false
+				}
+			}
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		// Rollback: make api_key hidden again
+		collection, err := app.FindCollectionByNameOrId("ai_providers")
+		if err != nil {
+			return nil
+		}
+
+		for _, field := range collection.Fields {
+			if field.GetName() == "api_key" {
+				if textField, ok := field.(*core.TextField); ok {
+					textField.Hidden = true
+				}
+			}
+		}
+
+		return app.Save(collection)
+	})
+}


### PR DESCRIPTION
PocketBase Hidden: true prevents fields from being received in API requests, not just from being returned. This caused api_key to be silently dropped from create/update requests, so the encryption hook never received the value.

- Added migration to remove Hidden from api_key for existing DBs
- Updated init migration for new installs
- api_key_encrypted remains hidden (only stores encrypted value)