### PR TITLE
Fix Docker build: Update Go version from 1.23 to 1.24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@
 # - Air is pre-installed
 # - Runtime dependency installation is handled by scripts with hash caching
 
-FROM mcr.microsoft.com/devcontainers/go:1.23
+FROM mcr.microsoft.com/devcontainers/go:1.24
 
 # Build-time only: use goproxy.cn as fallback for restricted environments
 # (proxy.golang.org redirects to storage.googleapis.com which may be blocked)


### PR DESCRIPTION
The go.mod requires go >= 1.24.0 but the devcontainer was using Go 1.23 base image, causing `go mod tidy` to fail during postCreateCommand.