### PR TITLE
fix: update svelte, kit, devalue for security patches

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1453,9 +1453,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.4.tgz",
-      "integrity": "sha512-JFtOqDoU0DI/+QSG8qnq5bKcehVb3tCHhOG4amsSYth5/KgO4EkJvi42xSAiyKmXAAULW1/Zdb6lkgGEgSxdZg==",
+      "version": "2.49.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.5.tgz",
+      "integrity": "sha512-dCYqelr2RVnWUuxc+Dk/dB/SjV/8JBndp1UovCyCZdIQezd8TRwFLNZctYkzgHxRJtaNvseCSRsuuHPeUgIN/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1464,7 +1464,7 @@
         "@types/cookie": "^0.6.0",
         "acorn": "^8.14.1",
         "cookie": "^0.6.0",
-        "devalue": "^5.3.2",
+        "devalue": "^5.6.2",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
@@ -2102,9 +2102,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
-      "integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -3998,9 +3998,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.1.tgz",
-      "integrity": "sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==",
+      "version": "5.46.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.4.tgz",
+      "integrity": "sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -4011,7 +4011,7 @@
         "aria-query": "^5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.5.0",
+        "devalue": "^5.6.2",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.1",
         "is-reference": "^3.0.3",
@@ -4732,8 +4732,10 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
## Summary

Updates frontend dependencies to fix 5 Dependabot security alerts.

## Updates

| Package | Before | After | Severity | Issue |
|---------|--------|-------|----------|-------|
| @sveltejs/kit | 2.49.4 | 2.49.5 | HIGH | DoS + SSRF in prerendering |
| @sveltejs/kit | 2.49.4 | 2.49.5 | HIGH | Memory amplification DoS in form deserializer |
| svelte | 5.46.1 | 5.46.4 | MEDIUM | XSS vulnerability |
| devalue | 5.6.1 | 5.6.2 | HIGH | DoS via memory exhaustion |
| devalue | 5.6.1 | 5.6.2 | HIGH | DoS via CPU exhaustion |

## Verification

- [x] Type check passes (0 errors, 0 warnings)
- [x] All patch versions (semver-compatible, no breaking changes)
- [x] Tested on :dev - no issues observed
- [x] npm audit shows 0 vulnerabilities

## Remaining (no fix available)

- `github.com/disintegration/imaging` (Go) - LOW severity, crash on crafted TIFF files. No patch released upstream.

## Release Notes

All changes are security fixes:
- @sveltejs/kit: `fix: add length checks to remote forms`
- svelte: `fix: devalue.uneval serialization`, `fix: reconnect clean deriveds`
- devalue: Security fix for memory/CPU exhaustion