### PR TITLE
Update production and dev Dockerfiles to Go 1.24

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Build Go backend
 # ============================================
-FROM golang:1.23-alpine AS backend-builder
+FROM golang:1.24-alpine AS backend-builder
 
 WORKDIR /build
 RUN apk add --no-cache gcc musl-dev

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Facet Development Dockerfile
 # Includes hot-reload for both backend and frontend
 
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 # Install dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
Both docker/Dockerfile and docker/Dockerfile.dev were using golang:1.23-alpine which doesn't satisfy go.mod's requirement of go >= 1.24.0.