### PR TITLE
docs: Clarify profile help text about public content visibility

### DIFF
--- a/frontend/src/routes/admin/profile/+page.svelte
+++ b/frontend/src/routes/admin/profile/+page.svelte
@@ -200,7 +200,7 @@
 <div class="max-w-3xl mx-auto">
 	<PageHelp pageKey="profile">
 		<p><strong>Profile</strong> is your core identity - name, headline, summary, and photos.</p>
-		<p>This info appears on your homepage and can be overridden per-facet. Want a different headline for recruiters vs. conference attendees? Create facets with custom hero sections.</p>
+		<p>This info appears on your homepage, along with <strong>all content items marked as "public"</strong> (experience, projects, posts, talks, etc.). Use facets to create curated views with only the items you choose.</p>
 		<p><strong>Tip:</strong> Keep your default headline broad. Use facet overrides for audience-specific messaging.</p>
 	</PageHelp>
 


### PR DESCRIPTION
## Summary

Updates the profile page help text to clarify the relationship between visibility settings and the homepage.

- Explains that **all content items marked as "public"** (experience, projects, posts, talks, etc.) will appear on the homepage
- Clarifies the role of facets for creating curated views
- Maintains the existing tip about keeping headlines broad

## Changes

**Before:**
> This info appears on your homepage and can be overridden per-facet. Want a different headline for recruiters vs. conference attendees? Create facets with custom hero sections.

**After:**
> This info appears on your homepage, along with **all content items marked as "public"** (experience, projects, posts, talks, etc.). Use facets to create curated views with only the items you choose.

Fixes #225