### PR TITLE
Fix project detail back navigation from views

### DIFF
--- a/frontend/src/components/public/ProjectsSection.svelte
+++ b/frontend/src/components/public/ProjectsSection.svelte
@@ -2,8 +2,14 @@
 	import type { Project } from '$lib/pocketbase';
 	import { truncate, parseMarkdown } from '$lib/utils';
 
-	export let items: Project[];
-	export let layout: string = 'grid-3';
+export let items: Project[];
+export let layout: string = 'grid-3';
+export let viewSlug: string = '';
+
+const projectHref = (slug: string | undefined) => {
+	if (!slug) return '#';
+	return viewSlug ? `/projects/${slug}?from=${encodeURIComponent(viewSlug)}` : `/projects/${slug}`;
+};
 
 	function getLinkIcon(type: string) {
 		switch (type.toLowerCase()) {
@@ -51,7 +57,7 @@
 						<div class="flex items-start justify-between gap-2">
 							<h3 class="text-2xl font-semibold text-gray-900 dark:text-white">
 								{#if featuredItem.slug}
-									<a href="/projects/{featuredItem.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+									<a href={projectHref(featuredItem.slug)} class="hover:text-primary-600 dark:hover:text-primary-400">
 										{featuredItem.title}
 									</a>
 								{:else}
@@ -122,7 +128,7 @@
 							<div class="p-5">
 								<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
 									{#if project.slug}
-										<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+										<a href={projectHref(project.slug)} class="hover:text-primary-600 dark:hover:text-primary-400">
 											{project.title}
 										</a>
 									{:else}
@@ -260,7 +266,7 @@
 						<div class="flex items-start justify-between gap-2">
 							<h3 class="text-xl font-semibold text-gray-900 dark:text-white">
 								{#if project.slug}
-									<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+									<a href={projectHref(project.slug)} class="hover:text-primary-600 dark:hover:text-primary-400">
 										{project.title}
 									</a>
 								{:else}
@@ -340,7 +346,7 @@
 						<div class="flex items-start justify-between gap-2">
 							<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
 								{#if project.slug}
-									<a href="/projects/{project.slug}" class="hover:text-primary-600 dark:hover:text-primary-400">
+									<a href={projectHref(project.slug)} class="hover:text-primary-600 dark:hover:text-primary-400">
 										{project.title}
 									</a>
 								{:else}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -284,7 +284,7 @@
 			{/if}
 
 			{#if data.projects.length > 0}
-				<ProjectsSection items={data.projects} />
+				<ProjectsSection items={data.projects} viewSlug={data.view?.slug || ''} />
 			{/if}
 
 			{#if data.education.length > 0}

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -308,7 +308,11 @@
 						</div>
 					{:else if sectionKey === 'projects' && data.sections?.projects?.length > 0}
 						<div class={getWidthClass(getSectionWidth('projects'))}>
-							<ProjectsSection items={data.sections.projects} layout={getSectionLayout('projects')} />
+							<ProjectsSection
+								items={data.sections.projects}
+								layout={getSectionLayout('projects')}
+								viewSlug={data.view?.slug || ''}
+							/>
 						</div>
 					{:else if sectionKey === 'education' && data.sections?.education?.length > 0}
 						<div class={getWidthClass(getSectionWidth('education'))}>

--- a/frontend/src/routes/projects/[slug]/+page.server.ts
+++ b/frontend/src/routes/projects/[slug]/+page.server.ts
@@ -9,9 +9,10 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
+export const load: PageServerLoad = async ({ params, fetch, url }) => {
 	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
 	const { slug } = params;
+	const fromView = url.searchParams.get('from');
 
 	try {
 		const response = await fetch(`${pbUrl}/api/project/${slug}`);
@@ -36,7 +37,8 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 				cover_image_url: project.cover_image_url || null,
 				media_urls: project.media_urls || []
 			},
-			profile: project.profile || null
+			profile: project.profile || null,
+			fromView: fromView || null
 		};
 	} catch (err) {
 		if ((err as { status?: number }).status === 404) {

--- a/frontend/src/routes/projects/[slug]/+page.svelte
+++ b/frontend/src/routes/projects/[slug]/+page.svelte
@@ -6,6 +6,10 @@
 
 	export let data: PageData;
 
+	// Back navigation: return to originating view if provided, otherwise home
+	$: backUrl = data.fromView ? `/${data.fromView}` : '/';
+	$: backLabel = data.fromView ? 'Back to Profile' : 'Back to Profile';
+
 	function getLinkIcon(type: string) {
 		switch (type.toLowerCase()) {
 			case 'github':
@@ -59,13 +63,13 @@
 		<div class="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
 			<!-- Back navigation -->
 			<a
-				href="/"
+				href={backUrl}
 				class="inline-flex items-center gap-2 text-gray-300 hover:text-white mb-6 transition-colors"
 			>
 				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
 				</svg>
-				<span>Back to Profile</span>
+				<span>{backLabel}</span>
 			</a>
 
 			<!-- Project title and badges -->


### PR DESCRIPTION
## Title
Fix project detail back navigation from views

## Summary
- pass the originating view slug into project links so `/projects/[slug]` carries `from=<viewSlug>`
- project detail page reads `from` and routes “Back” to the originating view, defaulting to `/` when none
- applied to view pages and home projects section

## Testing
- npm run check
