### PR TITLE
fix: add git config before changelog commit and pull before tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -116,6 +116,10 @@ jobs:
           REPO: ${{ github.repository }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          # Configure git for commits
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           # Clean up any previous temp files
           rm -f /tmp/bugs.txt /tmp/features.txt /tmp/other.txt /tmp/pr_links.txt /tmp/pr_data.json
 
@@ -333,7 +337,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create annotated tag with PR info
+          # Pull latest main to include the changelog commit
+          git pull origin main
+
+          # Create annotated tag with PR info (on the changelog commit)
           if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             git tag -a "$NEW_TAG" -m "Release $NEW_TAG (manual trigger)"
           else


### PR DESCRIPTION
## Summary

Fix two issues that caused auto-tag workflow to fail with exit code 128:

1. **git config not set before changelog commit** - The "Update CHANGELOG" step tries to commit but git config (user.name/email) was only set in the later "Create tag" step
2. **Local HEAD out of sync after changelog push** - After pushing the changelog to main, local HEAD was behind remote, so the tag would be created on the wrong commit

## Changes

- Add `git config` commands at the start of "Update CHANGELOG" step
- Add `git pull origin main` before creating the tag to ensure it points to the changelog commit