### PR TITLE
Update documentation to reflect Go 1.24 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Each view can show/hide sections, include/exclude specific items, override your 
 ### 3. **Developers** (Contributing to Facet or customizing it)
 
 The codebase is:
-- **Backend**: Go 1.23 with PocketBase (a lightweight backend framework)
+- **Backend**: Go 1.24 with PocketBase (a lightweight backend framework)
 - **Frontend**: SvelteKit 2.0 with TypeScript and Tailwind CSS
 - **Database**: SQLite (embedded, single file)
 - **Deployment**: Docker with Caddy reverse proxy
@@ -377,7 +377,7 @@ Search engines can index your public content. Unlisted and private stuff stays h
 ## Tech Stack (For Developers)
 
 **Backend:**
-- **Go 1.23** (backend language)
+- **Go 1.24** (backend language)
 - **PocketBase v0.23.4** (lightweight backend framework built on SQLite and Fiber)
 - **SQLite** (embedded database, single file)
 - **AES-256-GCM** (encryption for API keys and tokens)
@@ -537,7 +537,7 @@ Full security docs: [docs/SECURITY.md](docs/SECURITY.md)
 ### Local Development
 
 **Prerequisites:**
-- Go 1.23+
+- Go 1.24+
 - Node.js 20+
 - [Air](https://github.com/air-verse/air) for Go hot reload (install: `go install github.com/air-verse/air@v1.61.7`)
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -24,7 +24,7 @@ If credentials don't work, reset the database: `rm -rf pb_data && ./scripts/star
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.24+
 - Node.js 20+
 - [Air](https://github.com/air-verse/air) for Go hot reload
 


### PR DESCRIPTION
Updated all documentation to reflect the Go 1.24 upgrade in the previous commit.

Changes:
- README.md: Updated 3 references (1.23 → 1.24)
- docs/DEV.md: Updated prerequisites section (1.23+ → 1.24+)

This ensures documentation matches the actual go.mod requirements after upgrading to Go 1.24.4 for golang.org/x/crypto v0.45.0 security fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)