### PR TITLE
fix(contacts): add missing contact method types (whatsapp, telegram, …

### DIFF
--- a/backend/migrations/1737600000_add_contact_method_types.go
+++ b/backend/migrations/1737600000_add_contact_method_types.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Adds missing contact method types: whatsapp, telegram, discord, slack, other
+// Fixes GitHub issue #277
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("contact_methods")
+		if err != nil {
+			return nil // Collection doesn't exist, skip
+		}
+
+		// Find the type field and update its allowed values
+		typeField := collection.Fields.GetByName("type")
+		if typeField == nil {
+			return nil
+		}
+
+		selectField, ok := typeField.(*core.SelectField)
+		if !ok {
+			return nil
+		}
+
+		// Updated list with all contact types
+		selectField.Values = []string{
+			"email",
+			"phone",
+			"linkedin",
+			"github",
+			"twitter",
+			"facebook",
+			"instagram",
+			"youtube",
+			"mastodon",
+			"bluesky",
+			"website",
+			"portfolio",
+			"blog",
+			"whatsapp",
+			"telegram",
+			"discord",
+			"slack",
+			"other",
+			"custom", // Keep for backwards compatibility
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		// Rollback: restore original values (optional, but good practice)
+		collection, err := app.FindCollectionByNameOrId("contact_methods")
+		if err != nil {
+			return nil
+		}
+
+		typeField := collection.Fields.GetByName("type")
+		if typeField == nil {
+			return nil
+		}
+
+		selectField, ok := typeField.(*core.SelectField)
+		if !ok {
+			return nil
+		}
+
+		selectField.Values = []string{
+			"email",
+			"phone",
+			"linkedin",
+			"github",
+			"twitter",
+			"facebook",
+			"instagram",
+			"youtube",
+			"mastodon",
+			"bluesky",
+			"website",
+			"portfolio",
+			"blog",
+			"custom",
+		}
+
+		return app.Save(collection)
+	})
+}

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -246,12 +246,18 @@ export type ContactMethodType =
 	| 'twitter'
 	| 'facebook'
 	| 'instagram'
+	| 'youtube'
+	| 'mastodon'
+	| 'bluesky'
 	| 'website'
+	| 'portfolio'
+	| 'blog'
 	| 'whatsapp'
 	| 'telegram'
 	| 'discord'
 	| 'slack'
-	| 'other';
+	| 'other'
+	| 'custom';
 
 export type ProtectionLevel = 'none' | 'obfuscation' | 'click_to_reveal' | 'captcha';
 

--- a/frontend/src/routes/admin/contacts/+page.svelte
+++ b/frontend/src/routes/admin/contacts/+page.svelte
@@ -117,11 +117,17 @@
 		{ value: 'twitter', label: 'Twitter', icon: '🐦', placeholder: 'https://twitter.com/username' },
 		{ value: 'facebook', label: 'Facebook', icon: '👥', placeholder: 'https://facebook.com/username' },
 		{ value: 'instagram', label: 'Instagram', icon: '📷', placeholder: 'https://instagram.com/username' },
+		{ value: 'youtube', label: 'YouTube', icon: '🎬', placeholder: 'https://youtube.com/@channel' },
+		{ value: 'mastodon', label: 'Mastodon', icon: '🐘', placeholder: 'https://mastodon.social/@username' },
+		{ value: 'bluesky', label: 'Bluesky', icon: '🦋', placeholder: 'username.bsky.social' },
 		{ value: 'website', label: 'Website', icon: '🌐', placeholder: 'https://yourwebsite.com' },
+		{ value: 'portfolio', label: 'Portfolio', icon: '💼', placeholder: 'https://portfolio.com' },
+		{ value: 'blog', label: 'Blog', icon: '✍️', placeholder: 'https://blog.com' },
 		{ value: 'whatsapp', label: 'WhatsApp', icon: '💬', placeholder: '+1 (555) 123-4567' },
 		{ value: 'telegram', label: 'Telegram', icon: '✈️', placeholder: '@username' },
-		{ value: 'discord', label: 'Discord', icon: '🎮', placeholder: 'username#1234' },
-		{ value: 'slack', label: 'Slack', icon: '💼', placeholder: '@username' },
+		{ value: 'discord', label: 'Discord', icon: '🎮', placeholder: 'username' },
+		{ value: 'slack', label: 'Slack', icon: '💬', placeholder: '@username' },
+		{ value: 'custom', label: 'Custom', icon: '⚙️', placeholder: 'Custom contact info' },
 		{ value: 'other', label: 'Other', icon: '🔗', placeholder: 'Contact information' }
 	];
 


### PR DESCRIPTION
…discord, slack, other)

Fixes #277 - Contact methods now support:
- WhatsApp, Telegram, Discord, Slack, Other
- YouTube, Mastodon, Bluesky, Portfolio, Blog, Custom

Also updates Discord placeholder from 'username#1234' to 'username' to reflect Discord's removal of discriminators.