### PR TITLE
feat(ux): replace native confirm dialogs with accessible styled modal

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -155,6 +155,38 @@
 }
 
 /* ==========================================================================
+   Reduced Motion Support
+   Respects user preference for reduced motion to prevent vestibular issues.
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+	/* Disable custom animations */
+	.animate-fade-in {
+		animation: none;
+	}
+
+	/* Disable smooth scrolling */
+	html {
+		scroll-behavior: auto;
+	}
+
+	/* Reduce transition durations significantly */
+	.transition-colors,
+	.transition-opacity,
+	.transition-transform,
+	.transition-all {
+		transition-duration: 0.01ms !important;
+	}
+
+	/* Disable transform animations on buttons/interactive elements */
+	.btn,
+	button,
+	a {
+		transition: none !important;
+	}
+}
+
+/* ==========================================================================
    Print Stylesheet
    Optimizes public views for printing and browser-based PDF generation.
    Designed for ATS-friendly, professional resume output.

--- a/frontend/src/components/admin/AdminHeader.svelte
+++ b/frontend/src/components/admin/AdminHeader.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { pb, currentUser } from '$lib/pocketbase';
-	import { adminSidebarOpen } from '$lib/stores';
+	import { adminSidebarOpen, confirm } from '$lib/stores';
 	import { demoMode as demoModeStore, initDemoMode } from '$lib/stores/demo';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
 
@@ -52,7 +52,13 @@
 		console.log('[TOGGLE] toggleDemoMode() called, current demoMode:', demoMode);
 		if (!demoMode) {
 			// Turning on demo mode
-			if (!confirm('This will replace your current profile data with sample data. Your original data will be backed up and can be restored when you toggle off demo mode.\n\nNote: If you currently have no profile data, toggling demo OFF later will keep the demo data as your starting profile. Continue?')) {
+			const confirmed = await confirm({
+				title: 'Enable Demo Mode',
+				message: 'This will replace your current profile data with sample data. Your original data will be backed up and can be restored when you toggle off demo mode.\n\nNote: If you currently have no profile data, toggling demo OFF later will keep the demo data as your starting profile.',
+				confirmText: 'Enable Demo',
+				cancelText: 'Cancel'
+			});
+			if (!confirmed) {
 				console.log('[TOGGLE] User cancelled');
 				return;
 			}

--- a/frontend/src/components/shared/ConfirmDialog.svelte
+++ b/frontend/src/components/shared/ConfirmDialog.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { confirmDialog } from '$lib/stores';
+	import { icon } from '$lib/icons';
+
+	let dialogEl: HTMLDivElement;
+	let cancelBtnEl: HTMLButtonElement;
+	let previousActiveElement: HTMLElement | null = null;
+
+	$: isOpen = $confirmDialog.open;
+	$: options = $confirmDialog.options;
+
+	// Focus trap and keyboard handling
+	function handleKeydown(event: KeyboardEvent) {
+		if (!isOpen) return;
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			confirmDialog.respond(false);
+			return;
+		}
+
+		// Focus trap
+		if (event.key === 'Tab') {
+			const focusableElements = dialogEl?.querySelectorAll<HTMLElement>(
+				'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+			);
+			
+			if (!focusableElements?.length) return;
+
+			const firstElement = focusableElements[0];
+			const lastElement = focusableElements[focusableElements.length - 1];
+
+			if (event.shiftKey && document.activeElement === firstElement) {
+				event.preventDefault();
+				lastElement.focus();
+			} else if (!event.shiftKey && document.activeElement === lastElement) {
+				event.preventDefault();
+				firstElement.focus();
+			}
+		}
+	}
+
+	// Handle overlay click
+	function handleOverlayClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) {
+			confirmDialog.respond(false);
+		}
+	}
+
+	// Lock body scroll when open
+	$: if (typeof document !== 'undefined') {
+		if (isOpen) {
+			previousActiveElement = document.activeElement as HTMLElement;
+			document.body.style.overflow = 'hidden';
+			// Focus cancel button after dialog renders
+			requestAnimationFrame(() => {
+				cancelBtnEl?.focus();
+			});
+		} else {
+			document.body.style.overflow = '';
+			// Restore focus to previous element
+			if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+				previousActiveElement.focus();
+			}
+		}
+	}
+
+	onDestroy(() => {
+		if (typeof document !== 'undefined') {
+			document.body.style.overflow = '';
+		}
+	});
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if isOpen && options}
+	<!-- Backdrop -->
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-fade-in"
+		on:click={handleOverlayClick}
+		on:keydown={handleKeydown}
+		role="presentation"
+	>
+		<!-- Dialog -->
+		<div
+			bind:this={dialogEl}
+			role="alertdialog"
+			aria-modal="true"
+			aria-labelledby="confirm-dialog-title"
+			aria-describedby="confirm-dialog-message"
+			class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full p-6 animate-fade-in"
+		>
+			<!-- Icon and Title -->
+			<div class="flex items-start gap-4">
+				{#if options.danger}
+					<div class="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center text-red-600 dark:text-red-400">
+						{@html icon('warning')}
+					</div>
+				{:else}
+					<div class="flex-shrink-0 w-10 h-10 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 dark:text-primary-400">
+						{@html icon('info')}
+					</div>
+				{/if}
+				<div class="flex-1 min-w-0">
+					<h2
+						id="confirm-dialog-title"
+						class="text-lg font-semibold text-gray-900 dark:text-white"
+					>
+						{options.title}
+					</h2>
+					<p
+						id="confirm-dialog-message"
+						class="mt-2 text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap"
+					>
+						{options.message}
+					</p>
+				</div>
+			</div>
+
+			<!-- Buttons -->
+			<div class="mt-6 flex justify-end gap-3">
+				<button
+					bind:this={cancelBtnEl}
+					type="button"
+					class="btn btn-secondary"
+					on:click={() => confirmDialog.respond(false)}
+				>
+					{options.cancelText || 'Cancel'}
+				</button>
+				<button
+					type="button"
+					class="btn {options.danger ? 'btn-danger' : 'btn-primary'}"
+					on:click={() => confirmDialog.respond(true)}
+				>
+					{options.confirmText || 'Confirm'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	/* Ensure dialog animations respect reduced motion preference */
+	@media (prefers-reduced-motion: reduce) {
+		.animate-fade-in {
+			animation: none;
+		}
+	}
+</style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import { beforeNavigate, afterNavigate } from '$app/navigation';
 	import { theme, toasts } from '$lib/stores';
 	import Toast from '$components/shared/Toast.svelte';
+	import ConfirmDialog from '$components/shared/ConfirmDialog.svelte';
 	import { ACCENT_COLORS, DEFAULT_ACCENT_COLOR, type AccentColor } from '$lib/colors';
 
 	// Debug navigation in development
@@ -269,3 +270,6 @@ $: if (mounted && lastCustomCSS && accentStyleEl) {
 		<Toast {toast} on:dismiss={() => toasts.remove(toast.id)} />
 	{/each}
 </div>
+
+<!-- Confirm dialog -->
+<ConfirmDialog />

--- a/frontend/src/routes/admin/awards/+page.svelte
+++ b/frontend/src/routes/admin/awards/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Award } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { formatDate, truncate } from '$lib/utils';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
 
@@ -123,7 +123,13 @@
 	}
 
 	async function deleteAward(award: Award) {
-		if (!confirm(`Are you sure you want to delete "${award.title}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Award',
+			message: `Are you sure you want to delete "${award.title}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -166,7 +172,13 @@
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Awards',
+			message: `Are you sure you want to delete ${ids.length} award(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('awards').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/certifications/+page.svelte
+++ b/frontend/src/routes/admin/certifications/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Certification } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { formatDate } from '$lib/utils';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
 
@@ -119,7 +119,13 @@
 	}
 
 	async function deleteCertification(cert: Certification) {
-		if (!confirm(`Are you sure you want to delete "${cert.name}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Certification',
+			message: `Are you sure you want to delete "${cert.name}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -205,7 +211,13 @@
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Certifications',
+			message: `Are you sure you want to delete ${ids.length} certification(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('certifications').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/contacts/+page.svelte
+++ b/frontend/src/routes/admin/contacts/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type ContactMethod, type ContactMethodType, type ProtectionLevel, type View } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	
 
 	// State
@@ -171,7 +171,13 @@
 
 	async function deleteContact(contact: ContactMethod) {
 		const displayValue = contact.label || contact.value;
-		if (!confirm(`Are you sure you want to delete "${displayValue}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Contact Method',
+			message: `Are you sure you want to delete "${displayValue}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 

--- a/frontend/src/routes/admin/education/+page.svelte
+++ b/frontend/src/routes/admin/education/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Education } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import AIContentHelper from '$components/admin/AIContentHelper.svelte';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
 
@@ -119,7 +119,13 @@
 	}
 
 	async function deleteEducation(edu: Education) {
-		if (!confirm(`Are you sure you want to delete "${edu.degree} at ${edu.institution}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Education',
+			message: `Are you sure you want to delete "${edu.degree} at ${edu.institution}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -183,7 +189,13 @@
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} education item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Education',
+			message: `Are you sure you want to delete ${ids.length} education item(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('education').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/experience/+page.svelte
+++ b/frontend/src/routes/admin/experience/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Experience } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { formatDate } from '$lib/utils';
 	import AIContentHelper from '$components/admin/AIContentHelper.svelte';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
@@ -146,9 +146,13 @@
 	}
 
 	async function deleteExperience(exp: Experience) {
-		if (!confirm(`Are you sure you want to delete "${exp.title} at ${exp.company}"?`)) {
-			return;
-		}
+		const confirmed = await confirm({
+			title: 'Delete Experience',
+			message: `Are you sure you want to delete "${exp.title} at ${exp.company}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) return;
 
 		try {
 			await await collection('experience').delete(exp.id);
@@ -221,7 +225,13 @@
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Are you sure you want to delete ${ids.length} experience(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Experiences',
+			message: `Are you sure you want to delete ${ids.length} experience(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		
 		try {
 			for (const id of ids) {

--- a/frontend/src/routes/admin/media/+page.svelte
+++ b/frontend/src/routes/admin/media/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import { formatDate } from '$lib/utils';
 	import { pb } from '$lib/pocketbase';
@@ -172,7 +172,13 @@
 	}
 
 	async function deleteFile(item: MediaItem) {
-		if (!confirm(`Delete ${item.filename}? This cannot be undone.`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Media',
+			message: `Delete "${item.filename}"? This cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			if (item.external && item.record_id) {
 				const res = await fetch(`/api/media/external/${item.record_id}`, {
@@ -248,7 +254,13 @@
 
 	async function bulkDeleteSelected() {
 		if (selectedOrphans.size === 0) return;
-		if (!confirm(`Delete ${selectedOrphans.size} orphan file(s)? This cannot be undone.`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Orphan Files',
+			message: `Delete ${selectedOrphans.size} orphan file(s)? These files are not referenced anywhere and this action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 
 		try {
 			const res = await fetch('/api/media/bulk-delete', {

--- a/frontend/src/routes/admin/posts/+page.svelte
+++ b/frontend/src/routes/admin/posts/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 import { pb, type Post } from '$lib/pocketbase';
 import { collection } from '$lib/stores/demo';
-import { toasts } from '$lib/stores';
+import { toasts, confirm } from '$lib/stores';
 import { formatDate } from '$lib/utils';
 import AIContentHelper from '$components/admin/AIContentHelper.svelte';
 import BulkActionBar from '$components/admin/BulkActionBar.svelte';
@@ -274,7 +274,13 @@ function openEditForm(post: Post) {
 	}
 
 	async function deletePost(post: Post) {
-		if (!confirm(`Are you sure you want to delete "${post.title}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Post',
+			message: `Are you sure you want to delete "${post.title}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -332,7 +338,13 @@ function openEditForm(post: Post) {
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Posts',
+			message: `Are you sure you want to delete ${ids.length} post(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('posts').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/profile/+page.svelte
+++ b/frontend/src/routes/admin/profile/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { pb, type View } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import AIContentHelper from '$components/admin/AIContentHelper.svelte';
 
@@ -151,7 +151,13 @@
 	
 	async function removeAvatar() {
 		if (!profile) return;
-		if (!confirm('Remove your avatar image?')) return;
+		const confirmed = await confirm({
+			title: 'Remove Avatar',
+			message: 'Are you sure you want to remove your avatar image?',
+			confirmText: 'Remove',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			await collection('profile').update(profile.id as string, { avatar: null });
 			avatarUrl = null;
@@ -165,7 +171,13 @@
 	
 	async function removeHeroImage() {
 		if (!profile) return;
-		if (!confirm('Remove your hero image?')) return;
+		const confirmed = await confirm({
+			title: 'Remove Hero Image',
+			message: 'Are you sure you want to remove your hero image?',
+			confirmText: 'Remove',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			await collection('profile').update(profile.id as string, { hero_image: null });
 			heroImageUrl = null;

--- a/frontend/src/routes/admin/projects/+page.svelte
+++ b/frontend/src/routes/admin/projects/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Project, getFileUrl } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import AIContentHelper from '$components/admin/AIContentHelper.svelte';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
 
@@ -283,7 +283,13 @@ async function loadProjects() {
 	}
 
 	async function deleteProject(project: Project) {
-		if (!confirm(`Are you sure you want to delete "${project.title}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Project',
+			message: `Are you sure you want to delete "${project.title}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -369,7 +375,13 @@ async function loadProjects() {
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Projects',
+			message: `Are you sure you want to delete ${ids.length} project(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('projects').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Profile } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import {
 		ACCENT_COLORS,
@@ -315,7 +315,13 @@
 	}
 
 	async function deleteProvider(id: string) {
-		if (!confirm('Are you sure you want to delete this provider?')) return;
+		const confirmed = await confirm({
+			title: 'Delete AI Provider',
+			message: 'Are you sure you want to delete this AI provider? This action cannot be undone.',
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) return;
 
 		try {
 			await pb.collection('ai_providers').delete(id);

--- a/frontend/src/routes/admin/skills/+page.svelte
+++ b/frontend/src/routes/admin/skills/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Skill } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
 
 	let skills: Skill[] = [];
@@ -108,7 +108,13 @@
 	}
 
 	async function deleteSkill(skill: Skill) {
-		if (!confirm(`Are you sure you want to delete "${skill.name}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Skill',
+			message: `Are you sure you want to delete "${skill.name}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -205,7 +211,13 @@
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Skills',
+			message: `Are you sure you want to delete ${ids.length} skill(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('skills').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/talks/+page.svelte
+++ b/frontend/src/routes/admin/talks/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type Talk } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { formatDate } from '$lib/utils';
 	import AIContentHelper from '$components/admin/AIContentHelper.svelte';
 	import BulkActionBar from '$components/admin/BulkActionBar.svelte';
@@ -262,7 +262,13 @@ async function resolveMediaRefs(selected: string[]) {
 	}
 
 	async function deleteTalk(talk: Talk) {
-		if (!confirm(`Are you sure you want to delete "${talk.title}"?`)) {
+		const confirmed = await confirm({
+			title: 'Delete Talk',
+			message: `Are you sure you want to delete "${talk.title}"? This action cannot be undone.`,
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -318,7 +324,13 @@ async function resolveMediaRefs(selected: string[]) {
 
 	async function bulkDelete() {
 		const ids = Array.from(selectedIds);
-		if (!confirm(`Delete ${ids.length} item(s)?`)) return;
+		const confirmed = await confirm({
+			title: 'Delete Talks',
+			message: `Are you sure you want to delete ${ids.length} talk(s)? This action cannot be undone.`,
+			confirmText: 'Delete All',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			for (const id of ids) await collection('talks').delete(id);
 			toasts.add('success', `Deleted ${ids.length} items`);

--- a/frontend/src/routes/admin/tokens/+page.svelte
+++ b/frontend/src/routes/admin/tokens/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb, type ShareToken, type View } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
 
 	let loading = true;
@@ -99,7 +99,13 @@
 	}
 
 	async function revokeToken(tokenId: string) {
-		if (!confirm('Are you sure you want to revoke this token? It will no longer be usable.')) {
+		const confirmed = await confirm({
+			title: 'Revoke Token',
+			message: 'Are you sure you want to revoke this token? It will no longer be usable.',
+			confirmText: 'Revoke',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 
@@ -123,7 +129,13 @@
 	}
 
 	async function deleteToken(tokenId: string) {
-		if (!confirm('Are you sure you want to permanently delete this token?')) {
+		const confirmed = await confirm({
+			title: 'Delete Token',
+			message: 'Are you sure you want to permanently delete this token? This action cannot be undone.',
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) {
 			return;
 		}
 

--- a/frontend/src/routes/admin/views/+page.svelte
+++ b/frontend/src/routes/admin/views/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import { formatDate } from '$lib/utils';
 
@@ -39,7 +39,13 @@
 	}
 
 	async function deleteView(id: string) {
-		if (!confirm('Are you sure you want to delete this view?')) return;
+		const confirmed = await confirm({
+			title: 'Delete View',
+			message: 'Are you sure you want to delete this view? This action cannot be undone.',
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			await collection('views').delete(id);
 			toasts.add('success', 'View deleted');

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -4,7 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { pb, type View, type ViewSection, type ItemConfig, type Profile, type SectionWidth, OVERRIDABLE_FIELDS, VALID_LAYOUTS, VALID_WIDTHS, getValidWidthsForLayout, isWidthValidForLayout } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
-	import { toasts } from '$lib/stores';
+	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
 	import { dndzone, TRIGGERS, SHADOW_PLACEHOLDER_ITEM_ID } from 'svelte-dnd-action';
 	import { ACCENT_COLORS, ACCENT_COLOR_LIST, type AccentColor } from '$lib/colors';
@@ -252,7 +252,13 @@
 
 	async function deleteExport(exportId: string) {
 		if (!slug) return;
-		if (!confirm('Delete this export? This cannot be undone.')) return;
+		const confirmed = await confirm({
+			title: 'Delete Export',
+			message: 'Delete this export? This action cannot be undone.',
+			confirmText: 'Delete',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			const response = await fetch(`/api/view/${slug}/exports/${exportId}`, {
 				method: 'DELETE',
@@ -285,7 +291,13 @@
 
 	async function removeHeroImage() {
 		if (!view) return;
-		if (!confirm('Remove hero image from this view?')) return;
+		const confirmed = await confirm({
+			title: 'Remove Hero Image',
+			message: 'Are you sure you want to remove the hero image from this view?',
+			confirmText: 'Remove',
+			danger: true
+		});
+		if (!confirmed) return;
 		try {
 			await collection('views').update(viewId, { hero_image: null });
 			heroImageUrl = null;


### PR DESCRIPTION
## Summary
- Replace all 28 native `window.confirm()` calls with a styled, accessible modal dialog
- Add `prefers-reduced-motion` CSS support for vestibular accessibility

## Changes
- **New**: `ConfirmDialog.svelte` component with full a11y (focus trap, Escape key, ARIA attributes, scroll lock)
- **New**: `confirmDialog` store + `confirm()` helper in `stores.ts`
- **Updated**: 16 admin pages to use the new confirm dialog
- **Updated**: `app.css` with reduced motion support

## Accessibility Features
- Focus trap within dialog
- Escape key to cancel
- `aria-modal`, `aria-labelledby`, `aria-describedby`
- Focus restoration on close
- Body scroll lock when open
- Respects `prefers-reduced-motion`

## Testing
- [x] `svelte-check` passes (0 errors, 0 warnings)