### PR TITLE
debug: Add verbose logging to posts/talks/homepage APIs and page loaders

### DIFF
--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -13,53 +13,69 @@
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch }) => {
+	console.log('[ROOT PAGE] ========== LOAD START ==========');
+
 	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
+	console.log('[ROOT PAGE] pbUrl:', pbUrl);
 
 	try {
 		// Check if there's a default view configured
+		console.log('[ROOT PAGE] Fetching default-view...');
 		const defaultViewResponse = await fetch(`${pbUrl}/api/default-view`);
+		console.log('[ROOT PAGE] default-view response status:', defaultViewResponse.status);
 
 		if (defaultViewResponse.ok) {
 			const defaultViewInfo = await defaultViewResponse.json();
+			console.log('[ROOT PAGE] default-view info:', JSON.stringify(defaultViewInfo));
 
 			if (defaultViewInfo.has_default && defaultViewInfo.slug) {
+				console.log('[ROOT PAGE] Has default view, fetching view data for slug:', defaultViewInfo.slug);
 				// Fetch the default view's data
 				const viewDataResponse = await fetch(`${pbUrl}/api/view/${defaultViewInfo.slug}/data`);
+				console.log('[ROOT PAGE] view data response status:', viewDataResponse.status);
 
 				if (viewDataResponse.ok) {
 					const viewData = await viewDataResponse.json();
+					console.log('[ROOT PAGE] view data received, sections:', Object.keys(viewData.sections || {}));
 
 					// Return data in a format compatible with both view and homepage layouts
 					const profile = viewData.profile || null;
+					console.log('[ROOT PAGE] Profile from view:', profile ? profile.name : 'null');
 
 					// Get posts and talks from view sections
 					let posts = viewData.sections?.posts || [];
 					let talks = viewData.sections?.talks || [];
+					console.log('[ROOT PAGE] From view sections - posts:', posts.length, 'talks:', talks.length);
 
 					// If posts/talks aren't in the view's sections, fetch them from the homepage API
 					// This ensures posts/talks always appear on the profile even if the view
 					// doesn't explicitly include them as sections
 					if (posts.length === 0 || talks.length === 0) {
+						console.log('[ROOT PAGE] Posts/talks empty, fetching from homepage API...');
 						try {
 							const homepageResponse = await fetch(`${pbUrl}/api/homepage`);
+							console.log('[ROOT PAGE] homepage fallback response status:', homepageResponse.status);
 							if (homepageResponse.ok) {
 								const homepageData = await homepageResponse.json();
+								console.log('[ROOT PAGE] homepage data - posts:', (homepageData.posts || []).length, 'talks:', (homepageData.talks || []).length);
 								if (posts.length === 0 && homepageData.posts) {
 									posts = homepageData.posts.map((p: Record<string, unknown>) => ({
 										...p,
 										cover_image: p.cover_image_url || null
 									}));
+									console.log('[ROOT PAGE] Populated posts from homepage:', posts.length);
 								}
 								if (talks.length === 0 && homepageData.talks) {
 									talks = homepageData.talks;
+									console.log('[ROOT PAGE] Populated talks from homepage:', talks.length);
 								}
 							}
-						} catch {
-							// Ignore errors - posts/talks are optional
+						} catch (fallbackErr) {
+							console.log('[ROOT PAGE] Homepage fallback error (ignored):', fallbackErr);
 						}
 					}
 
-					return {
+					const result = {
 						// View-specific data
 						view: {
 							id: viewData.id,
@@ -92,15 +108,30 @@ export const load: PageServerLoad = async ({ fetch }) => {
 						// Indicate this is a view-based homepage
 						isDefaultView: true
 					};
+					console.log('[ROOT PAGE] Returning DEFAULT VIEW data:');
+					console.log('[ROOT PAGE]   view.slug:', result.view.slug);
+					console.log('[ROOT PAGE]   profile:', result.profile?.name);
+					console.log('[ROOT PAGE]   experience:', result.experience.length);
+					console.log('[ROOT PAGE]   projects:', result.projects.length);
+					console.log('[ROOT PAGE]   education:', result.education.length);
+					console.log('[ROOT PAGE]   certifications:', result.certifications.length);
+					console.log('[ROOT PAGE]   skills:', result.skills.length);
+					console.log('[ROOT PAGE]   posts:', result.posts.length);
+					console.log('[ROOT PAGE]   talks:', result.talks.length);
+					console.log('[ROOT PAGE] ========== LOAD END (default view) ==========');
+					return result;
 				}
 			}
 		}
 
 		// Fallback: No default view or failed to load - use legacy homepage
+		console.log('[ROOT PAGE] No default view, using legacy homepage API...');
 		const response = await fetch(`${pbUrl}/api/homepage`);
+		console.log('[ROOT PAGE] homepage response status:', response.status);
 
 		if (!response.ok) {
-			console.error('Homepage API error:', response.status);
+			const errorText = await response.text();
+			console.error('[ROOT PAGE] Homepage API error:', response.status, errorText);
 			return {
 				profile: null,
 				experience: [],
@@ -115,9 +146,19 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		}
 
 		const data = await response.json();
+		console.log('[ROOT PAGE] Homepage data received:');
+		console.log('[ROOT PAGE]   profile:', data.profile?.name || 'null');
+		console.log('[ROOT PAGE]   experience:', (data.experience || []).length);
+		console.log('[ROOT PAGE]   projects:', (data.projects || []).length);
+		console.log('[ROOT PAGE]   education:', (data.education || []).length);
+		console.log('[ROOT PAGE]   skills:', (data.skills || []).length);
+		console.log('[ROOT PAGE]   posts:', (data.posts || []).length);
+		console.log('[ROOT PAGE]   talks:', (data.talks || []).length);
+		console.log('[ROOT PAGE]   certifications:', (data.certifications || []).length);
 
 		// Check if profile is private
 		if (!data.profile) {
+			console.log('[ROOT PAGE] No profile in response - profile is private or missing');
 			return {
 				profile: null,
 				experience: [],
@@ -150,7 +191,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			cover_image: p.cover_image_url || null
 		}));
 
-		return {
+		const result = {
 			profile,
 			experience: data.experience || [],
 			projects,
@@ -162,8 +203,17 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			// Indicate this is legacy homepage mode
 			isDefaultView: false
 		};
+		console.log('[ROOT PAGE] Returning LEGACY homepage data:');
+		console.log('[ROOT PAGE]   isDefaultView:', result.isDefaultView);
+		console.log('[ROOT PAGE]   profile:', result.profile?.name);
+		console.log('[ROOT PAGE]   experience:', result.experience.length);
+		console.log('[ROOT PAGE]   projects:', result.projects.length);
+		console.log('[ROOT PAGE]   posts:', result.posts.length);
+		console.log('[ROOT PAGE]   talks:', result.talks.length);
+		console.log('[ROOT PAGE] ========== LOAD END (legacy) ==========');
+		return result;
 	} catch (error) {
-		console.error('Failed to load profile data:', error);
+		console.error('[ROOT PAGE] EXCEPTION:', error);
 		return {
 			profile: null,
 			experience: [],

--- a/frontend/src/routes/talks/+page.server.ts
+++ b/frontend/src/routes/talks/+page.server.ts
@@ -8,16 +8,28 @@
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch, url }) => {
+	console.log('[TALKS PAGE] ========== LOAD START ==========');
+	console.log('[TALKS PAGE] URL:', url.toString());
+
 	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
 	const year = url.searchParams.get('year');
 	const fromView = url.searchParams.get('from');
 
+	console.log('[TALKS PAGE] pbUrl:', pbUrl);
+	console.log('[TALKS PAGE] year:', year);
+	console.log('[TALKS PAGE] fromView:', fromView);
+
 	try {
 		// Use custom API endpoint that bypasses collection access rules
-		const response = await fetch(`${pbUrl}/api/talks`);
+		const apiUrl = `${pbUrl}/api/talks`;
+		console.log('[TALKS PAGE] Fetching:', apiUrl);
+
+		const response = await fetch(apiUrl);
+		console.log('[TALKS PAGE] Response status:', response.status);
 
 		if (!response.ok) {
-			console.error('Talks API error:', response.status);
+			const errorText = await response.text();
+			console.error('[TALKS PAGE] API error:', response.status, errorText);
 			return {
 				talks: [],
 				profile: null,
@@ -28,8 +40,13 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 		}
 
 		const data = await response.json();
+		console.log('[TALKS PAGE] API response data:', JSON.stringify(data, null, 2));
+
 		let talks = data.talks || [];
 		const profile = data.profile || null;
+
+		console.log('[TALKS PAGE] Talks count:', talks.length);
+		console.log('[TALKS PAGE] Profile:', profile);
 
 		// Get unique years from all talks for filter UI (before filtering)
 		const allYears = new Set<string>();
@@ -41,21 +58,27 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 
 		// If year filter is specified, filter client-side
 		if (year) {
+			const beforeFilter = talks.length;
 			talks = talks.filter((talk: { date?: string }) => {
 				if (!talk.date) return false;
 				return new Date(talk.date).getFullYear().toString() === year;
 			});
+			console.log('[TALKS PAGE] Filtered by year:', year, 'from', beforeFilter, 'to', talks.length);
 		}
 
-		return {
+		const result = {
 			talks,
 			profile,
 			selectedYear: year,
 			allYears: Array.from(allYears).sort((a, b) => parseInt(b) - parseInt(a)), // Descending
 			fromView: fromView || null
 		};
+		console.log('[TALKS PAGE] Returning:', JSON.stringify({ ...result, talks: `[${talks.length} items]` }));
+		console.log('[TALKS PAGE] ========== LOAD END ==========');
+
+		return result;
 	} catch (err) {
-		console.error('Failed to load talks:', err);
+		console.error('[TALKS PAGE] EXCEPTION:', err);
 		return {
 			talks: [],
 			profile: null,


### PR DESCRIPTION
Extensive logging added to debug posts/talks visibility issues:
- Backend: /api/posts, /api/talks, /api/homepage endpoints
- Frontend: posts page loader, talks page loader, root page loader

All logs prefixed with [API ...] or [... PAGE] for easy filtering.