### PR TITLE
security: add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/hall-of-fame.yml
+++ b/.github/workflows/hall-of-fame.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   celebrate:
     if: github.event.pull_request.merged == true && github.event.pull_request.user.login != 'jesposito'

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -7,6 +7,9 @@ on:
       - 'frontend/src/lib/i18n/**'
       - 'scripts/validate-translations.js'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Translations


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` blocks to workflow files that were missing them, satisfying GitHub's code scanning security requirements.

## Changes

- **i18n-check.yml** - Added minimal read-only permissions
- **hall-of-fame.yml** - Added minimal read-only permissions

Both workflows only need read access to repository contents.

## Security Alerts Resolved

- Code scanning alert #6 (i18n-check.yml missing permissions)
- Code scanning alert #7 (hall-of-fame.yml job 1 missing permissions)
- Code scanning alert #9 (hall-of-fame.yml job 2 missing permissions)

## Remaining Alerts (not actionable)

| Alert | Package | Severity | Status |
|-------|---------|----------|--------|
| #11 | esbuild | Medium | Upstream in svelte-i18n (already at latest 4.0.1) |
| #1 | imaging (Go) | Low | No patch available from maintainer |

The esbuild alert is a dev-server-only vulnerability that doesn't affect production builds. The imaging alert affects TIFF processing and has no fix released yet.

## Test plan

- [x] Workflow YAML syntax is valid
- [x] Permissions follow principle of least privilege