### PR TITLE
fix: add actions:write permission to trigger Docker workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -34,6 +34,7 @@ jobs:
     
     permissions:
       contents: write
+      actions: write
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
GITHUB_TOKEN needs actions:write permission to use gh workflow run.