### PR TITLE
feat: add custom error pages and SEO enhancements

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "svelte-dnd-action": "^0.9.69"
       },
       "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@sveltejs/adapter-node": "^5.0.0",
         "@sveltejs/kit": "^2.0.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -716,6 +717,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -3088,6 +3105,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pocketbase": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,11 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@sveltejs/adapter-node": "^5.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const uiBaseURL =
+	process.env.PLAYWRIGHT_BASE_URL ||
+	process.env.VITE_POCKETBASE_URL ||
+	'http://localhost:5173';
+
+export default defineConfig({
+	testDir: './tests',
+	timeout: 30_000,
+	expect: {
+		timeout: 5_000
+	},
+	retries: process.env.CI ? 2 : 0,
+	use: {
+		baseURL: uiBaseURL,
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		video: 'retain-on-failure'
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+	]
+});

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,0 +1,110 @@
+import type { RecordModel } from 'pocketbase';
+
+// Type definitions for JSON-LD schemas
+export interface JsonLdPerson {
+	'@context': 'https://schema.org';
+	'@type': 'Person';
+	name?: string;
+	jobTitle?: string;
+	description?: string;
+	url?: string;
+	image?: string;
+	sameAs?: string[];
+}
+
+export interface JsonLdArticle {
+	'@context': 'https://schema.org';
+	'@type': 'BlogPosting' | 'Article';
+	headline: string;
+	description?: string;
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	author?: JsonLdPerson;
+	url?: string;
+}
+
+export interface JsonLdWebSite {
+	'@context': 'https://schema.org';
+	'@type': 'WebSite';
+	name: string;
+	description?: string;
+	url: string;
+}
+
+/**
+ * Generate JSON-LD for a person profile (homepage)
+ */
+export function generatePersonJsonLd(profile: RecordModel, baseUrl: string): JsonLdPerson {
+	const socialLinks: string[] = [];
+
+	// Extract social links
+	if (profile.contact_links && Array.isArray(profile.contact_links)) {
+		for (const link of profile.contact_links) {
+			if (link.url) {
+				socialLinks.push(link.url);
+			}
+		}
+	}
+
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'Person',
+		name: profile.name || undefined,
+		jobTitle: profile.headline || undefined,
+		description: profile.summary || undefined,
+		url: baseUrl,
+		image: profile.avatar_url || undefined,
+		sameAs: socialLinks.length > 0 ? socialLinks : undefined
+	};
+}
+
+/**
+ * Generate JSON-LD for a blog post
+ */
+export function generateArticleJsonLd(
+	post: RecordModel,
+	baseUrl: string,
+	author?: RecordModel
+): JsonLdArticle {
+	const authorData: JsonLdPerson | undefined = author
+		? {
+				'@context': 'https://schema.org',
+				'@type': 'Person',
+				name: author.name || undefined,
+				url: baseUrl
+		  }
+		: undefined;
+
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'BlogPosting',
+		headline: post.title,
+		description: post.excerpt || undefined,
+		image: post.cover_image_url || undefined,
+		datePublished: post.published_at || post.created,
+		dateModified: post.updated,
+		author: authorData,
+		url: `${baseUrl}/posts/${post.slug}`
+	};
+}
+
+/**
+ * Generate JSON-LD for the website itself
+ */
+export function generateWebSiteJsonLd(profile: RecordModel, baseUrl: string): JsonLdWebSite {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		name: profile.name ? `${profile.name}'s Profile` : 'Profile',
+		description: profile.headline || profile.summary || undefined,
+		url: baseUrl
+	};
+}
+
+/**
+ * Serialize JSON-LD to HTML script tag content
+ */
+export function serializeJsonLd(data: object): string {
+	return JSON.stringify(data, null, 0); // Minified for production
+}

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
+	import { dev } from '$app/environment';
 
 	onMount(() => {
 		console.error('[ERROR PAGE] Displayed error:', {
@@ -9,34 +10,149 @@
 			url: $page.url.href
 		});
 	});
+
+	$: is404 = $page.status === 404;
+	$: is500 = $page.status >= 500;
 </script>
 
-<div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-	<div class="text-center p-8 max-w-lg">
-		<h1 class="text-6xl font-bold text-gray-900 dark:text-white mb-4">
-			{$page.status}
-		</h1>
-		<p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
-			{#if $page.error?.message}
-				{$page.error.message}
-			{:else if $page.status === 404}
-				Page not found
-			{:else}
-				Something went wrong
-			{/if}
-		</p>
+<div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+	<div class="text-center max-w-2xl">
 
-		<!-- Debug info for development -->
-		<div class="text-left text-sm bg-gray-100 dark:bg-gray-800 p-4 rounded-lg mb-8">
-			<p class="text-gray-500 dark:text-gray-400 mb-2">Debug info:</p>
-			<ul class="text-gray-600 dark:text-gray-400 space-y-1">
-				<li><strong>URL:</strong> {$page.url.pathname}</li>
-				<li><strong>Status:</strong> {$page.status}</li>
-				<li><strong>Error:</strong> {$page.error?.message || 'None'}</li>
-			</ul>
-		</div>
+		{#if is404}
+			<!-- 404: I Didn't Build That Facet -->
+			<div class="mb-8">
+				<!-- SVG Illustration: Developer with incomplete diamond -->
+				<svg class="w-64 h-64 mx-auto mb-6" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<!-- Incomplete diamond (missing a facet) -->
+					<g class="text-primary-500" stroke="currentColor" stroke-width="2" fill="none">
+						<path d="M 100 30 L 150 80 L 130 150 L 100 170 L 70 150 L 50 80 Z" opacity="0.3"/>
+						<line x1="100" y1="30" x2="150" y2="80"/>
+						<line x1="150" y1="80" x2="130" y2="150"/>
+						<line x1="130" y1="150" x2="100" y2="170"/>
+						<line x1="100" y1="170" x2="70" y2="150"/>
+						<line x1="70" y1="150" x2="50" y2="80"/>
+						<!-- Missing facet - dashed line -->
+						<line x1="50" y1="80" x2="100" y2="30" stroke-dasharray="5,5" opacity="0.3"/>
+					</g>
 
-		<div class="space-x-4">
+					<!-- Stick figure developer -->
+					<g class="text-gray-700 dark:text-gray-300" stroke="currentColor" stroke-width="2" fill="none">
+						<!-- Head -->
+						<circle cx="40" cy="120" r="8"/>
+						<!-- Body -->
+						<line x1="40" y1="128" x2="40" y2="155"/>
+						<!-- Arms - scratching head -->
+						<line x1="40" y1="135" x2="35" y2="145"/>
+						<line x1="40" y1="135" x2="38" y2="115"/>
+						<!-- Legs -->
+						<line x1="40" y1="155" x2="33" y2="170"/>
+						<line x1="40" y1="155" x2="47" y2="170"/>
+					</g>
+
+					<!-- TODO sticky note -->
+					<g class="text-yellow-400" fill="currentColor" opacity="0.9">
+						<rect x="145" y="40" width="45" height="35" rx="2"/>
+						<text x="150" y="52" font-size="6" class="fill-gray-800" font-family="monospace">TODO:</text>
+						<text x="150" y="60" font-size="6" class="fill-gray-800" font-family="monospace">Build</text>
+						<text x="150" y="68" font-size="6" class="fill-gray-800" font-family="monospace">this!</text>
+					</g>
+
+					<!-- Question marks -->
+					<text x="33" y="110" font-size="12" class="fill-gray-400">?</text>
+				</svg>
+			</div>
+
+			<h1 class="text-5xl font-bold text-gray-900 dark:text-white mb-4">
+				404: I Didn't Build That Facet
+			</h1>
+			<p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
+				Turns out I didn't cut this part of the diamond.<br/>
+				Maybe it's on the roadmap... maybe I forgot.
+			</p>
+
+		{:else if is500}
+			<!-- 500: I Should Have Added More Tests -->
+			<div class="mb-8">
+				<!-- SVG Illustration: Developer with broken diamond -->
+				<svg class="w-64 h-64 mx-auto mb-6" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<!-- Broken diamond pieces -->
+					<g class="text-primary-500" stroke="currentColor" stroke-width="2" fill="none">
+						<!-- Main broken piece -->
+						<path d="M 95 40 L 130 70 L 115 120" transform="rotate(-5 110 80)"/>
+						<!-- Fragment 1 -->
+						<path d="M 120 130 L 135 140 L 125 155" transform="rotate(15 127 142)"/>
+						<!-- Fragment 2 -->
+						<path d="M 80 125 L 70 140 L 85 145" transform="rotate(-10 77 135)"/>
+						<!-- Crack lines -->
+						<line x1="100" y1="100" x2="110" y2="120" stroke-dasharray="3,3" class="text-red-500"/>
+						<line x1="105" y1="110" x2="95" y2="125" stroke-dasharray="3,3" class="text-red-500"/>
+					</g>
+
+					<!-- Stick figure developer looking sheepish -->
+					<g class="text-gray-700 dark:text-gray-300" stroke="currentColor" stroke-width="2" fill="none">
+						<!-- Head -->
+						<circle cx="45" cy="130" r="8"/>
+						<!-- Worried face -->
+						<circle cx="43" cy="128" r="1" class="fill-current"/>
+						<circle cx="47" cy="128" r="1" class="fill-current"/>
+						<path d="M 42 134 Q 45 132 48 134" stroke-linecap="round"/>
+						<!-- Body -->
+						<line x1="45" y1="138" x2="45" y2="165"/>
+						<!-- Arms - holding hammer -->
+						<line x1="45" y1="145" x2="55" y2="140"/>
+						<rect x="54" y="136" width="8" height="4" rx="1" class="fill-gray-600"/>
+						<line x1="45" y1="145" x2="35" y2="150"/>
+						<!-- Legs -->
+						<line x1="45" y1="165" x2="38" y2="180"/>
+						<line x1="45" y1="165" x2="52" y2="180"/>
+					</g>
+
+					<!-- Thought bubble -->
+					<g class="text-gray-400" fill="currentColor">
+						<circle cx="20" cy="115" r="2"/>
+						<circle cx="24" cy="108" r="3"/>
+						<ellipse cx="30" cy="90" rx="20" ry="15" class="fill-white dark:fill-gray-800 stroke-current" stroke-width="1"/>
+						<text x="18" y="93" font-size="6" class="fill-gray-700 dark:fill-gray-300" font-family="monospace">Should've</text>
+						<text x="15" y="99" font-size="6" class="fill-gray-700 dark:fill-gray-300" font-family="monospace">added tests</text>
+					</g>
+				</svg>
+			</div>
+
+			<h1 class="text-5xl font-bold text-gray-900 dark:text-white mb-4">
+				500: I Should Have Added More Tests
+			</h1>
+			<p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
+				Something I wrote is broken. Shocking, I know.<br/>
+				Check back in 5 minutes after I frantically Google this.
+			</p>
+
+		{:else}
+			<!-- Other errors - generic but still themed -->
+			<div class="mb-8">
+				<div class="text-6xl mb-4">💎</div>
+			</div>
+			<h1 class="text-5xl font-bold text-gray-900 dark:text-white mb-4">
+				{$page.status}: Something's Off
+			</h1>
+			<p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
+				{$page.error?.message || "This facet isn't quite right."}
+			</p>
+		{/if}
+
+		<!-- Debug info for development only -->
+		{#if dev}
+			<div class="text-left text-sm bg-gray-100 dark:bg-gray-800 p-4 rounded-lg mb-8 max-w-md mx-auto">
+				<p class="text-gray-500 dark:text-gray-400 mb-2 font-mono">Debug info:</p>
+				<ul class="text-gray-600 dark:text-gray-400 space-y-1 font-mono text-xs">
+					<li><strong>URL:</strong> {$page.url.pathname}</li>
+					<li><strong>Status:</strong> {$page.status}</li>
+					<li><strong>Error:</strong> {$page.error?.message || 'None'}</li>
+				</ul>
+			</div>
+		{/if}
+
+		<!-- Action buttons -->
+		<div class="flex flex-wrap gap-4 justify-center">
 			<a
 				href="/"
 				class="inline-flex items-center gap-2 px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
@@ -44,17 +160,32 @@
 				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
 				</svg>
-				Go Home
+				{is404 ? 'Back to What Actually Works' : 'Go Home'}
 			</a>
-			<button
-				on:click={() => window.location.reload()}
-				class="inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-			>
-				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-				</svg>
-				Reload Page
-			</button>
+
+			{#if is404}
+				<a
+					href="/projects"
+					class="inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+				>
+					See What I Did Build
+				</a>
+			{:else}
+				<button
+					on:click={() => window.location.reload()}
+					class="inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+				>
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+					</svg>
+					{is500 ? 'Refresh and Pray' : 'Try Again'}
+				</button>
+			{/if}
 		</div>
+
+		<!-- Subtle signature -->
+		<p class="mt-12 text-sm text-gray-400 dark:text-gray-500 italic">
+			— Error pages crafted with self-awareness
+		</p>
 	</div>
 </div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -16,12 +16,18 @@
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
 	import { ACCENT_COLORS, type AccentColor } from '$lib/colors';
 	import { pb } from '$lib/pocketbase';
+	import { generatePersonJsonLd, generateWebSiteJsonLd, serializeJsonLd } from '$lib/seo';
 
 	export let data: PageData;
 
 	// Get headline and summary - use view overrides if this is a default view
 	$: headline = data.view?.hero_headline || data.profile?.headline;
 	$: summary = data.view?.hero_summary || data.profile?.summary;
+
+	// Generate JSON-LD for SEO
+	$: baseUrl = browser ? window.location.origin : 'http://localhost:8080';
+	$: personJsonLd = data.profile ? serializeJsonLd(generatePersonJsonLd(data.profile, baseUrl)) : null;
+	$: websiteJsonLd = data.profile ? serializeJsonLd(generateWebSiteJsonLd(data.profile, baseUrl)) : null;
 
 	// Print menu state
 	let showPrintMenu = false;
@@ -168,6 +174,14 @@
 	{/if}
 	<!-- Canonical URL is always / for the homepage -->
 	<link rel="canonical" href="/" />
+
+	<!-- JSON-LD Structured Data -->
+	{#if personJsonLd}
+		{@html `<script type="application/ld+json">${personJsonLd}</script>`}
+	{/if}
+	{#if websiteJsonLd}
+		{@html `<script type="application/ld+json">${websiteJsonLd}</script>`}
+	{/if}
 </svelte:head>
 
 {#if data.homepageDisabled}

--- a/frontend/src/routes/robots.txt/+server.ts
+++ b/frontend/src/routes/robots.txt/+server.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	const baseUrl = process.env.PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:8080';
+
+	const robotsTxt = `# Facet - Personal Profile Platform
+# Your profile, your data, your rules.
+
+User-agent: *
+Allow: /
+Allow: /projects
+Allow: /posts
+Allow: /talks
+
+# Disallow admin and private areas
+Disallow: /admin
+Disallow: /s/
+Disallow: /v/
+
+# Sitemap
+Sitemap: ${baseUrl}/sitemap.xml
+`;
+
+	return new Response(robotsTxt, {
+		headers: {
+			'Content-Type': 'text/plain',
+			'Cache-Control': 'public, max-age=86400' // Cache for 24 hours
+		}
+	});
+};

--- a/frontend/src/routes/sitemap.xml/+server.ts
+++ b/frontend/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,151 @@
+import { pb } from '$lib/pocketbase';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	try {
+		// Fetch all public content
+		const [projects, posts, talks, views] = await Promise.all([
+			pb.collection('projects').getFullList({
+				filter: 'visibility = "public" && is_draft = false',
+				fields: 'slug,updated'
+			}),
+			pb.collection('posts').getFullList({
+				filter: 'visibility = "public" && is_draft = false',
+				fields: 'slug,updated'
+			}),
+			pb.collection('talks').getFullList({
+				filter: 'visibility = "public"',
+				fields: 'slug,updated'
+			}),
+			pb.collection('views').getFullList({
+				filter: 'visibility = "public" && is_active = true',
+				fields: 'slug,updated'
+			})
+		]);
+
+		const baseUrl = process.env.PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:8080';
+
+		const urls: Array<{ loc: string; lastmod: string; priority: string; changefreq: string }> = [];
+
+		// Homepage - highest priority
+		urls.push({
+			loc: baseUrl,
+			lastmod: new Date().toISOString().split('T')[0],
+			priority: '1.0',
+			changefreq: 'weekly'
+		});
+
+		// Public views
+		for (const view of views) {
+			urls.push({
+				loc: `${baseUrl}/${view.slug}`,
+				lastmod: new Date(view.updated).toISOString().split('T')[0],
+				priority: '0.9',
+				changefreq: 'weekly'
+			});
+		}
+
+		// Projects index
+		if (projects.length > 0) {
+			urls.push({
+				loc: `${baseUrl}/projects`,
+				lastmod: new Date(projects[0].updated).toISOString().split('T')[0],
+				priority: '0.8',
+				changefreq: 'weekly'
+			});
+		}
+
+		// Individual projects
+		for (const project of projects) {
+			urls.push({
+				loc: `${baseUrl}/projects/${project.slug}`,
+				lastmod: new Date(project.updated).toISOString().split('T')[0],
+				priority: '0.7',
+				changefreq: 'monthly'
+			});
+		}
+
+		// Posts index
+		if (posts.length > 0) {
+			urls.push({
+				loc: `${baseUrl}/posts`,
+				lastmod: new Date(posts[0].updated).toISOString().split('T')[0],
+				priority: '0.8',
+				changefreq: 'weekly'
+			});
+		}
+
+		// Individual posts
+		for (const post of posts) {
+			urls.push({
+				loc: `${baseUrl}/posts/${post.slug}`,
+				lastmod: new Date(post.updated).toISOString().split('T')[0],
+				priority: '0.7',
+				changefreq: 'monthly'
+			});
+		}
+
+		// Talks index
+		if (talks.length > 0) {
+			urls.push({
+				loc: `${baseUrl}/talks`,
+				lastmod: new Date(talks[0].updated).toISOString().split('T')[0],
+				priority: '0.6',
+				changefreq: 'monthly'
+			});
+		}
+
+		// Individual talks
+		for (const talk of talks) {
+			if (talk.slug) {
+				urls.push({
+					loc: `${baseUrl}/talks/${talk.slug}`,
+					lastmod: new Date(talk.updated).toISOString().split('T')[0],
+					priority: '0.5',
+					changefreq: 'monthly'
+				});
+			}
+		}
+
+		// Generate XML
+		const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls
+	.map(
+		(url) => `  <url>
+    <loc>${url.loc}</loc>
+    <lastmod>${url.lastmod}</lastmod>
+    <changefreq>${url.changefreq}</changefreq>
+    <priority>${url.priority}</priority>
+  </url>`
+	)
+	.join('\n')}
+</urlset>`;
+
+		return new Response(sitemap, {
+			headers: {
+				'Content-Type': 'application/xml',
+				'Cache-Control': 'public, max-age=3600' // Cache for 1 hour
+			}
+		});
+	} catch (error) {
+		console.error('Sitemap generation error:', error);
+		// Return minimal sitemap on error
+		const baseUrl = process.env.PUBLIC_APP_URL || process.env.APP_URL || 'http://localhost:8080';
+		const fallbackSitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${baseUrl}</loc>
+    <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>`;
+
+		return new Response(fallbackSitemap, {
+			headers: {
+				'Content-Type': 'application/xml'
+			}
+		});
+	}
+};

--- a/frontend/src/routes/test-500/+page.server.ts
+++ b/frontend/src/routes/test-500/+page.server.ts
@@ -1,0 +1,7 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	// Intentionally throw a 500 error for testing
+	throw error(500, 'Test server error - this route intentionally triggers a 500');
+};

--- a/frontend/tests/admin-flows.spec.ts
+++ b/frontend/tests/admin-flows.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { apiBaseURL, adminEmail, adminPassword } from './config';
+import { fetchFirstView, loginAsAdmin } from './helpers';
+
+const shouldRunAdmin = Boolean(adminEmail && adminPassword);
+
+test.describe('Admin-secured flows', () => {
+	test.skip(!shouldRunAdmin, 'ADMIN_EMAIL and ADMIN_PASSWORD are required for admin tests');
+
+	test('can authenticate and list views', async ({ request }) => {
+		const { token, record } = await loginAsAdmin(request);
+
+		const viewsRes = await request.get(
+			`${apiBaseURL}/api/collections/views/records?page=1&perPage=5`,
+			{
+				headers: { Authorization: token }
+			}
+		);
+		expect(viewsRes.ok()).toBeTruthy();
+
+		const views = await viewsRes.json();
+		expect(Array.isArray(views.items)).toBeTruthy();
+		expect(record).toBeTruthy();
+	});
+
+	test('share token lifecycle for a view', async ({ request }) => {
+		const { token } = await loginAsAdmin(request);
+
+		const view = await fetchFirstView(request, token);
+		test.skip(!view, 'No views available to exercise share tokens');
+		test.skip(!view?.slug, 'View is missing a slug');
+
+		const generateRes = await request.post(`${apiBaseURL}/api/share/generate`, {
+			headers: { Authorization: token },
+			data: {
+				view_id: view.id,
+				name: 'playwright-share'
+			}
+		});
+		expect(generateRes.ok()).toBeTruthy();
+		const generated = await generateRes.json();
+		expect(generated).toHaveProperty('token');
+		expect(generated).toHaveProperty('id');
+
+		const shareToken = generated.token as string;
+		const shareId = generated.id as string;
+
+		const validateRes = await request.post(`${apiBaseURL}/api/share/validate`, {
+			data: { token: shareToken, view_id: view.id }
+		});
+		expect(validateRes.ok()).toBeTruthy();
+		const validation = await validateRes.json();
+		expect(validation.valid).toBe(true);
+		expect(validation.view_slug || validation.view_id).toBeTruthy();
+
+		const viewDataRes = await request.get(`${apiBaseURL}/api/view/${view.slug}/data`, {
+			headers: { 'X-Share-Token': shareToken }
+		});
+		expect(viewDataRes.ok()).toBeTruthy();
+		const viewData = await viewDataRes.json();
+		expect(viewData.slug).toBe(view.slug);
+
+		const revokeRes = await request.post(`${apiBaseURL}/api/share/revoke/${shareId}`, {
+			headers: { Authorization: token }
+		});
+		expect(revokeRes.ok()).toBeTruthy();
+
+		const validateAfter = await request.post(`${apiBaseURL}/api/share/validate`, {
+			data: { token: shareToken, view_id: view.id }
+		});
+		expect(validateAfter.ok()).toBeTruthy();
+		const validationAfter = await validateAfter.json();
+		expect(validationAfter.valid).toBe(false);
+	});
+});

--- a/frontend/tests/config.ts
+++ b/frontend/tests/config.ts
@@ -1,0 +1,7 @@
+export const apiBaseURL =
+	process.env.API_BASE_URL ||
+	process.env.POCKETBASE_URL ||
+	'http://localhost:8090';
+
+export const adminEmail = process.env.ADMIN_EMAIL || '';
+export const adminPassword = process.env.ADMIN_PASSWORD || '';

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -1,0 +1,40 @@
+import { expect, APIRequestContext } from '@playwright/test';
+import { adminEmail, adminPassword, apiBaseURL } from './config';
+
+export async function loginAsAdmin(request: APIRequestContext) {
+	if (!adminEmail || !adminPassword) {
+		throw new Error('ADMIN_EMAIL and ADMIN_PASSWORD are required for admin tests');
+	}
+
+	const res = await request.post(`${apiBaseURL}/api/collections/users/auth-with-password`, {
+		data: {
+			identity: adminEmail,
+			password: adminPassword
+		}
+	});
+
+	expect(res.ok()).toBeTruthy();
+	const body = await res.json();
+
+	return {
+		token: body?.token as string,
+		record: body?.record
+	};
+}
+
+export async function fetchFirstView(request: APIRequestContext, token: string) {
+	const res = await request.get(
+		`${apiBaseURL}/api/collections/views/records?page=1&perPage=5`,
+		{
+			headers: { Authorization: token }
+		}
+	);
+
+	if (!res.ok()) {
+		return null;
+	}
+
+	const body = await res.json();
+	const items = (body?.items ?? []) as Array<Record<string, any>>;
+	return items.length ? items[0] : null;
+}

--- a/frontend/tests/public-api.spec.ts
+++ b/frontend/tests/public-api.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { apiBaseURL } from './config';
+
+test.describe('Public APIs and feeds', () => {
+	test('default view or homepage is reachable', async ({ request }) => {
+		const defaultViewRes = await request.get(`${apiBaseURL}/api/default-view`);
+		expect(defaultViewRes.ok()).toBeTruthy();
+		const defaultView = await defaultViewRes.json();
+
+		if (defaultView.has_default && defaultView.slug) {
+			const viewRes = await request.get(`${apiBaseURL}/api/view/${defaultView.slug}/data`);
+			expect(viewRes.ok()).toBeTruthy();
+			const view = await viewRes.json();
+			expect(view.slug).toBe(defaultView.slug);
+			expect(view.sections).toBeDefined();
+		} else {
+			const homeRes = await request.get(`${apiBaseURL}/api/homepage`);
+			expect(homeRes.ok()).toBeTruthy();
+			const home = await homeRes.json();
+			expect(home).toHaveProperty('homepage_enabled');
+		}
+	});
+
+	test('AI and AI Print capability endpoints respond', async ({ request }) => {
+		const aiStatusRes = await request.get(`${apiBaseURL}/api/ai/status`);
+		expect(aiStatusRes.ok()).toBeTruthy();
+		const aiStatus = await aiStatusRes.json();
+		expect(aiStatus).toHaveProperty('available');
+
+		const printStatusRes = await request.get(`${apiBaseURL}/api/ai-print/status`);
+		expect(printStatusRes.ok()).toBeTruthy();
+		const printStatus = await printStatusRes.json();
+		expect(printStatus).toHaveProperty('available');
+		expect(printStatus).toHaveProperty('supported_formats');
+	});
+
+	test('Posts and talks listings return success (even if empty)', async ({ request }) => {
+		const postsRes = await request.get(`${apiBaseURL}/api/posts`);
+		expect(postsRes.ok()).toBeTruthy();
+		const posts = await postsRes.json();
+		expect(posts).toHaveProperty('posts');
+
+		const talksRes = await request.get(`${apiBaseURL}/api/talks`);
+		expect(talksRes.ok()).toBeTruthy();
+		const talks = await talksRes.json();
+		expect(talks).toHaveProperty('talks');
+	});
+
+	test('RSS and ICS feeds are available', async ({ request }) => {
+		const rssRes = await request.get(`${apiBaseURL}/rss.xml`);
+		expect(rssRes.status()).toBe(200);
+		const rssText = await rssRes.text();
+		expect(rssText.toLowerCase()).toContain('<rss');
+
+		const icsRes = await request.get(`${apiBaseURL}/talks.ics`);
+		expect(icsRes.status()).toBe(200);
+		const icsText = await icsRes.text();
+		expect(icsText).toContain('BEGIN:VCALENDAR');
+	});
+});


### PR DESCRIPTION
Implements Phase 9 improvements with personality and discoverability.

## Custom Error Pages (404/500)

**Self-deprecating, on-brand error pages with hand-drawn SVG illustrations:**

404: "I Didn't Build That Facet"
- Stick figure developer with incomplete diamond
- TODO sticky note
- Playful copy: "Maybe it's on the roadmap... maybe I forgot"
- Button: "Back to What Actually Works"

500: "I Should Have Added More Tests"
- Stick figure dev with broken diamond and hammer
- Thought bubble: "Should've added tests"
- Copy: "Check back in 5 minutes after I frantically Google this"
- Button: "Refresh and Pray"

Features:
- Debug info shown only in dev mode
- Adapts to light/dark theme
- Pure SVG illustrations (no external assets)
- Fallback for other error codes
- Test route: /test-500 for testing 500 errors

## SEO Enhancements

### sitemap.xml (/sitemap.xml)
- Auto-generates from public content
- Includes homepage, views, projects, posts, talks
- Priority weighting (1.0 for homepage down to 0.5 for talks)
- Proper lastmod dates from record updates
- 1-hour cache
- Graceful fallback on errors

### robots.txt (/robots.txt)
- Allows all public content
- Disallows admin, share tokens, legacy routes
- Links to sitemap
- 24-hour cache
- On-brand comment header

### JSON-LD Structured Data
- Person schema for homepage (name, jobTitle, social links)
- WebSite schema with description
- Ready for Article schema on blog posts
- Helps search engines understand content
- Improves rich snippet eligibility

## Technical Implementation

New Files:
- frontend/src/lib/seo.ts - JSON-LD utilities
- frontend/src/routes/sitemap.xml/+server.ts
- frontend/src/routes/robots.txt/+server.ts
- frontend/src/routes/test-500/+page.server.ts

Modified Files:
- frontend/src/routes/+error.svelte - Custom error pages
- frontend/src/routes/+page.svelte - JSON-LD on homepage

## Testing
- Error pages tested manually (404 on any invalid URL, 500 at /test-500)
- Sitemap accessible at /sitemap.xml
- Robots.txt accessible at /robots.txt
- JSON-LD validates in browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)