### PR TITLE
Add media orphan detection, stats, and cleanup

### DIFF
--- a/backend/services/media.go
+++ b/backend/services/media.go
@@ -26,6 +26,7 @@ type MediaItem struct {
 	DisplayName   string    `json:"display_name,omitempty"`
 	RecordLabel   string    `json:"record_label,omitempty"`
 	CollectionKey string    `json:"collection_key,omitempty"`
+	Orphan        bool      `json:"orphan,omitempty"`
 }
 
 // FlattenFileValue normalizes PocketBase file field values (string or []string) into a slice.


### PR DESCRIPTION
Title: Add media orphan detection, stats, and cleanup

Summary
- extend /api/media to report referenced files plus optional orphans, with counts/sizes in the response
- allow deleting both referenced files (record-aware) and orphan files (by relative path with sanitization)
- update admin Media page with scope filter, stats, orphan badges, and deletion for orphans

Testing
- backend: cd backend && go test ./...
- frontend: cd frontend && npm run check
