### PR TITLE
Add media cleanup bulk delete and storage stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Open `http://localhost:8080` — you're live.
 - **Experience, projects, education, skills, certifications, awards** — all the professional sections you'd expect
 - **Posts & talks** — share your writing and speaking engagements (RSS feed, iCal for talks)
 - **Views & theming** — per-view section curation, overrides, accent colors, and custom CSS
-- **Media library** — browse/search/delete uploads with orphan detection and responsive thumbnails
+- **Media library** — browse/search/delete uploads with orphan detection, responsive thumbnails, usage stats, and bulk orphan cleanup
 - **View membership cues** — admin lists show which views a project/post belongs to (with links to edit)
 - **Exports** — JSON/YAML export, print-ready stylesheet, AI print/resume (beta)
 - **Markdown everywhere** — rich content without a heavy editor

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,9 +9,9 @@ This roadmap reflects current implementation status and planned work, ordered ch
 ## Current Status Snapshot
 - ✅ Rebrand complete; branding, assets, and metadata reflect Facet.
 - ✅ Core flows: views, share tokens/passwords, GitHub import, AI enrichment (optional), admin CRUD, public pages, print stylesheet.
-- ✅ View editor with overrides/reordering; per-view theming; accent colors; media library with orphan detection.
+- ✅ View editor with overrides/reordering; per-view theming; accent colors; media library with orphan detection and cleanup.
 - ✅ Media optimization (thumb/srcset) live on posts/projects/homepage; view membership badges in admin lists.
-- 🟡 In progress/up next: orphan cleanup UX (bulk delete/storage usage), external media embeds, testing backlog.
+- 🟡 In progress/up next: external media embeds, storage usage polish (bulk stats in UI done), testing backlog.
 - 🔜 Planned: Security/Audit (Phase 8), Performance/SEO polish (Phase 9), Demo Mode toggle/persona (Phase 10).
 
 ---
@@ -68,7 +68,7 @@ This roadmap reflects current implementation status and planned work, ordered ch
 ## Phase 7: Media Management (🟡 Partially Complete)
 - 7.1 Media library: ✅ `/admin/media` listing, filters, search, delete; orphan detection
 - 7.2 Image optimization: ✅ thumbnails + responsive srcsets for posts/projects/homepage
-- 7.3 Cleanup UX: 🟡 orphan detection done; 🔜 bulk delete, storage usage display
+- 7.3 Cleanup UX: ✅ orphan detection + bulk delete + storage usage stats
 - 7.4 External media: 🔜 embed external URLs, YouTube/Vimeo thumbs, previews
 
 ## Phase 8: Security & Audit (🔜 Planned)


### PR DESCRIPTION
## Summary
- add storage usage stats to media API responses and compute orphan totals on every media listing
- introduce `/api/media/bulk-delete` for auth’d orphan cleanup and reuse safer path handling for deletes
- update admin media UI with storage/referenced/orphan size badges, orphan selection, select-all-visible, and bulk delete actions; refresh resets selections
- document media cleanup in README and mark Phase 7.3 complete on the roadmap

## Testing
- backend: `cd backend && go test ./...`
- frontend: `cd frontend && npm run check`
