### PR TITLE
Claude/custom content continued

### DIFF
--- a/.github/prompts/changelog-prompt.txt
+++ b/.github/prompts/changelog-prompt.txt
@@ -14,6 +14,9 @@ Rules:
 4. Remove prefixes like 'fix:', 'feat:', 'Claude/' from descriptions
 5. Start descriptions with a verb (Add, Fix, Improve, Update, etc.)
 6. Look at the PR title AND description to find all changes
+7. CRITICAL: Do NOT include changes already documented in the "Recent changelog" section below
+8. If a PR describes something already in the recent changelog, skip it entirely
+9. Only create entries for genuinely NEW changes not already documented
 
 Output format (JSON array - same PR number can appear multiple times):
 [

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -137,17 +137,36 @@ jobs:
           PRS=$(gh pr list --state merged --base main --search "merged:>=$SINCE_DATE" --json number,title,url,body --limit 100)
           echo "$PRS" > /tmp/pr_data.json
 
+          # Extract PR numbers already documented in changelog to avoid duplicates
+          EXISTING_PRS=$(grep -oE '\[#[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')
+          echo "Already documented PRs: $EXISTING_PRS"
+
+          # Filter out already-documented PRs
+          if [ -n "$EXISTING_PRS" ]; then
+            FILTERED_PRS=$(echo "$PRS" | jq --arg existing "$EXISTING_PRS" '
+              [.[] | select(.number as $n | ($existing | split(" ") | map(select(. != "")) | map(tonumber)) | index($n) | not)]
+            ')
+          else
+            FILTERED_PRS="$PRS"
+          fi
+
+          PR_COUNT=$(echo "$FILTERED_PRS" | jq 'length')
+          echo "New PRs to document: $PR_COUNT"
+
           # Try AI-powered changelog generation
           # Priority: 1) GitHub Models (Copilot), 2) OpenAI API, 3) Keyword fallback
           AI_SUCCESS=false
           AI_SOURCE=""
 
-          # Build prompt with PR data
-          PR_LIST=$(echo "$PRS" | jq -r '.[] | "PR #\(.number): \(.title)\nDescription: \(.body // "No description")\n---"')
+          # Build prompt with PR data (using filtered list)
+          PR_LIST=$(echo "$FILTERED_PRS" | jq -r '.[] | "PR #\(.number): \(.title)\nDescription: \(.body // "No description")\n---"')
+
+          # Get recent changelog entries for AI context (helps avoid semantic duplicates)
+          RECENT_CHANGELOG=$(head -50 CHANGELOG.md | tail -45)
 
           # Read prompt template from file (avoids YAML parsing issues)
           PROMPT_TEMPLATE=$(cat .github/prompts/changelog-prompt.txt)
-          PROMPT=$(printf '%s\n%s\n\nOutput only valid JSON, no markdown or explanation.' "$PROMPT_TEMPLATE" "$PR_LIST")
+          PROMPT=$(printf '%s\n\nRecent changelog (DO NOT duplicate these entries):\n%s\n\nNew PRs to document:\n%s\n\nOutput only valid JSON, no markdown or explanation.' "$PROMPT_TEMPLATE" "$RECENT_CHANGELOG" "$PR_LIST")
 
           # Try GitHub Models (Copilot) first - uses GITHUB_TOKEN
           echo "Trying GitHub Models (Copilot)..."
@@ -224,7 +243,7 @@ jobs:
           if [ "$AI_SUCCESS" = false ]; then
             echo "Using keyword-based categorization..."
 
-            echo "$PRS" | jq -c '.[]' | while read -r pr; do
+            echo "$FILTERED_PRS" | jq -c '.[]' | while read -r pr; do
               [ -z "$pr" ] && continue
               NUMBER=$(echo "$pr" | jq -r '.number')
               TITLE=$(echo "$pr" | jq -r '.title')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,29 +23,6 @@ All notable changes to Facet will be documented in this file.
 ---
 
 
-## v2.8.15 - January 26, 2026
-
-**Bugs Fixed:**
-- Fix navigation toggle not persisting state
-- Fix mobile layout issues
-- Fix image upload errors on profile settings
-
-**New Features:**
-- Add usage badges to admin items
-- Introduce dark mode for user profiles
-- Add ability to filter portfolios by category
-- Enhance search functionality with keyword suggestions
-
-**Other Changes:**
-- Update documentation for dark mode feature
-- Refactor portfolio display component for better performance
-- Update CI/CD pipeline for faster deployments
-
-**Pull Requests:** [#123](),[#124](),[#125](),[#126](),[#127](),[#128](),[#129](),[#130](),
-
----
-
-
 ## v2.8.14 - January 26, 2026
 
 **Other Changes:**

--- a/frontend/src/components/admin/AdminSidebar.svelte
+++ b/frontend/src/components/admin/AdminSidebar.svelte
@@ -5,8 +5,77 @@
 	import { adminSidebarOpen, sidebarSectionStates, sidebarFacetsVersion } from '$lib/stores';
 	import { collection } from '$lib/stores/demo';
 	import { testimonialsStore, refreshTestimonialsPendingCount } from '$lib/stores/testimonials';
+	import { browser } from '$app/environment';
 
 	const appVersion = __APP_VERSION__;
+
+	// Version check state
+	let newVersionAvailable = $state(false);
+	let latestVersion = $state('');
+
+	// Check for new version (cached daily)
+	async function checkForNewVersion() {
+		if (!browser) return;
+
+		const CACHE_KEY = 'facet_version_check';
+		const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+
+		try {
+			// Check cache first
+			const cached = localStorage.getItem(CACHE_KEY);
+			if (cached) {
+				const { timestamp, latest, hasUpdate } = JSON.parse(cached);
+				if (Date.now() - timestamp < CACHE_DURATION) {
+					latestVersion = latest;
+					newVersionAvailable = hasUpdate;
+					return;
+				}
+			}
+
+			// Fetch latest release from GitHub
+			const response = await fetch('https://api.github.com/repos/jesposito/Facet/releases/latest', {
+				headers: { 'Accept': 'application/vnd.github.v3+json' }
+			});
+
+			if (!response.ok) return;
+
+			const data = await response.json();
+			const latest = data.tag_name || '';
+
+			// Compare versions (strip 'v' prefix for comparison)
+			const currentClean = appVersion.replace(/^v/, '').split('-')[0];
+			const latestClean = latest.replace(/^v/, '');
+
+			const hasUpdate = latestClean && currentClean !== latestClean &&
+				compareVersions(latestClean, currentClean) > 0;
+
+			// Cache result
+			localStorage.setItem(CACHE_KEY, JSON.stringify({
+				timestamp: Date.now(),
+				latest,
+				hasUpdate
+			}));
+
+			latestVersion = latest;
+			newVersionAvailable = hasUpdate;
+		} catch {
+			// Silently fail - version check is non-critical
+		}
+	}
+
+	// Compare semver versions: returns 1 if a > b, -1 if a < b, 0 if equal
+	function compareVersions(a: string, b: string): number {
+		const partsA = a.split('.').map(Number);
+		const partsB = b.split('.').map(Number);
+
+		for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+			const numA = partsA[i] || 0;
+			const numB = partsB[i] || 0;
+			if (numA > numB) return 1;
+			if (numA < numB) return -1;
+		}
+		return 0;
+	}
 
 	interface Props {
 		isMobile?: boolean;
@@ -53,6 +122,7 @@
 		sidebarSectionStates.initialize(ALL_SECTION_IDS, SECTION_IDS.information);
 		scheduleFacetsLoad();
 		refreshTestimonialsPendingCount();
+		checkForNewVersion();
 	});
 
 	// Reload facets when sidebarFacetsVersion changes (e.g., after demo mode toggle)
@@ -589,6 +659,16 @@ let isActive = $derived((href: string): boolean => {
 			<div class="text-center text-xs text-gray-400 dark:text-gray-500">
 				{appVersion}
 			</div>
+			{#if newVersionAvailable}
+				<div class="mt-1 text-center">
+					<span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300">
+						<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+						</svg>
+						Update available
+					</span>
+				</div>
+			{/if}
 		</div>
 	{/if}
 </aside>

--- a/frontend/src/routes/admin/settings/about/+page.svelte
+++ b/frontend/src/routes/admin/settings/about/+page.svelte
@@ -1,8 +1,77 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 
 	// App version from Vite config
 	const appVersion = __APP_VERSION__;
+
+	// Version check state
+	let newVersionAvailable = $state(false);
+	let latestVersion = $state('');
+
+	// Check for new version (cached daily)
+	async function checkForNewVersion() {
+		if (!browser) return;
+
+		const CACHE_KEY = 'facet_version_check';
+		const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+
+		try {
+			// Check cache first
+			const cached = localStorage.getItem(CACHE_KEY);
+			if (cached) {
+				const { timestamp, latest, hasUpdate } = JSON.parse(cached);
+				if (Date.now() - timestamp < CACHE_DURATION) {
+					latestVersion = latest;
+					newVersionAvailable = hasUpdate;
+					return;
+				}
+			}
+
+			// Fetch latest release from GitHub
+			const response = await fetch('https://api.github.com/repos/jesposito/Facet/releases/latest', {
+				headers: { 'Accept': 'application/vnd.github.v3+json' }
+			});
+
+			if (!response.ok) return;
+
+			const data = await response.json();
+			const latest = data.tag_name || '';
+
+			// Compare versions (strip 'v' prefix for comparison)
+			const currentClean = appVersion.replace(/^v/, '').split('-')[0];
+			const latestClean = latest.replace(/^v/, '');
+
+			const hasUpdate = latestClean && currentClean !== latestClean &&
+				compareVersions(latestClean, currentClean) > 0;
+
+			// Cache result
+			localStorage.setItem(CACHE_KEY, JSON.stringify({
+				timestamp: Date.now(),
+				latest,
+				hasUpdate
+			}));
+
+			latestVersion = latest;
+			newVersionAvailable = hasUpdate;
+		} catch {
+			// Silently fail - version check is non-critical
+		}
+	}
+
+	// Compare semver versions: returns 1 if a > b, -1 if a < b, 0 if equal
+	function compareVersions(a: string, b: string): number {
+		const partsA = a.split('.').map(Number);
+		const partsB = b.split('.').map(Number);
+
+		for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+			const numA = partsA[i] || 0;
+			const numB = partsB[i] || 0;
+			if (numA > numB) return 1;
+			if (numA < numB) return -1;
+		}
+		return 0;
+	}
 
 	// Changelog state
 	interface ChangelogEntry {
@@ -27,6 +96,7 @@
 
 	onMount(async () => {
 		await loadChangelog();
+		checkForNewVersion();
 	});
 
 	async function loadChangelog() {
@@ -108,9 +178,19 @@
 	<div class="card p-6">
 		<div class="flex items-center justify-between mb-4">
 			<h1 class="text-2xl font-semibold text-gray-900 dark:text-white">About Facet</h1>
-			<span class="px-3 py-1 text-sm font-mono bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg">
-				{appVersion}
-			</span>
+			<div class="flex items-center gap-2">
+				<span class="px-3 py-1 text-sm font-mono bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg">
+					{appVersion}
+				</span>
+				{#if newVersionAvailable}
+					<span class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300">
+						<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+						</svg>
+						{latestVersion} available
+					</span>
+				{/if}
+			</div>
 		</div>
 
 		<p class="text-gray-600 dark:text-gray-400 mb-6">


### PR DESCRIPTION
## Summary
- Add "Update available" badge to admin sidebar and About page when a newer version is released
- Fix AI changelog generator creating duplicate/fabricated entries by filtering already-documented PRs
- Pass recent changelog context to AI to prevent semantic duplicates

## Changes

### Version Update Notifications
- Checks GitHub API for latest release on page load (cached for 24 hours)
- Shows accent-colored badge in sidebar under version number
- Shows badge with new version number on About Facet page

### Changelog Duplicate Fix
- Filters out PRs already documented in changelog before sending to AI
- Passes last ~45 lines of changelog as context to AI
- Added rules 7-9 to prompt: "Do NOT include changes already documented"
- Removed AI fabricated v2.8.15 entry (had empty PR links like `[#123]()`)
