### PR TITLE
fix(favicon): add dedicated API endpoints and fix reactivity

### DIFF
--- a/backend/hooks/settings.go
+++ b/backend/hooks/settings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/filesystem"
 )
 
 // RegisterSiteSettingsHooks exposes site settings for homepage/privacy control.
@@ -140,6 +141,72 @@ func RegisterSiteSettingsHooks(app *pocketbase.PocketBase) {
 				"skills_category_order":   settings.SkillsCategoryOrder,
 				"site_cta_enabled":        settings.SiteCtaEnabled,
 				"favicon":                 settings.Favicon,
+			})
+		})
+
+		// Authenticated: upload favicon
+		se.Router.POST("/api/site-settings/favicon", func(e *core.RequestEvent) error {
+			if e.Auth == nil {
+				return apis.NewUnauthorizedError("authentication required", nil)
+			}
+
+			settings, err := services.LoadSiteSettings(app)
+			if err != nil || settings.Record == nil {
+				return apis.NewBadRequestError("failed to load site settings", err)
+			}
+
+			// Get uploaded file
+			file, fileHeader, err := e.Request.FormFile("favicon")
+			if err != nil {
+				return apis.NewBadRequestError("favicon file required", err)
+			}
+			defer file.Close()
+
+			// Create filesystem.File from multipart file
+			fsFile, err := filesystem.NewFileFromMultipart(fileHeader)
+			if err != nil {
+				return apis.NewBadRequestError("failed to process file", err)
+			}
+
+			// Set the file on the record
+			settings.Record.Set("favicon", fsFile)
+
+			if err := app.Save(settings.Record); err != nil {
+				return apis.NewBadRequestError("failed to save favicon", err)
+			}
+
+			// Build the new favicon URL
+			faviconFile := settings.Record.GetString("favicon")
+			var faviconURL string
+			if faviconFile != "" {
+				faviconURL = "/api/files/" + settings.Record.Collection().Id + "/" + settings.Record.Id + "/" + faviconFile
+			}
+
+			return e.JSON(http.StatusOK, map[string]any{
+				"favicon": faviconURL,
+			})
+		})
+
+		// Authenticated: remove favicon
+		se.Router.DELETE("/api/site-settings/favicon", func(e *core.RequestEvent) error {
+			if e.Auth == nil {
+				return apis.NewUnauthorizedError("authentication required", nil)
+			}
+
+			settings, err := services.LoadSiteSettings(app)
+			if err != nil || settings.Record == nil {
+				return apis.NewBadRequestError("failed to load site settings", err)
+			}
+
+			// Clear the favicon field
+			settings.Record.Set("favicon", nil)
+
+			if err := app.Save(settings.Record); err != nil {
+				return apis.NewBadRequestError("failed to remove favicon", err)
+			}
+
+			return e.JSON(http.StatusOK, map[string]any{
+				"favicon": nil,
 			})
 		})
 

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -54,9 +54,8 @@
 
 	// Favicon state
 	let faviconUrl: string | null = $state(null);
-	let faviconFile: File | null = null;
-	let faviconBlobUrl: string | null = null;
-	let siteSettingsRecordId: string | null = $state(null);
+	let faviconFile: File | null = $state(null);
+	let faviconBlobUrl: string | null = $state(null);
 	let faviconSaving = $state(false);
 
 	// Export state
@@ -366,12 +365,6 @@
 				hideDemoToggle = data.hide_demo_toggle || false;
 				faviconUrl = data.favicon || null;
 			}
-
-			// Also load the site_settings record ID for direct file uploads
-			const records = await pb.collection('site_settings').getList(1, 1);
-			if (records.items.length > 0) {
-				siteSettingsRecordId = records.items[0].id;
-			}
 		} catch (err) {
 			console.error('Failed to load site settings:', err);
 		} finally {
@@ -443,14 +436,26 @@
 	}
 
 	async function saveFavicon() {
-		if (!faviconFile || !siteSettingsRecordId) return;
+		if (!faviconFile) return;
 
 		faviconSaving = true;
 		try {
 			const formData = new FormData();
 			formData.append('favicon', faviconFile);
 
-			const updated = await pb.collection('site_settings').update(siteSettingsRecordId, formData);
+			const response = await fetch('/api/site-settings/favicon', {
+				method: 'POST',
+				headers: {
+					Authorization: pb.authStore.token || ''
+				},
+				body: formData
+			});
+
+			const result = await response.json();
+			if (!response.ok) {
+				toasts.add('error', result.error || 'Failed to save favicon');
+				return;
+			}
 
 			// Clean up blob URL
 			if (faviconBlobUrl) {
@@ -460,8 +465,8 @@
 			faviconFile = null;
 
 			// Update URL with cache buster
-			if (updated.favicon) {
-				const newUrl = `/api/files/${updated.collectionId}/${updated.id}/${updated.favicon}?${Date.now()}`;
+			if (result.favicon) {
+				const newUrl = `${result.favicon}?${Date.now()}`;
 				faviconUrl = newUrl;
 				// Notify layout to update favicon in browser tab
 				window.dispatchEvent(new CustomEvent('favicon-changed', { detail: newUrl }));
@@ -477,8 +482,6 @@
 	}
 
 	async function removeFavicon() {
-		if (!siteSettingsRecordId) return;
-
 		const confirmed = await confirm({
 			title: 'Remove Favicon',
 			message: 'Are you sure you want to remove your custom favicon? The default Facet favicon will be used.',
@@ -489,7 +492,18 @@
 
 		faviconSaving = true;
 		try {
-			await pb.collection('site_settings').update(siteSettingsRecordId, { favicon: null });
+			const response = await fetch('/api/site-settings/favicon', {
+				method: 'DELETE',
+				headers: {
+					Authorization: pb.authStore.token || ''
+				}
+			});
+
+			if (!response.ok) {
+				const result = await response.json();
+				toasts.add('error', result.error || 'Failed to remove favicon');
+				return;
+			}
 
 			if (faviconBlobUrl) {
 				URL.revokeObjectURL(faviconBlobUrl);


### PR DESCRIPTION
## Summary

Fixes the favicon upload functionality which was broken due to PocketBase collection rules requiring superuser access.

## Changes

### Backend
- Add `POST /api/site-settings/favicon` endpoint for uploading favicons
- Add `DELETE /api/site-settings/favicon` endpoint for removing favicons
- Uses authenticated endpoints instead of direct PocketBase SDK calls

### Frontend
- Fix `faviconFile` and `faviconBlobUrl` reactivity by adding `$state()`
- Update upload/remove functions to use new API endpoints
- Remove direct `pb.collection('site_settings')` calls that caused 403 errors
- Remove unused `siteSettingsRecordId` variable

## Test Plan
- [ ] Upload favicon - should show Save/Cancel buttons
- [ ] Save favicon - should update preview and browser tab
- [ ] Cancel upload - should revert to previous state
- [ ] Remove favicon - should show confirmation, then revert to default
- [ ] File size validation - files > 512KB should show error