### PR TITLE
fix: ensure Docker images include updated changelog

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -108,33 +108,6 @@ jobs:
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
           echo "New version: $NEW_TAG"
 
-      - name: Create and push tag
-        env:
-          NEW_TAG: ${{ steps.new_version.outputs.new_tag }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          BUMP_TYPE: ${{ steps.bump_type.outputs.bump }}
-          PREV_TAG: ${{ steps.get_tag.outputs.latest }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Create annotated tag with PR info
-          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
-            git tag -a "$NEW_TAG" -m "Release $NEW_TAG (manual trigger)"
-          else
-            git tag -a "$NEW_TAG" -m "Release $NEW_TAG" -m "" -m "PR: #$PR_NUMBER" -m "Title: $PR_TITLE"
-          fi
-
-          git push origin "$NEW_TAG"
-
-          echo "## Tag Created" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**New Tag:** \`$NEW_TAG\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Bump Type:** $BUMP_TYPE" >> $GITHUB_STEP_SUMMARY
-          echo "**Previous Tag:** $PREV_TAG" >> $GITHUB_STEP_SUMMARY
-
       - name: Update CHANGELOG
         env:
           GH_TOKEN: ${{ github.token }}
@@ -347,3 +320,30 @@ jobs:
             fi
             echo "CHANGELOG.md has been updated with release notes for $NEW_TAG" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Create and push tag
+        env:
+          NEW_TAG: ${{ steps.new_version.outputs.new_tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BUMP_TYPE: ${{ steps.bump_type.outputs.bump }}
+          PREV_TAG: ${{ steps.get_tag.outputs.latest }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create annotated tag with PR info
+          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
+            git tag -a "$NEW_TAG" -m "Release $NEW_TAG (manual trigger)"
+          else
+            git tag -a "$NEW_TAG" -m "Release $NEW_TAG" -m "" -m "PR: #$PR_NUMBER" -m "Title: $PR_TITLE"
+          fi
+
+          git push origin "$NEW_TAG"
+
+          echo "## Tag Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**New Tag:** \`$NEW_TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Bump Type:** $BUMP_TYPE" >> $GITHUB_STEP_SUMMARY
+          echo "**Previous Tag:** $PREV_TAG" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,8 @@
 # Uses native ARM runners for faster arm64 builds (no QEMU emulation).
 #
 # Triggers on:
-#   - Push to main branch (publishes as :latest and :main)
 #   - Version tags (v1.0.0 publishes as :1.0.0, :1.0, :1, :latest)
+#   - Feature branches (for testing)
 #   - Manual dispatch (workflow_dispatch)
 #
 # Images are published to: ghcr.io/jesposito/facet
@@ -15,7 +15,8 @@ name: Build and Publish Docker Image
 on:
   push:
     branches:
-      - main
+      # Note: 'main' removed - release builds happen on version tags only
+      # This ensures the changelog is included (generated before tag)
       - 'upgrade/*'
       - 'claude/*'
       - 'auto-claude/*'
@@ -171,11 +172,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            # Set latest tag for version tags (releases)
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             # Dev tag for upgrade, claude, auto-claude, feature, dev, and fix branches
             type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/heads/upgrade/') || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/auto-claude/') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/dev/') || startsWith(github.ref, 'refs/heads/fix/') }}
-            # Branch name (e.g., main)
+            # Branch name (e.g., feature/foo)
             type=ref,event=branch
             # Tag name (e.g., v1.0.0 -> 1.0.0)
             type=semver,pattern={{version}}


### PR DESCRIPTION
## Summary

Fix Docker images not including the updated changelog by reordering the auto-tag workflow and updating docker-publish triggers.

### Changes

**auto-tag.yml:**
- Reorder steps: changelog is now committed BEFORE creating the tag
- Tag now points to a commit that includes the changelog entry

**docker-publish.yml:**
- Remove `main` branch from triggers (releases only build on tags)
- Apply `:latest` tag to version tags (`refs/tags/v*`) instead of default branch

### Flow After This Fix

1. PR merged to main
2. auto-tag workflow runs:
   - Generates changelog entry
   - Commits and pushes changelog to main
   - Creates and pushes version tag (pointing to changelog commit)
3. Tag triggers docker-publish
4. Docker image includes updated changelog
5. `:latest` tag applied to release

### Result

- `ghcr.io/jesposito/facet:latest` will include the changelog
- Fewer duplicate builds (no separate main branch build)
- Unraid users get the correct changelog when they update