### PR TITLE
fix: Fix AI provider creation and GOSUMDB setting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,8 +33,7 @@
 
   "containerEnv": {
     "ENCRYPTION_KEY": "devcontainer-only-key-do-not-use-in-production!!",
-    "GOPROXY": "https://goproxy.cn,https://proxy.golang.org,direct",
-    "GOSUMDB": "off"
+    "GOPROXY": "https://goproxy.cn,https://proxy.golang.org,direct"
   },
 
   "mounts": [


### PR DESCRIPTION
- Remove GOSUMDB=off from devcontainer.json (was blocking gopls install)
- Fix AI provider creation by not sending empty base_url field (URLField validation rejects empty strings)
- Add debug logging for provider creation payload