### PR TITLE
ui: Move Testimonials section below Your Information and Your Voice in sidebar

### DIFF
--- a/frontend/src/components/admin/AdminSidebar.svelte
+++ b/frontend/src/components/admin/AdminSidebar.svelte
@@ -99,10 +99,12 @@
 
 const navSections = [
 	{
+		id: 'dashboard',
 		title: 'Dashboard',
 		items: [{ href: '/admin', label: 'Dashboard', icon: 'home' }]
 	},
 	{
+		id: 'information',
 		title: 'Your Information',
 		items: [
 			{ href: '/admin/contacts', label: 'Contact Methods', icon: 'mail' },
@@ -116,6 +118,7 @@ const navSections = [
 		]
 	},
 	{
+		id: 'voice',
 		title: 'Your Voice',
 		items: [
 			{ href: '/admin/posts', label: 'Posts', icon: 'document' },
@@ -123,6 +126,7 @@ const navSections = [
 		]
 	},
 	{
+		id: 'settings',
 		title: 'Settings',
 		items: [
 			{ href: '/admin/settings', label: 'General', icon: 'cog' },
@@ -131,6 +135,9 @@ const navSections = [
 		]
 	}
 ];
+
+const primarySections = navSections.filter(s => s.id === 'information' || s.id === 'voice');
+const settingsSections = navSections.filter(s => s.id === 'settings');
 
 // Reactive function that updates when $page changes
 let isActive = $derived((href: string): boolean => {
@@ -269,67 +276,8 @@ let isActive = $derived((href: string): boolean => {
 			</div>
 		</div>
 
-		<!-- Testimonials Section -->
-		<div class="space-y-2">
-			<button
-				type="button"
-				onclick={() => sidebarSectionStates.toggle(SECTION_IDS.testimonials, ALL_SECTION_IDS)}
-				class="flex items-center justify-between w-full text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors {$adminSidebarOpen ? '' : 'sr-only'}"
-				aria-expanded={isSectionExpanded(SECTION_IDS.testimonials)}
-				aria-controls="sidebar-testimonials-items"
-			>
-				<span class="flex items-center gap-2">
-					Testimonials
-					{#if $testimonialsStore.pendingCount > 0}
-						<span class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
-							{$testimonialsStore.pendingCount}
-						</span>
-					{/if}
-				</span>
-				<svg
-					class="w-4 h-4 transition-transform duration-200 {isSectionExpanded(SECTION_IDS.testimonials) ? 'rotate-0' : '-rotate-90'}"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					aria-hidden="true"
-				>
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-				</svg>
-			</button>
-			{#if isSectionExpanded(SECTION_IDS.testimonials)}
-				<div id="sidebar-testimonials-items" class="space-y-1">
-					<a
-						href="/admin/testimonials"
-						class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive('/admin/testimonials')
-							? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
-							: 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}"
-						title={!$adminSidebarOpen ? 'Testimonials' : undefined}
-						aria-current={isActive('/admin/testimonials') ? 'page' : undefined}
-					>
-						<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-						</svg>
-						<span class={$adminSidebarOpen ? '' : 'sr-only'}>Manage</span>
-					</a>
-					<a
-						href="/admin/testimonials/requests"
-						class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive('/admin/testimonials/requests')
-							? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
-							: 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}"
-						title={!$adminSidebarOpen ? 'Request Links' : undefined}
-						aria-current={isActive('/admin/testimonials/requests') ? 'page' : undefined}
-					>
-						<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-						</svg>
-						<span class={$adminSidebarOpen ? '' : 'sr-only'}>Request Links</span>
-					</a>
-				</div>
-			{/if}
-		</div>
-
-		<!-- Remaining Sections -->
-		{#each navSections.slice(1) as section}
+		<!-- Your Information and Your Voice Sections -->
+		{#each primarySections as section (section.id)}
 			{@const sectionId = sectionTitleToId[section.title] || `sidebar-${section.title.toLowerCase().replace(/\s+/g, '-')}`}
 			<div class="space-y-2">
 				<button
@@ -352,7 +300,7 @@ let isActive = $derived((href: string): boolean => {
 				</button>
 				{#if isSectionExpanded(sectionId)}
 					<div id="{sectionId}-items" class="space-y-1">
-						{#each section.items as item}
+						{#each section.items as item (item.href)}
 							<a
 								href={item.href}
 								class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive(item.href)
@@ -438,6 +386,123 @@ let isActive = $derived((href: string): boolean => {
 							{/if}
 
 							<!-- Always render label for screen readers, visually hide when sidebar collapsed -->
+							<span class={$adminSidebarOpen ? '' : 'sr-only'}>{item.label}</span>
+						</a>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/each}
+
+		<!-- Testimonials Section -->
+		<div class="space-y-2">
+			<button
+				type="button"
+				onclick={() => sidebarSectionStates.toggle(SECTION_IDS.testimonials, ALL_SECTION_IDS)}
+				class="flex items-center justify-between w-full text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors {$adminSidebarOpen ? '' : 'sr-only'}"
+				aria-expanded={isSectionExpanded(SECTION_IDS.testimonials)}
+				aria-controls="sidebar-testimonials-items"
+			>
+				<span class="flex items-center gap-2">
+					Testimonials
+					{#if $testimonialsStore.pendingCount > 0}
+						<span class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+							{$testimonialsStore.pendingCount}
+						</span>
+					{/if}
+				</span>
+				<svg
+					class="w-4 h-4 transition-transform duration-200 {isSectionExpanded(SECTION_IDS.testimonials) ? 'rotate-0' : '-rotate-90'}"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+					aria-hidden="true"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+				</svg>
+			</button>
+			{#if isSectionExpanded(SECTION_IDS.testimonials)}
+				<div id="sidebar-testimonials-items" class="space-y-1">
+					<a
+						href="/admin/testimonials"
+						class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive('/admin/testimonials')
+							? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
+							: 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}"
+						title={!$adminSidebarOpen ? 'Testimonials' : undefined}
+						aria-current={isActive('/admin/testimonials') ? 'page' : undefined}
+					>
+						<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+						</svg>
+						<span class={$adminSidebarOpen ? '' : 'sr-only'}>Manage</span>
+					</a>
+					<a
+						href="/admin/testimonials/requests"
+						class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive('/admin/testimonials/requests')
+							? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
+							: 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}"
+						title={!$adminSidebarOpen ? 'Request Links' : undefined}
+						aria-current={isActive('/admin/testimonials/requests') ? 'page' : undefined}
+					>
+						<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+						</svg>
+						<span class={$adminSidebarOpen ? '' : 'sr-only'}>Request Links</span>
+					</a>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Settings Section -->
+		{#each settingsSections as section (section.id)}
+			{@const sectionId = sectionTitleToId[section.title] || `sidebar-${section.title.toLowerCase().replace(/\s+/g, '-')}`}
+			<div class="space-y-2">
+				<button
+					type="button"
+					onclick={() => sidebarSectionStates.toggle(sectionId, ALL_SECTION_IDS)}
+					class="flex items-center justify-between w-full text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors {$adminSidebarOpen ? '' : 'sr-only'}"
+					aria-expanded={isSectionExpanded(sectionId)}
+					aria-controls="{sectionId}-items"
+				>
+					<span>{section.title}</span>
+					<svg
+						class="w-4 h-4 transition-transform duration-200 {isSectionExpanded(sectionId) ? 'rotate-0' : '-rotate-90'}"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						aria-hidden="true"
+					>
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+					</svg>
+				</button>
+				{#if isSectionExpanded(sectionId)}
+					<div id="{sectionId}-items" class="space-y-1">
+						{#each section.items as item (item.href)}
+							<a
+								href={item.href}
+								class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive(item.href)
+									? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300'
+									: 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}"
+								title={!$adminSidebarOpen ? `${section.title}: ${item.label}` : undefined}
+								aria-current={isActive(item.href) ? 'page' : undefined}
+							>
+							{#if item.icon === 'cog'}
+								<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+								</svg>
+							{:else if item.icon === 'image'}
+								<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+									<rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+									<circle cx="9" cy="9" r="2" />
+									<path d="m21 15-4-4a3 3 0 0 0-4.24 0L3 21" />
+								</svg>
+							{:else if item.icon === 'link'}
+								<svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+								</svg>
+							{/if}
+
 							<span class={$adminSidebarOpen ? '' : 'sr-only'}>{item.label}</span>
 						</a>
 						{/each}


### PR DESCRIPTION
## Summary

Reorders the admin sidebar to improve daily workflow by placing core content management sections higher in the navigation.

**New sidebar order:**
1. Dashboard
2. Profile
3. Facets
4. Your Information (collapsible)
5. Your Voice (collapsible)
6. Testimonials (collapsible) ← moved here
7. Settings (collapsible)

## Rationale

- **Your Information** and **Your Voice** contain primary content users manage daily
- **Testimonials** is a supplementary feature used less frequently
- Having core content management sections higher in the sidebar improves daily workflow
- Settings and Testimonials are both "secondary" concerns that fit better at the bottom

## Implementation

Per Oracle review, the implementation was improved to be more robust:

- **Added explicit IDs** to `navSections` for stable identification
- **Used keyed `{#each}` loops** (`section.id`, `item.href`) for proper Svelte state management
- **Replaced brittle index-based slicing** (`slice(1, 3)`, `slice(3)`) with semantic filtering:
  ```js
  const primarySections = navSections.filter(s => s.id === 'information' || s.id === 'voice');
  const settingsSections = navSections.filter(s => s.id === 'settings');
  ```

This approach is more maintainable if sections are added/reordered in the future.

## Testing

- ✅ `svelte-check` passes with 0 errors and 0 warnings
- Accessibility attributes preserved (`aria-expanded`, `aria-controls`, `button` semantics)

Fixes #227