### PR TITLE
fix: homepage visitor counter, navbar pill timing, content visibility hint, encryption banner rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,12 @@ Facet isn't just private. It's designed to be verifiably secure. Read the full s
 git clone https://github.com/jesposito/Facet.git
 cd Facet
 
-# Generate an encryption key (required for API keys and tokens)
-openssl rand -hex 32
-
 # Copy the example config
 cp .env.example .env
 
 # Edit .env:
-# - Set ENCRYPTION_KEY (required)
 # - Set ADMIN_EMAILS to your email
+# - (Optional) Set ENCRYPTION_KEY — if not set, one is auto-generated and saved to /data/.encryption_key
 # - (Optional) Add OAuth credentials (GOOGLE_CLIENT_ID/SECRET or GITHUB_CLIENT_ID/SECRET)
 
 # Run it
@@ -556,7 +553,7 @@ For detailed architecture: [ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
 | Variable | Required? | Default | What It Does |
 |----------|-----------|---------|--------------|
-| `ENCRYPTION_KEY` | **Yes** | — | 32-byte hex key for encrypting API keys and tokens (`openssl rand -hex 32`) |
+| `ENCRYPTION_KEY` | No | Auto-generated | 32-byte hex key for encrypting API keys and tokens. If not set, one is auto-generated and saved to `/data/.encryption_key`. Generate manually with `openssl rand -hex 32` |
 | `PORT` | No | `8080` | Public port for the app |
 | `APP_URL` | No | `http://localhost:8080` | Your public URL (needed for OAuth callbacks) |
 | `ADMIN_EMAILS` | No | — | Comma-separated email allowlist for OAuth login |

--- a/backend/hooks/settings.go
+++ b/backend/hooks/settings.go
@@ -41,7 +41,7 @@ func RegisterSiteSettingsHooks(app *pocketbase.PocketBase) {
 			}
 
 			return e.JSON(http.StatusOK, map[string]any{
-				"homepage_enabled":         settings.HomepageEnabled,
+				"homepage_enabled":        settings.HomepageEnabled,
 				"landing_page_message":    settings.LandingPageMessage,
 				"custom_css":              settings.CustomCSS,
 				"ga_measurement_id":       settings.GAMeasurementID,
@@ -56,6 +56,8 @@ func RegisterSiteSettingsHooks(app *pocketbase.PocketBase) {
 				"site_cta_enabled":        settings.SiteCtaEnabled,
 				"favicon":                 settings.Favicon,
 				"default_locale":          settings.DefaultLocale,
+				"homepage_view_count":     settings.HomepageViewCount,
+				"homepage_last_viewed_at": settings.HomepageLastViewedAt,
 			})
 		})
 
@@ -66,20 +68,20 @@ func RegisterSiteSettingsHooks(app *pocketbase.PocketBase) {
 			}
 
 			var req struct {
-				HomepageEnabled       *bool                                         `json:"homepage_enabled"`
-				LandingPageMessage    *string                                       `json:"landing_page_message"`
-				CustomCSS             *string                                       `json:"custom_css"`
-				GAMeasurementID       *string                                       `json:"ga_measurement_id"`
-				HideLoginButton       *bool                                         `json:"hide_login_button"`
-				HideDemoToggle        *bool                                         `json:"hide_demo_toggle"`
-				HomepageCustomContent []services.HomepageCustomContentItem          `json:"homepage_custom_content"`
-				HomepageSectionOrder  []string                                      `json:"homepage_section_order"`
-				HomepageSections      map[string]services.HomepageSectionConfig     `json:"homepage_sections"`
-				SiteNavEnabled        *bool                                         `json:"site_nav_enabled"`
-				SiteNavItems          []services.SiteNavItem                        `json:"site_nav_items"`
-				SkillsCategoryOrder   []string                                      `json:"skills_category_order"`
-				SiteCtaEnabled        *bool                                         `json:"site_cta_enabled"`
-				DefaultLocale         *string                                       `json:"default_locale"`
+				HomepageEnabled       *bool                                     `json:"homepage_enabled"`
+				LandingPageMessage    *string                                   `json:"landing_page_message"`
+				CustomCSS             *string                                   `json:"custom_css"`
+				GAMeasurementID       *string                                   `json:"ga_measurement_id"`
+				HideLoginButton       *bool                                     `json:"hide_login_button"`
+				HideDemoToggle        *bool                                     `json:"hide_demo_toggle"`
+				HomepageCustomContent []services.HomepageCustomContentItem      `json:"homepage_custom_content"`
+				HomepageSectionOrder  []string                                  `json:"homepage_section_order"`
+				HomepageSections      map[string]services.HomepageSectionConfig `json:"homepage_sections"`
+				SiteNavEnabled        *bool                                     `json:"site_nav_enabled"`
+				SiteNavItems          []services.SiteNavItem                    `json:"site_nav_items"`
+				SkillsCategoryOrder   []string                                  `json:"skills_category_order"`
+				SiteCtaEnabled        *bool                                     `json:"site_cta_enabled"`
+				DefaultLocale         *string                                   `json:"default_locale"`
 			}
 
 			if err := e.BindBody(&req); err != nil {
@@ -150,7 +152,7 @@ func RegisterSiteSettingsHooks(app *pocketbase.PocketBase) {
 			}
 
 			return e.JSON(http.StatusOK, map[string]any{
-				"homepage_enabled":         settings.HomepageEnabled,
+				"homepage_enabled":        settings.HomepageEnabled,
 				"landing_page_message":    settings.LandingPageMessage,
 				"custom_css":              settings.CustomCSS,
 				"ga_measurement_id":       settings.GAMeasurementID,

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -686,6 +686,10 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 				})
 			}
 
+			if settings != nil && settings.HomepageEnabled {
+				incrementHomepageViewCount(app)
+			}
+
 			// Find the default view (is_default = true, is_active = true, visibility = public)
 			records, err := app.FindRecordsByFilter(
 				"views",

--- a/backend/hooks/view_helpers.go
+++ b/backend/hooks/view_helpers.go
@@ -469,8 +469,20 @@ func filterBySelectedItemsWithDefault(items []map[string]interface{}, selectedIt
 	return result
 }
 
-// getSectionConfig returns the configuration for a section from homepage_sections.
-// Returns enabled, items, and isConfigured (whether the section has explicit config).
+func incrementHomepageViewCount(app core.App) {
+	go func() {
+		settings, err := services.LoadSiteSettings(app)
+		if err != nil || settings == nil || settings.Record == nil {
+			return
+		}
+		settings.Record.Set("homepage_view_count", settings.Record.GetInt("homepage_view_count")+1)
+		settings.Record.Set("homepage_last_viewed_at", time.Now())
+		if err := app.Save(settings.Record); err != nil {
+			app.Logger().Warn("Failed to update homepage view metrics", "error", err)
+		}
+	}()
+}
+
 func getSectionConfig(settings *services.SiteSettings, sectionKey string) (enabled bool, items []string, isConfigured bool) {
 	if settings == nil || settings.HomepageSections == nil {
 		return true, nil, false

--- a/backend/migrations/1769790000_add_homepage_view_metrics.go
+++ b/backend/migrations/1769790000_add_homepage_view_metrics.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Adds homepage view metrics fields to the site_settings collection.
+// - homepage_view_count: total public/unauthed homepage fetches
+// - homepage_last_viewed_at: timestamp of most recent public/unauthed homepage fetch
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("site_settings")
+		if err != nil {
+			return nil
+		}
+
+		// Add homepage_view_count if missing
+		if collection.Fields.GetByName("homepage_view_count") == nil {
+			collection.Fields.Add(&core.NumberField{
+				Name: "homepage_view_count",
+			})
+		}
+
+		// Add homepage_last_viewed_at if missing
+		if collection.Fields.GetByName("homepage_last_viewed_at") == nil {
+			collection.Fields.Add(&core.DateField{
+				Name: "homepage_last_viewed_at",
+			})
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("site_settings")
+		if err != nil {
+			return nil
+		}
+
+		// Remove fields on rollback (only if they exist)
+		collection.Fields.RemoveByName("homepage_view_count")
+		collection.Fields.RemoveByName("homepage_last_viewed_at")
+
+		return app.Save(collection)
+	})
+}

--- a/backend/services/settings.go
+++ b/backend/services/settings.go
@@ -17,12 +17,12 @@ type HomepageCustomContentItem struct {
 // HomepageSectionConfig represents per-section settings for the homepage
 // Mirrors the structure used in views for consistency
 type HomepageSectionConfig struct {
-	Enabled       bool              `json:"enabled"`
-	Items         []string          `json:"items,omitempty"`          // Selected item IDs (empty = all)
-	Layout        string            `json:"layout,omitempty"`         // Section layout
-	Width         string            `json:"width,omitempty"`          // Section width
-	CategoryOrder []string          `json:"categoryOrder,omitempty"`  // For skills: custom category order
-	ItemConfig    map[string]any    `json:"itemConfig,omitempty"`     // Per-item overrides
+	Enabled       bool           `json:"enabled"`
+	Items         []string       `json:"items,omitempty"`         // Selected item IDs (empty = all)
+	Layout        string         `json:"layout,omitempty"`        // Section layout
+	Width         string         `json:"width,omitempty"`         // Section width
+	CategoryOrder []string       `json:"categoryOrder,omitempty"` // For skills: custom category order
+	ItemConfig    map[string]any `json:"itemConfig,omitempty"`    // Per-item overrides
 }
 
 // SiteNavItem represents a navigation button configuration
@@ -49,6 +49,8 @@ type SiteSettings struct {
 	SiteCtaEnabled        bool
 	Favicon               string
 	DefaultLocale         string
+	HomepageViewCount     int
+	HomepageLastViewedAt  string
 	Record                *core.Record
 }
 
@@ -152,6 +154,8 @@ func LoadSiteSettings(app core.App) (*SiteSettings, error) {
 		SiteCtaEnabled:        siteCtaEnabled,
 		Favicon:               faviconURL,
 		DefaultLocale:         record.GetString("default_locale"),
+		HomepageViewCount:     record.GetInt("homepage_view_count"),
+		HomepageLastViewedAt:  record.GetString("homepage_last_viewed_at"),
 		Record:                record,
 	}, nil
 }

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -45,6 +45,17 @@
         reverse_proxy localhost:8090
     }
 
+    # Version files - no caching to ensure updates are seen immediately
+    handle /CHANGELOG.md {
+        header Cache-Control "no-cache, no-store, must-revalidate"
+        reverse_proxy localhost:3000
+    }
+
+    handle /LATEST_VERSION {
+        header Cache-Control "no-cache, no-store, must-revalidate"
+        reverse_proxy localhost:3000
+    }
+
     handle /_/* {
         # PocketBase admin - only allow if ADMIN_ENABLED=true
         @admin_disabled expression `{env.ADMIN_ENABLED} != "true"`

--- a/docs/AI_FEATURES.md
+++ b/docs/AI_FEATURES.md
@@ -93,7 +93,7 @@ When environment variables are detected, providers are created automatically wit
 
 - API keys are **never stored in plaintext**
 - Keys are encrypted using AES-256-GCM before storage
-- Encryption key is set via the `ENCRYPTION_KEY` environment variable
+- Encryption key is set via the `ENCRYPTION_KEY` environment variable or auto-generated on first start (saved to `/data/.encryption_key`)
 - The `api_key` field is marked as a "hidden" field in PocketBase (not returned in API responses)
 - Only the `api_key_encrypted` field is stored
 
@@ -461,7 +461,7 @@ Deletes a generated export.
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `ENCRYPTION_KEY` | 32-byte key for API key encryption | Yes |
+| `ENCRYPTION_KEY` | 32-byte key for API key encryption (auto-generated if not set) | No |
 | `ANTHROPIC_API_KEY` | Auto-configures Anthropic Claude | No |
 | `OPENAI_API_KEY` | Auto-configures OpenAI | No |
 | `OLLAMA_BASE_URL` | Auto-configures Ollama | No |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1048,7 +1048,7 @@ These export features are planned for later phases:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ENCRYPTION_KEY` | Yes | — | 32-byte hex key for encryption |
+| `ENCRYPTION_KEY` | No | Auto-generated | 32-byte hex key for encryption. Auto-generated and saved to `/data/.encryption_key` if not set |
 | `PORT` | No | `8080` | Public port |
 | `APP_URL` | No | `http://localhost:8080` | Public URL |
 | `TRUST_PROXY` | No | `false` | Trust proxy headers for IP |

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -700,7 +700,7 @@ Key variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENCRYPTION_KEY` | (required in prod) | AES-256-GCM key for AI tokens |
+| `ENCRYPTION_KEY` | Auto-generated | AES-256-GCM key for AI tokens. Auto-generated and saved to `/data/.encryption_key` if not set |
 | `SEED_DATA` | — | Seed mode: `dev` for dev profile, unset for no seeding |
 | `DATA_DIR` | `./pb_data` | PocketBase data directory |
 | `LOG_LEVEL` | `info` | Logging verbosity |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,12 +6,17 @@ This document describes security features, authentication flows, and known limit
 
 ### Master Encryption Key
 
-All sensitive data is encrypted using AES-256-GCM. The encryption key is derived from the `ENCRYPTION_KEY` environment variable.
+All sensitive data is encrypted using AES-256-GCM. The encryption key can be set via the `ENCRYPTION_KEY` environment variable or auto-generated on first start.
+
+**Key sources (in priority order):**
+1. `ENCRYPTION_KEY` environment variable (if set)
+2. `/data/.encryption_key` file (if exists)
+3. Auto-generated and saved to `/data/.encryption_key` (first start)
 
 **Requirements:**
 - Minimum 32 characters (256 bits)
-- Generate with: `openssl rand -hex 32`
-- Application **will not start** without a valid key
+- Generate manually with: `openssl rand -hex 32`
+- If auto-generated, ensure `/data` is included in backups — losing the key means encrypted data cannot be recovered
 
 **What's encrypted:**
 - AI provider API keys (`ai_providers.api_key_encrypted`)
@@ -444,7 +449,7 @@ Files are served via PocketBase at `/api/files/{collectionId}/{recordId}/{filena
 
 | Aspect | Development | Production |
 |--------|-------------|------------|
-| Encryption key | Dev-only key in docker-compose.dev.yml | **Required** via `ENCRYPTION_KEY` |
+| Encryption key | Dev-only key in docker-compose.dev.yml | Auto-generated or set via `ENCRYPTION_KEY` |
 | PocketBase Admin | Enabled at `/_/` | Disabled by default (`ADMIN_ENABLED=false`) |
 | Seed data | Created automatically | Not created |
 | Debug logging | Enabled | Disabled |

--- a/docs/SELF-HOSTING-GUIDE.md
+++ b/docs/SELF-HOSTING-GUIDE.md
@@ -82,23 +82,19 @@ mkdir ~/facet && cd ~/facet
 
 **Step 3: Create your configuration**
 
-```bash
-# Generate an encryption key (required)
-openssl rand -hex 32
-```
-
-Copy that key, then create a `.env` file:
+Create a `.env` file:
 
 ```bash
 cat > .env << 'EOF'
-# Paste your generated key here
-ENCRYPTION_KEY=paste-your-key-here
-
 # Your email (for admin login)
 ADMIN_EMAILS=you@example.com
 
 # Leave these as-is for now
 TRUST_PROXY=false
+
+# Optional: Set your own encryption key. If not set, one is auto-generated
+# and saved to /data/.encryption_key. Make sure /data is in your backups.
+# ENCRYPTION_KEY=your-key-here
 EOF
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -26,11 +26,11 @@ cp .env.example .env
 Edit `.env` and set at minimum:
 
 ```env
-# Generate this with: openssl rand -hex 32
-ENCRYPTION_KEY=your-32-byte-hex-key-here
-
 # Your admin email (for login)
 ADMIN_EMAILS=you@example.com
+
+# Optional: Set your own encryption key (if not set, one is auto-generated and saved to /data/.encryption_key)
+# ENCRYPTION_KEY=your-32-byte-hex-key-here
 ```
 
 ### 3. Start the Container
@@ -142,7 +142,7 @@ On startup, Facet will automatically enable the providers you configure and the 
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ENCRYPTION_KEY` | Yes | — | 32-byte hex key (`openssl rand -hex 32`) |
+| `ENCRYPTION_KEY` | No | Auto-generated | 32-byte hex key (`openssl rand -hex 32`). If not set, auto-generated and saved to `/data/.encryption_key` |
 | `PORT` | No | `8080` | Public port |
 | `APP_URL` | No | `http://localhost:8080` | Your public URL |
 | `TRUST_PROXY` | No | `false` | Set `true` behind reverse proxy |
@@ -236,12 +236,8 @@ Facet works great on Unraid! You can install it via Community Applications or ma
 
 2. **Create .env file**
    ```bash
-   # Generate encryption key
-   openssl rand -hex 32
-
-   # Create .env file
+   # Create .env file (encryption key is auto-generated if not set)
    cat > .env << 'EOF'
-   ENCRYPTION_KEY=paste-generated-key-here
    DATA_PATH=/mnt/user/appdata/facet
    APP_URL=http://tower.local:8080
    TRUST_PROXY=false
@@ -249,6 +245,8 @@ Facet works great on Unraid! You can install it via Community Applications or ma
    PORT=8080
    EOF
    ```
+
+   > **Note:** The encryption key is automatically generated on first start and saved to `/data/.encryption_key`. Make sure your `/data` directory (i.e., `/mnt/user/appdata/facet`) is included in your Unraid backups. If you prefer to set it manually, add `ENCRYPTION_KEY=your-key-here` to the `.env` file.
 
 3. **Create docker-compose.yml**
    ```bash

--- a/frontend/src/components/admin/HomepageSectionManager.svelte
+++ b/frontend/src/components/admin/HomepageSectionManager.svelte
@@ -235,6 +235,15 @@
 		</div>
 	</div>
 
+	{#if customContentItems.length > 0}
+		<div class="mt-3 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+			<p class="text-sm text-blue-700 dark:text-blue-300">
+				<strong>Note:</strong> Only custom content marked as <strong>public</strong> and <strong>not in draft</strong> appears here.
+				To change visibility, go to <a href="/admin/custom" class="underline hover:no-underline">Custom Content</a>.
+			</p>
+		</div>
+	{/if}
+
 	{#if loading}
 		<div class="animate-pulse text-center py-8">Loading sections...</div>
 	{:else}

--- a/frontend/src/components/public/ProfileNav.svelte
+++ b/frontend/src/components/public/ProfileNav.svelte
@@ -51,9 +51,13 @@
 	let activeSection = $state('');
 
 	onMount(() => {
-		// Set up intersection observer for section highlighting
 		if (typeof IntersectionObserver !== 'undefined') {
 			const sections = document.querySelectorAll('section[id]');
+
+			if (sections.length > 0) {
+				activeSection = sections[0].id;
+			}
+
 			const observer = new IntersectionObserver(
 				(entries) => {
 					for (const entry of entries) {
@@ -63,7 +67,7 @@
 						}
 					}
 				},
-				{ rootMargin: '-20% 0px -60% 0px' }
+				{ rootMargin: '-5% 0px -70% 0px' }
 			);
 
 			sections.forEach((section) => observer.observe(section));

--- a/frontend/src/lib/stores/version.ts
+++ b/frontend/src/lib/stores/version.ts
@@ -85,13 +85,14 @@ export async function checkForNewVersion(force = false): Promise<void> {
 		// Try LATEST_VERSION file first (avoids API rate limits, works without releases)
 		let latest = '';
 
-		const versionFileResponse = await fetch('https://raw.githubusercontent.com/jesposito/Facet/main/LATEST_VERSION');
+		const versionFileResponse = await fetch('https://raw.githubusercontent.com/jesposito/Facet/main/LATEST_VERSION', { cache: 'no-store' });
 		if (versionFileResponse.ok) {
 			latest = (await versionFileResponse.text()).trim();
 		} else {
 			// Fall back to GitHub releases API
 			const releaseResponse = await fetch('https://api.github.com/repos/jesposito/Facet/releases/latest', {
-				headers: { Accept: 'application/vnd.github.v3+json' }
+				headers: { Accept: 'application/vnd.github.v3+json' },
+				cache: 'no-store'
 			});
 
 			if (releaseResponse.ok) {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5,7 +5,9 @@
 			"close_navigation": "Navigationsmenü schließen",
 			"encryption_warning_title": "Verschlüsselungsschlüssel automatisch generiert",
 			"encryption_warning_message": "Ihr Verschlüsselungsschlüssel wurde automatisch generiert und unter /data/.encryption_key gespeichert. Dieser Schlüssel verschlüsselt Ihre API-Tokens — stellen Sie sicher, dass Ihr /data-Verzeichnis in Ihren Backups enthalten ist.",
-			"encryption_warning_dismiss": "Schließen"
+			"encryption_warning_dismiss": "Schließen",
+			"encryption_info_title": "Erinnerung: Verschlüsselungsschlüssel sichern",
+			"encryption_info_message": "Ihr Verschlüsselungsschlüssel ist unter /data/.encryption_key gespeichert. Dieser Schlüssel schützt Ihre API-Tokens und Freigabelinks. Stellen Sie sicher, dass /data in Ihren Backups enthalten ist — wenn dieser Schlüssel verloren geht, können verschlüsselte Daten nicht wiederhergestellt werden."
 		},
 		"settings_page": {
 			"title": "Einstellungen",
@@ -418,7 +420,8 @@
 			"visitor_view_name": "Ansicht",
 			"visitor_count": "Besucher",
 			"visitor_last_visited": "Zuletzt besucht",
-			"visitor_never": "Noch nicht besucht"
+			"visitor_never": "Noch nicht besucht",
+			"visitor_homepage": "Startseite"
 		},
 		"login": {
 			"title": "Bei Facet anmelden",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -5,7 +5,9 @@
 			"close_navigation": "Close the paths of wandering",
 			"encryption_warning_title": "The Key of Binding was woven anew",
 			"encryption_warning_message": "Your key of encryption was woven of its own accord and laid within /data/.encryption_key. This key guards your sealed tokens — ensure the halls of /data are preserved in your chronicles.",
-			"encryption_warning_dismiss": "Dismiss"
+			"encryption_warning_dismiss": "Dismiss",
+			"encryption_info_title": "A Gentle Reminder: The Key of Binding",
+			"encryption_info_message": "Thy key of encryption rests within /data/.encryption_key. This key wards thy API tokens and passages of sharing. Ensure the halls of /data are preserved in thy chronicles — should this key be lost, that which was sealed cannot be unsealed."
 		},
 		"settings_page": {
 			"title": "Inscriptions",
@@ -418,7 +420,8 @@
 			"visitor_view_name": "Vision",
 			"visitor_count": "Wayfarers",
 			"visitor_last_visited": "Last Beheld",
-			"visitor_never": "Not yet beheld"
+			"visitor_never": "Not yet beheld",
+			"visitor_homepage": "The Great Hall"
 		},
 		"login": {
 			"title": "Enter the Realm of Facet",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5,7 +5,9 @@
 			"close_navigation": "Close navigation menu",
 			"encryption_warning_title": "Encryption Key Auto-Generated",
 			"encryption_warning_message": "Your encryption key was auto-generated and saved to /data/.encryption_key. This key encrypts your API tokens — make sure your /data directory is included in your backups.",
-			"encryption_warning_dismiss": "Dismiss"
+			"encryption_warning_dismiss": "Dismiss",
+			"encryption_info_title": "Backup Reminder: Encryption Key",
+			"encryption_info_message": "Your encryption key is stored at /data/.encryption_key. This key protects your API tokens and share links. Make sure /data is included in your backups — if this key is lost, encrypted data cannot be recovered."
 		},
 		"settings_page": {
 			"title": "Settings",
@@ -418,7 +420,8 @@
 			"visitor_view_name": "View",
 			"visitor_count": "Visitors",
 			"visitor_last_visited": "Last Visited",
-			"visitor_never": "Not yet visited"
+			"visitor_never": "Not yet visited",
+			"visitor_homepage": "Homepage"
 		},
 		"login": {
 			"title": "Sign in to Facet",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -5,7 +5,9 @@
 			"close_navigation": "Seal the tactical display",
 			"encryption_warning_title": "Encryption Key Forged Automatically",
 			"encryption_warning_message": "Your encryption key was forged and stored at /data/.encryption_key. This key protects your API tokens — ensure your /data territory is secured in your backups!",
-			"encryption_warning_dismiss": "Dismiss"
+			"encryption_warning_dismiss": "Dismiss",
+			"encryption_info_title": "Tactical Reminder: Encryption Key",
+			"encryption_info_message": "Your encryption key is secured at /data/.encryption_key. This key guards your API tokens and access codes. Ensure /data is included in your backup protocols — if this key is lost, encrypted data cannot be recovered. A warrior always protects their arsenal."
 		},
 		"settings_page": {
 			"title": "Battle Configurations",
@@ -418,7 +420,8 @@
 			"visitor_view_name": "View",
 			"visitor_count": "Intruders",
 			"visitor_last_visited": "Last Scanned",
-			"visitor_never": "No intruders detected"
+			"visitor_never": "No intruders detected",
+			"visitor_homepage": "Home Base"
 		},
 		"login": {
 			"title": "Enter the Domain of Facet",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -5,7 +5,9 @@
 			"close_navigation": "Cloze teh nav menu",
 			"encryption_warning_title": "Encrypshun Key Wuz Auto-Maded",
 			"encryption_warning_message": "Ur encrypshun key wuz auto-maded n savd 2 /data/.encryption_key. Dis key protectz ur API tokens — maek shur ur /data folder iz in ur backupz kthx.",
-			"encryption_warning_dismiss": "K whatevr"
+			"encryption_warning_dismiss": "K whatevr",
+			"encryption_info_title": "Remindr: Bak Up Ur Encrypshun Kee",
+			"encryption_info_message": "Ur encrypshun kee iz at /data/.encryption_key. Dis kee protectz ur API tokenz n share linkz. Maek shur /data iz in ur bakupz — if dis kee iz lost, encryptd data cant be recoverd. Srsly."
 		},
 		"settings_page": {
 			"title": "Settingz",
@@ -418,7 +420,8 @@
 			"visitor_view_name": "View",
 			"visitor_count": "Vizitorz",
 			"visitor_last_visited": "Last Vizited",
-			"visitor_never": "No vizitorz yet"
+			"visitor_never": "No vizitorz yet",
+			"visitor_homepage": "Hoem Paeg"
 		},
 		"login": {
 			"title": "Sign in 2 Facet",

--- a/frontend/src/routes/admin/+layout.svelte
+++ b/frontend/src/routes/admin/+layout.svelte
@@ -35,7 +35,7 @@
 	let profileData: Profile | null = $state(null);
 	let viewsData: View[] = $state([]);
 	let showEncryptionWarning = $state(false);
-
+	let encryptionKeySource = $state('');
 
 
 
@@ -50,6 +50,7 @@
 			if (response.ok) {
 				const data = await response.json();
 				if (data.source === 'auto' || data.source === 'file') {
+					encryptionKeySource = data.source;
 					showEncryptionWarning = true;
 				}
 			}
@@ -312,19 +313,19 @@
 					{isMobile ? '' : ($adminSidebarOpen ? 'lg:ml-64' : 'lg:ml-16')}"
 			>
 				{#if showEncryptionWarning}
-					<div class="mb-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4" role="alert">
+					<div class="mb-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4" role="status">
 						<div class="flex items-start gap-3">
-							<svg class="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+							<svg class="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
 							</svg>
 							<div class="flex-1">
-								<h3 class="text-sm font-medium text-amber-800 dark:text-amber-200">{$t('admin.layout.encryption_warning_title')}</h3>
-								<p class="text-sm text-amber-700 dark:text-amber-300 mt-1">{$t('admin.layout.encryption_warning_message')}</p>
+								<h3 class="text-sm font-medium text-blue-800 dark:text-blue-200">{$t('admin.layout.encryption_info_title')}</h3>
+								<p class="text-sm text-blue-700 dark:text-blue-300 mt-1">{$t('admin.layout.encryption_info_message')}</p>
 							</div>
 							<button
 								type="button"
 								onclick={dismissEncryptionWarning}
-								class="flex-shrink-0 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
+								class="flex-shrink-0 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
 								aria-label={$t('admin.layout.encryption_warning_dismiss')}
 							>
 								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -13,6 +13,7 @@
 	});
 
 	let viewMetrics: Array<{ id: string; name: string; slug: string; view_count: number; last_viewed_at: string }> = $state([]);
+	let homepageMetrics = $state({ view_count: 0, last_viewed_at: '' });
 	let recentActivity: Array<{ type: string; title: string }> = $state([]);
 	let loading = $state(true);
 	let mounted = false;
@@ -31,11 +32,12 @@
 		if (!mounted) return;
 
 		try {
-			const [projectsRes, experienceRes, viewsRes, proposalsRes] = await Promise.all([
+			const [projectsRes, experienceRes, viewsRes, proposalsRes, settingsRes] = await Promise.all([
 				collection('projects').getList(1, 1),
 				collection('experience').getList(1, 1),
 				collection('views').getFullList({ sort: '-view_count' }),
-				pb.collection('import_proposals').getList(1, 1, { filter: "status = 'pending'" })
+				pb.collection('import_proposals').getList(1, 1, { filter: "status = 'pending'" }),
+				fetch('/api/site-settings').then(r => r.ok ? r.json() : null).catch(() => null)
 			]);
 
 			if (!mounted) return;
@@ -43,10 +45,16 @@
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const views = viewsRes as any[];
 
+			const hpViewCount = settingsRes?.homepage_view_count || 0;
+			homepageMetrics = {
+				view_count: hpViewCount,
+				last_viewed_at: settingsRes?.homepage_last_viewed_at || ''
+			};
+
 			stats = {
 				projects: projectsRes.totalItems,
 				experience: experienceRes.totalItems,
-				totalVisitors: views.reduce((sum, v) => sum + (v.view_count || 0), 0),
+				totalVisitors: views.reduce((sum, v) => sum + (v.view_count || 0), 0) + hpViewCount,
 				pendingProposals: proposalsRes.totalItems
 			};
 
@@ -352,7 +360,7 @@
 	</div>
 
 	<!-- Visitor stats -->
-	{#if !loading && viewMetrics.length > 0}
+	{#if !loading && (viewMetrics.length > 0 || homepageMetrics.view_count > 0)}
 		<div class="mt-6 card p-6">
 			<h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{$t('admin.dashboard.visitor_stats')}</h2>
 			<div class="overflow-x-auto">
@@ -365,6 +373,22 @@
 						</tr>
 					</thead>
 					<tbody>
+						<tr class="border-b border-gray-100 dark:border-gray-800">
+							<td class="py-2.5 pr-4">
+								<a href="/admin/homepage" class="text-gray-900 dark:text-white hover:text-primary-600 dark:hover:text-primary-400 flex items-center gap-1.5">
+									<svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+									</svg>
+									{$t('admin.dashboard.visitor_homepage')}
+								</a>
+							</td>
+							<td class="text-right py-2.5 px-4 font-medium text-gray-900 dark:text-white">
+								{homepageMetrics.view_count.toLocaleString()}
+							</td>
+							<td class="text-right py-2.5 pl-4 text-gray-500 dark:text-gray-400">
+								{homepageMetrics.last_viewed_at ? formatRelativeDate(homepageMetrics.last_viewed_at) : $t('admin.dashboard.visitor_never')}
+							</td>
+						</tr>
 						{#each viewMetrics as view}
 							<tr class="border-b border-gray-100 dark:border-gray-800 last:border-0">
 								<td class="py-2.5 pr-4">


### PR DESCRIPTION
## Summary

Addresses **#384**, **#387**, **#385**, plus reworks the encryption key banner and updates all documentation for the optional/auto-generated encryption key behavior.

---

## Issue #384 — Homepage Visitor Counter

**Problem:** Homepage views were not being counted in visitor statistics. The admin dashboard only tracked views for individual profile views (slugs), missing all homepage traffic entirely.

**Root cause:** The `/api/default-view` endpoint (called once per homepage SSR load) had no view-counting logic — only slug-based views were instrumented.

**Fix:**

| File | Change |
|------|--------|
| `backend/migrations/1769790000_add_homepage_view_metrics.go` | **New migration** — adds `homepage_view_count` (int) and `homepage_last_viewed_at` (string) fields to the `site_settings` collection |
| `backend/services/settings.go` | Added `HomepageViewCount` and `HomepageLastViewedAt` to `SiteSettings` struct; `LoadSiteSettings` reads them |
| `backend/hooks/view.go` | `/api/default-view` handler now calls `incrementHomepageViewCount(app)` when homepage is enabled |
| `backend/hooks/view_helpers.go` | New `incrementHomepageViewCount()` function — async goroutine increments `homepage_view_count` and sets `homepage_last_viewed_at` on the `site_settings` record (same pattern as existing slug view counting) |
| `backend/hooks/settings.go` | `GET /api/site-settings` response now includes `homepage_view_count` and `homepage_last_viewed_at` |
| `frontend/src/routes/admin/+page.svelte` | Dashboard fetches homepage metrics from `/api/site-settings`, shows "Homepage" row (with home icon) at the top of the visitor stats table; homepage count is included in the total visitors sum |
| All 5 locale files | Added `visitor_homepage` translation key |

**How it works:** The `/api/default-view` endpoint is called exactly once per homepage load by SvelteKit SSR. When the homepage is enabled, it fires a goroutine that atomically increments the counter on the `site_settings` record — zero performance impact on the request path.

---

## Issue #387 — Navbar Pill Appears Late

**Problem:** On public profile pages, the active section pill/indicator in the navigation bar didn't appear until the user scrolled, making the page feel broken on initial load.

**Root cause:** `activeSection` was initialized to an empty string and only set via the IntersectionObserver callback. The observer's narrow `rootMargin` (`-20% 0px -60% 0px`) also meant the pill could lag behind actual scroll position.

**Fix:**

| File | Change |
|------|--------|
| `frontend/src/components/public/ProfileNav.svelte` | 1) Initialize `activeSection` to the first section's ID on mount (immediate pill display). 2) Changed IntersectionObserver `rootMargin` from `'-20% 0px -60% 0px'` to `'-5% 0px -70% 0px'` (triggers earlier, more responsive feel) |

---

## Issue #385 — Custom Content Homepage Hint

**Problem:** Users expected all custom content to appear in the homepage content selector, but only public non-draft items are available. There was no indication of this filtering.

**Investigation:** Verified there is **no bug** — both frontend filter (`visibility === "public" && is_draft === false`) and backend filter are correct and consistent. This is purely a UX clarity issue.

**Fix:**

| File | Change |
|------|--------|
| `frontend/src/components/admin/HomepageSectionManager.svelte` | Added a blue info banner when custom content items exist: *"Only custom content marked as **public** and **not in draft** appears here. To change visibility, go to Custom Content."* — includes a direct link to `/admin/custom` |

---

## Encryption Key Banner Rework

**Problem:** The existing amber warning banner with ⚠️ icon felt alarming for Unraid users where the encryption key is auto-generated by default. The messaging talked about "setting a variable" which doesn't apply to most users.

**Fix:**

| File | Change |
|------|--------|
| `frontend/src/routes/admin/+layout.svelte` | 1) Added `encryptionKeySource` state var tracking `auto` / `file` / `env` from `/api/system/encryption-status`. 2) Changed banner from amber/warning (⚠️ triangle) to blue/info (ℹ️ circle). 3) Changed `role="alert"` to `role="status"`. 4) Now uses new i18n keys `encryption_info_title` / `encryption_info_message`. 5) Banner only shows for `auto` or `file` sources (not `env` — those users set it intentionally). |
| All 5 locale files | Added `encryption_info_title` and `encryption_info_message` keys with friendly "backup reminder" messaging. Old warning keys kept for backwards compat. |

**Banner behavior by source:**
- `env` → No banner (user explicitly set the var, they know what they're doing)
- `file` → Blue info banner: "Back up your encryption key at `/data/.encryption_key`"
- `auto` → Blue info banner: same friendly backup reminder

---

## Documentation Updates

Updated **7 documentation files** to reflect that `ENCRYPTION_KEY` is optional and auto-generated when not set:

| File | Key Change |
|------|------------|
| `README.md` | Removed "Generate an encryption key (required)" from Quick Start; changed env var table from **Yes** to No (Auto-generated) |
| `docs/SETUP.md` | ENCRYPTION_KEY shown as commented-out optional; added Unraid note about auto-generation and backup |
| `docs/DESIGN.md` | Changed required column from Yes to No \| Auto-generated |
| `docs/SECURITY.md` | Rewrote "Master Encryption Key" section documenting three key sources: env var → file → auto-generated |
| `docs/AI_FEATURES.md` | Updated encryption key description and required column |
| `docs/SELF-HOSTING-GUIDE.md` | Removed manual key generation step; made ENCRYPTION_KEY commented-out optional |
| `docs/DEV.md` | Changed from "(required in prod)" to "Auto-generated" |

---

## Files Changed (23 files, +208 / -80)

<details>
<summary>Full file list</summary>

**Backend (6 files)**
- `backend/migrations/1769790000_add_homepage_view_metrics.go` (new)
- `backend/hooks/settings.go`
- `backend/hooks/view.go`
- `backend/hooks/view_helpers.go`
- `backend/services/settings.go`
- `docker/Caddyfile`

**Frontend (7 files)**
- `frontend/src/components/admin/HomepageSectionManager.svelte`
- `frontend/src/components/public/ProfileNav.svelte`
- `frontend/src/lib/stores/version.ts`
- `frontend/src/locales/de.json`
- `frontend/src/locales/elvish.json`
- `frontend/src/locales/en.json`
- `frontend/src/locales/klingon.json`
- `frontend/src/locales/lolcat.json`
- `frontend/src/routes/admin/+layout.svelte`
- `frontend/src/routes/admin/+page.svelte`

**Documentation (7 files)**
- `README.md`
- `docs/SETUP.md`
- `docs/DESIGN.md`
- `docs/SECURITY.md`
- `docs/AI_FEATURES.md`
- `docs/SELF-HOSTING-GUIDE.md`
- `docs/DEV.md`

</details>

## Testing

- ✅ `go build ./...` — passes
- ✅ `go test ./...` — passes
- ✅ `svelte-check` — 0 errors (9 pre-existing warnings in unrelated files)
- ✅ `npm run build` — production build succeeds

Closes #384, closes #387, closes #385