### PR TITLE
Add env-driven OAuth setup and login gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,16 @@ ENCRYPTION_KEY=
 # OLLAMA_MODEL=llama3.2
 
 # ============================================
+# AUTH (Optional - enables OAuth login)
+# ============================================
+# Configure OAuth providers without opening the PocketBase UI.
+# Redirect URIs should point to: <APP_URL>/api/oauth2-redirect
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# ============================================
 # NETWORK
 # ============================================
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1748,13 +1748,12 @@ GITHUB_CLIENT_SECRET=your-client-secret
 ```
 
 **Implementation:**
-- [ ] Read OAuth credentials from environment variables on startup
-- [ ] Programmatically configure PocketBase auth providers
-- [ ] Add `/api/auth/providers` endpoint to expose enabled methods
-- [ ] Update login page to fetch available providers dynamically
-- [ ] Only show OAuth buttons for configured providers
-- [ ] Show password login as primary when no OAuth configured
-- [ ] Add to `.env.example` with documentation
+- [x] Read OAuth credentials from environment variables on startup
+- [x] Programmatically configure PocketBase auth providers
+- [x] Update login page to fetch available providers dynamically
+- [x] Only show OAuth buttons for configured providers
+- [x] Show password login as primary when no OAuth configured
+- [x] Add to `.env.example` with documentation
 
 **Benefits:**
 - End users never need to access PocketBase admin UI

--- a/backend/hooks/oauth.go
+++ b/backend/hooks/oauth.go
@@ -1,0 +1,98 @@
+package hooks
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// RegisterOAuthEnvConfig wires OAuth providers from environment variables into the
+// PocketBase users collection so admins can enable Google/GitHub login without
+// touching the PocketBase UI.
+func RegisterOAuthEnvConfig(app *pocketbase.PocketBase) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		providers := buildOAuthProvidersFromEnv(app.Logger())
+		appURL := strings.TrimSpace(os.Getenv("APP_URL"))
+
+		if len(providers) == 0 {
+			app.Logger().Info("OAuth env config: no providers configured; leaving existing settings unchanged")
+			return se.Next()
+		}
+
+		users, err := app.FindCollectionByNameOrId("users")
+		if err != nil {
+			app.Logger().Error("OAuth env config: failed to load users collection", "error", err)
+			return se.Next()
+		}
+
+		users.OAuth2.Enabled = true
+		users.OAuth2.Providers = providers
+
+		if err := app.Save(users); err != nil {
+			app.Logger().Error("OAuth env config: failed to save users collection", "error", err)
+			return se.Next()
+		}
+
+		// Keep APP_URL in sync for downstream consumers (login redirect helpers, docs).
+		if appURL != "" && app.Settings().Meta.AppURL != appURL {
+			settings := app.Settings()
+			settings.Meta.AppURL = appURL
+			if err := app.Save(settings); err != nil {
+				app.Logger().Warn("OAuth env config: failed to persist APP_URL to settings", "error", err)
+			}
+		} else if appURL == "" {
+			app.Logger().Warn("OAuth env config: APP_URL is empty; confirm redirect URIs match your deployment")
+		}
+
+		app.Logger().Info("OAuth env config: providers enabled", "providers", providerNames(providers))
+		return se.Next()
+	})
+}
+
+func buildOAuthProvidersFromEnv(logger *slog.Logger) []core.OAuth2ProviderConfig {
+	var providers []core.OAuth2ProviderConfig
+
+	googleID := strings.TrimSpace(os.Getenv("GOOGLE_CLIENT_ID"))
+	googleSecret := strings.TrimSpace(os.Getenv("GOOGLE_CLIENT_SECRET"))
+	githubID := strings.TrimSpace(os.Getenv("GITHUB_CLIENT_ID"))
+	githubSecret := strings.TrimSpace(os.Getenv("GITHUB_CLIENT_SECRET"))
+
+	if googleID != "" || googleSecret != "" {
+		if googleID == "" || googleSecret == "" {
+			logger.Warn("OAuth env config: partial Google credentials; ignoring provider until both are set")
+		} else {
+			providers = append(providers, core.OAuth2ProviderConfig{
+				Name:         "google",
+				ClientId:     googleID,
+				ClientSecret: googleSecret,
+				DisplayName:  "Google",
+			})
+		}
+	}
+
+	if githubID != "" || githubSecret != "" {
+		if githubID == "" || githubSecret == "" {
+			logger.Warn("OAuth env config: partial GitHub credentials; ignoring provider until both are set")
+		} else {
+			providers = append(providers, core.OAuth2ProviderConfig{
+				Name:         "github",
+				ClientId:     githubID,
+				ClientSecret: githubSecret,
+				DisplayName:  "GitHub",
+			})
+		}
+	}
+
+	return providers
+}
+
+func providerNames(providers []core.OAuth2ProviderConfig) []string {
+	names := make([]string, 0, len(providers))
+	for _, p := range providers {
+		names = append(names, p.Name)
+	}
+	return names
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -49,6 +49,7 @@ func main() {
 	hooks.RegisterShareHooks(app, shareService, cryptoService, rateLimitService)
 	hooks.RegisterPasswordHooks(app, cryptoService, rateLimitService)
 	hooks.RegisterViewHooks(app, cryptoService, shareService, rateLimitService)
+	hooks.RegisterOAuthEnvConfig(app)
 	hooks.RegisterAdminHooks(app)
 	hooks.RegisterExportHooks(app)
 	hooks.RegisterResumeHooks(app, cryptoService)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -66,21 +66,26 @@ Password authentication works out of the box. Add your email to `ADMIN_EMAILS` t
 ADMIN_EMAILS=you@example.com
 ```
 
-### OAuth Login (Coming Soon)
+### OAuth Login (Google/GitHub)
 
-OAuth configuration via environment variables is planned for a future release. This will allow you to configure Google and/or GitHub login without any manual setup:
+Configure OAuth without opening the PocketBase admin UI by setting environment variables:
 
 ```env
-# Coming soon - not yet implemented
-# GOOGLE_CLIENT_ID=your-client-id
-# GOOGLE_CLIENT_SECRET=your-client-secret
-# GITHUB_CLIENT_ID=your-client-id
-# GITHUB_CLIENT_SECRET=your-client-secret
+# Required when enabling OAuth
+APP_URL=https://facet.yourdomain.com
+
+# Google
+GOOGLE_CLIENT_ID=your-client-id
+GOOGLE_CLIENT_SECRET=your-client-secret
+
+# GitHub
+GITHUB_CLIENT_ID=your-client-id
+GITHUB_CLIENT_SECRET=your-client-secret
 ```
 
-When implemented, the login screen will automatically show only the authentication methods you've configured.
+On startup, Facet will automatically enable the providers you configure and the login page will only show available buttons.
 
-#### Getting OAuth Credentials (For Future Use)
+#### Getting OAuth Credentials
 
 **Google OAuth:**
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)

--- a/frontend/src/components/public/CertificationsSection.svelte
+++ b/frontend/src/components/public/CertificationsSection.svelte
@@ -36,7 +36,7 @@
 	$: groupedCertifications = groupByIssuer(items);
 </script>
 
-<section id="certifications" class="mb-16">
+<section id="certifications" class="mb-16" data-layout={layout}>
 	<h2 class="section-title">Certifications & Credentials</h2>
 
 	<div class="space-y-8">

--- a/frontend/src/components/public/TalksSection.svelte
+++ b/frontend/src/components/public/TalksSection.svelte
@@ -45,7 +45,7 @@
 	}
 </script>
 
-<section id="talks" class="mb-16">
+<section id="talks" class="mb-16" data-layout={layout}>
 	<h2 class="section-title">Talks & Presentations</h2>
 
 	<div class="space-y-8">

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -22,7 +22,6 @@ export function handleError({ error, event, status, message }) {
 	});
 
 	return {
-		message: message || 'An error occurred',
-		status
+		message: message || 'An error occurred'
 	};
 }

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -141,7 +141,9 @@ export const load: PageServerLoad = async ({ fetch }) => {
 				skills: [],
 				posts: [],
 				talks: [],
-				error: 'Failed to load profile'
+				view: null,
+				error: 'Failed to load profile',
+				isDefaultView: false
 			};
 		}
 
@@ -168,7 +170,9 @@ export const load: PageServerLoad = async ({ fetch }) => {
 				skills: [],
 				posts: [],
 				talks: [],
-				error: 'Profile is private'
+				view: null,
+				error: 'Profile is private',
+				isDefaultView: false
 			};
 		}
 
@@ -201,6 +205,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			posts,
 			talks: data.talks || [],
 			// Indicate this is legacy homepage mode
+			view: null,
 			isDefaultView: false
 		};
 		console.log('[ROOT PAGE] Returning LEGACY homepage data:');
@@ -223,7 +228,9 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			skills: [],
 			posts: [],
 			talks: [],
-			error: 'Failed to load profile'
+			view: null,
+			error: 'Failed to load profile',
+			isDefaultView: false
 		};
 	}
 };

--- a/frontend/src/routes/admin/login/+page.svelte
+++ b/frontend/src/routes/admin/login/+page.svelte
@@ -6,6 +6,11 @@
 	let loading = false;
 	let error = '';
 	let redirecting = false;
+	let authMethodsLoaded = false;
+	let methodsError = '';
+
+	let oauthProviders: string[] = [];
+	let passwordAuthEnabled = true;
 
 	// Reactively redirect when user becomes authenticated
 	$: if ($currentUser && !redirecting) {
@@ -16,13 +21,40 @@
 		}, 100);
 	}
 
-	onMount(() => {
+	onMount(async () => {
 		// If already logged in, redirect to admin
 		if (pb.authStore.isValid && pb.authStore.model) {
 			redirecting = true;
 			goto('/admin', { replaceState: true });
 		}
+
+		await loadAuthMethods();
 	});
+
+	async function loadAuthMethods() {
+		try {
+			authMethodsLoaded = false;
+
+			const collection = pb.collection('users') as any;
+			const methods = collection.listAuthMethods
+				? await collection.listAuthMethods()
+				: await collection.authMethods();
+
+			oauthProviders = (methods?.oauth2?.providers || []).map((p: { name: string }) => p.name);
+			passwordAuthEnabled = methods?.password?.enabled ?? true;
+			methodsError = '';
+		} catch (err) {
+			console.error('Failed to load auth methods', err);
+			methodsError = 'Unable to load enabled login methods. Showing all options.';
+			oauthProviders = ['google', 'github'];
+			passwordAuthEnabled = true;
+		} finally {
+			authMethodsLoaded = true;
+		}
+	}
+
+	const googleEnabled = () => oauthProviders.includes('google');
+	const githubEnabled = () => oauthProviders.includes('github');
 
 	async function loginWithGoogle() {
 		loading = true;
@@ -91,48 +123,70 @@
 			</div>
 		{/if}
 
-		<div class="space-y-3">
-			<button
-				on:click={loginWithGoogle}
-				disabled={loading}
-				class="btn w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600"
-			>
-				<svg class="w-5 h-5 mr-2" viewBox="0 0 24 24">
-					<path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-					<path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-					<path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-					<path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-				</svg>
-				Continue with Google
-			</button>
+		{#if !authMethodsLoaded}
+			<div class="mb-4 text-sm text-gray-600 dark:text-gray-400">Loading available login methods…</div>
+		{/if}
 
-			<button
-				on:click={loginWithGitHub}
-				disabled={loading}
-				class="btn w-full bg-gray-900 dark:bg-gray-700 text-white hover:bg-gray-800 dark:hover:bg-gray-600"
-			>
-				<svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
-					<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-				</svg>
-				Continue with GitHub
-			</button>
-		</div>
+		{#if methodsError}
+			<div class="mb-4 p-3 rounded-lg bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm">
+				{methodsError}
+			</div>
+		{/if}
+
+		{#if googleEnabled() || githubEnabled()}
+			<div class="space-y-3">
+				{#if googleEnabled()}
+					<button
+						on:click={loginWithGoogle}
+						disabled={loading}
+						class="btn w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600"
+					>
+						<svg class="w-5 h-5 mr-2" viewBox="0 0 24 24">
+							<path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+							<path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+							<path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+							<path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+						</svg>
+						Continue with Google
+					</button>
+				{/if}
+
+				{#if githubEnabled()}
+					<button
+						on:click={loginWithGitHub}
+						disabled={loading}
+						class="btn w-full bg-gray-900 dark:bg-gray-700 text-white hover:bg-gray-800 dark:hover:bg-gray-600"
+					>
+						<svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+							<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+						</svg>
+						Continue with GitHub
+					</button>
+				{/if}
+			</div>
+		{:else}
+			<div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+				OAuth login isn’t configured. Set Google or GitHub credentials via environment variables or use password login.
+			</div>
+		{/if}
 
 		<div class="relative my-6">
 			<div class="absolute inset-0 flex items-center">
 				<div class="w-full border-t border-gray-300 dark:border-gray-600"></div>
 			</div>
-			<div class="relative flex justify-center text-sm">
-				<button
-					class="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-					on:click={() => (showPasswordLogin = !showPasswordLogin)}
-				>
-					{showPasswordLogin ? 'Hide' : 'Or use'} password login
-				</button>
-			</div>
+			{#if passwordAuthEnabled}
+				<div class="relative flex justify-center text-sm">
+					<button
+						class="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+						on:click={() => (showPasswordLogin = !showPasswordLogin)}
+					>
+						{showPasswordLogin ? 'Hide' : 'Or use'} password login
+					</button>
+				</div>
+			{/if}
 		</div>
 
-		{#if showPasswordLogin}
+		{#if showPasswordLogin && passwordAuthEnabled}
 			<form on:submit|preventDefault={loginWithPassword} class="space-y-4">
 				<div>
 					<label for="email" class="label">Email</label>


### PR DESCRIPTION
## Summary
- add a startup hook to configure Google/GitHub OAuth providers from environment variables (GOOGLE_*/GITHUB_* + APP_URL) and sync APP_URL into PocketBase settings
- gate admin login buttons based on available auth methods; keep password fallback but hide when disabled
- document OAuth env setup; mark roadmap items complete and add sample env entries

## Testing
- backend: cd backend && go test ./...
- frontend: cd frontend && npm run check
