### PR TITLE
fix: move AI prompt to separate file to avoid YAML parsing errors

### DIFF
--- a/.github/prompts/changelog-prompt.txt
+++ b/.github/prompts/changelog-prompt.txt
@@ -1,0 +1,25 @@
+You are a changelog generator for a software project called Facet (a professional portfolio platform).
+
+Given these merged pull requests, extract ALL distinct changes and categorize each one. A single PR may contain multiple bug fixes, features, or other changes - create a separate entry for each.
+
+Categories:
+- BUG: Bug fixes, error corrections, patches
+- FEATURE: New features, enhancements, additions
+- OTHER: Refactoring, documentation, maintenance, CI/CD
+
+Rules:
+1. Extract EVERY distinct change from each PR (a PR can have multiple entries)
+2. Each change gets its own entry with the appropriate category
+3. Descriptions should be clear, concise, and user-facing (no technical jargon)
+4. Remove prefixes like 'fix:', 'feat:', 'Claude/' from descriptions
+5. Start descriptions with a verb (Add, Fix, Improve, Update, etc.)
+6. Look at the PR title AND description to find all changes
+
+Output format (JSON array - same PR number can appear multiple times):
+[
+  {"number": 123, "category": "BUG", "description": "Fix navigation toggle not persisting state"},
+  {"number": 123, "category": "FEATURE", "description": "Add usage badges to admin items"},
+  {"number": 124, "category": "BUG", "description": "Fix mobile layout issues"}
+]
+
+Pull Requests:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -167,36 +167,9 @@ jobs:
           # Build prompt with PR data
           PR_LIST=$(echo "$PRS" | jq -r '.[] | "PR #\(.number): \(.title)\nDescription: \(.body // "No description")\n---"')
 
-          PROMPT=$(cat <<'PROMPT_EOF'
-You are a changelog generator for a software project called Facet (a professional portfolio platform).
-
-Given these merged pull requests, extract ALL distinct changes and categorize each one. A single PR may contain multiple bug fixes, features, or other changes - create a separate entry for each.
-
-Categories:
-- BUG: Bug fixes, error corrections, patches
-- FEATURE: New features, enhancements, additions
-- OTHER: Refactoring, documentation, maintenance, CI/CD
-
-Rules:
-1. Extract EVERY distinct change from each PR (a PR can have multiple entries)
-2. Each change gets its own entry with the appropriate category
-3. Descriptions should be clear, concise, and user-facing (no technical jargon)
-4. Remove prefixes like 'fix:', 'feat:', 'Claude/' from descriptions
-5. Start descriptions with a verb (Add, Fix, Improve, Update, etc.)
-6. Look at the PR title AND description to find all changes
-
-Output format (JSON array - same PR number can appear multiple times):
-[
-  {"number": 123, "category": "BUG", "description": "Fix navigation toggle not persisting state"},
-  {"number": 123, "category": "FEATURE", "description": "Add usage badges to admin items"},
-  {"number": 124, "category": "BUG", "description": "Fix mobile layout issues"}
-]
-
-Pull Requests:
-PROMPT_EOF
-)
-          # Append PR_LIST to the prompt
-          PROMPT="$PROMPT
+          # Read prompt template from file (avoids YAML parsing issues)
+          PROMPT_TEMPLATE=$(cat .github/prompts/changelog-prompt.txt)
+          PROMPT="$PROMPT_TEMPLATE
 $PR_LIST
 
 Output only valid JSON, no markdown or explanation."


### PR DESCRIPTION
## Summary

Fix YAML syntax error in auto-tag workflow by moving the AI prompt template to a separate file.

The prompt content contains colons and special characters (like `- BUG: Bug fixes...`) that GitHub's YAML parser interprets as key-value pairs, even inside heredoc blocks. Moving the prompt to `.github/prompts/changelog-prompt.txt` and reading it at runtime completely avoids YAML parsing.

## Changes

- Add `.github/prompts/changelog-prompt.txt` - AI prompt template for changelog generation
- Update `.github/workflows/auto-tag.yml` - Read prompt from file instead of embedding it
