### PR TITLE
fix: clean up duplicate changelog entries and fix version numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,7 @@ All notable changes to Facet will be documented in this file.
 
 ---
 
----
-
-## v2.8.12 - January 26, 2026
+## v2.8.11 - January 26, 2026
 
 **Bugs Fixed:**
 - Fix site nav toggle state not persisting to database


### PR DESCRIPTION
- Remove extra separator between changelog sections
- Rename duplicate v2.8.12 to v2.8.11 (was previous release)