### PR TITLE
fix: use printf to avoid YAML multi-line string issues

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -169,10 +169,7 @@ jobs:
 
           # Read prompt template from file (avoids YAML parsing issues)
           PROMPT_TEMPLATE=$(cat .github/prompts/changelog-prompt.txt)
-          PROMPT="$PROMPT_TEMPLATE
-$PR_LIST
-
-Output only valid JSON, no markdown or explanation."
+          PROMPT=$(printf '%s\n%s\n\nOutput only valid JSON, no markdown or explanation.' "$PROMPT_TEMPLATE" "$PR_LIST")
 
           # Try GitHub Models (Copilot) first - uses GITHUB_TOKEN
           echo "Trying GitHub Models (Copilot)..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Facet will be documented in this file.
 
 ---
 
-## Unreleased - January 26, 2026
+## v2.8.12 - January 26, 2026
 
 **Bugs Fixed:**
 - Fix site nav toggle state not persisting to database


### PR DESCRIPTION
## Summary

- Fix YAML syntax error by using `printf` instead of multi-line string literal for prompt construction
- Fix changelog header from "Unreleased" to "v2.8.12"
