### PR TITLE
Group positions by company (#244)

### DIFF
--- a/backend/hooks/duplicate.go
+++ b/backend/hooks/duplicate.go
@@ -67,6 +67,8 @@ func RegisterDuplicateHooks(app *pocketbase.PocketBase) {
 				duplicate.Set("company", company+" (Copy)")
 			}
 
+			duplicate.Set("company_group_id", original.GetString("company_group_id"))
+
 			if slug := original.GetString("slug"); slug != "" {
 				duplicate.Set("slug", slug+"-copy")
 			}

--- a/backend/hooks/experience.go
+++ b/backend/hooks/experience.go
@@ -2,13 +2,64 @@ package hooks
 
 import (
 	"facet/services"
+	"strings"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
 
+// NormalizeCompanyName returns a normalized group ID from a company name.
+// It lowercases, trims whitespace, strips common suffixes and trailing punctuation.
+func NormalizeCompanyName(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	if s == "" {
+		return ""
+	}
+
+	suffixes := []string{
+		"s.a.", "inc.", "ltd.", "corp.", "co.", "gmbh", "ag", "sa", "inc", "llc",
+		"ltd", "corp", "co", "plc",
+	}
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(s, " "+suffix) {
+			s = strings.TrimSuffix(s, " "+suffix)
+			break
+		}
+	}
+
+	s = strings.TrimRight(s, ".,;:!? ")
+	s = strings.TrimSpace(s)
+
+	return s
+}
+
 // RegisterExperienceHooks sets up hooks for the experience and education collections.
 func RegisterExperienceHooks(app *pocketbase.PocketBase) {
+	// Before experience is created, auto-populate company_group_id if empty
+	app.OnRecordCreate("experience").BindFunc(func(e *core.RecordEvent) error {
+		if e.Record.GetString("company_group_id") == "" {
+			company := e.Record.GetString("company")
+			if company != "" {
+				e.Record.Set("company_group_id", NormalizeCompanyName(company))
+			}
+		}
+		return e.Next()
+	})
+
+	// Before experience is updated, auto-populate company_group_id if empty or company changed
+	app.OnRecordUpdate("experience").BindFunc(func(e *core.RecordEvent) error {
+		currentGroupID := e.Record.GetString("company_group_id")
+		company := e.Record.GetString("company")
+		originalCompany := e.Record.Original().GetString("company")
+
+		if currentGroupID == "" || company != originalCompany {
+			if company != "" {
+				e.Record.Set("company_group_id", NormalizeCompanyName(company))
+			}
+		}
+		return e.Next()
+	})
+
 	// After experience is created/updated, set the company logo display name to company name
 	app.OnRecordAfterCreateSuccess("experience").BindFunc(func(e *core.RecordEvent) error {
 		return setCompanyLogoDisplayName(app, e.Record)

--- a/backend/hooks/experience.go
+++ b/backend/hooks/experience.go
@@ -21,8 +21,8 @@ func NormalizeCompanyName(name string) string {
 		"ltd", "corp", "co", "plc",
 	}
 	for _, suffix := range suffixes {
-		if strings.HasSuffix(s, " "+suffix) {
-			s = strings.TrimSuffix(s, " "+suffix)
+		if cut, found := strings.CutSuffix(s, " "+suffix); found {
+			s = cut
 			break
 		}
 	}

--- a/backend/hooks/resume_upload.go
+++ b/backend/hooks/resume_upload.go
@@ -338,6 +338,7 @@ func createResumeRecords(app *pocketbase.PocketBase, parsed *services.ParsedResu
 		for _, exp := range parsed.Experience {
 			record := core.NewRecord(expCollection)
 			record.Set("company", exp.Company)
+			record.Set("company_group_id", NormalizeCompanyName(exp.Company))
 			record.Set("title", exp.Title)
 			record.Set("location", exp.Location)
 			if normalized := normalizeDate(exp.StartDate); normalized != "" {
@@ -597,6 +598,7 @@ func createResumeRecordsWithDeduplication(app *pocketbase.PocketBase, parsed *se
 
 			record := core.NewRecord(expCollection)
 			record.Set("company", exp.Company)
+			record.Set("company_group_id", NormalizeCompanyName(exp.Company))
 			record.Set("title", exp.Title)
 			record.Set("location", exp.Location)
 			if normalized := normalizeDate(exp.StartDate); normalized != "" {

--- a/backend/migrations/1769830000_add_experience_company_group.go
+++ b/backend/migrations/1769830000_add_experience_company_group.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		expCollection, err := app.FindCollectionByNameOrId("experience")
+		if err != nil {
+			return err
+		}
+
+		if expCollection.Fields.GetByName("company_group_id") == nil {
+			expCollection.Fields.Add(&core.TextField{
+				Name:    "company_group_id",
+				Max:     50,
+			})
+
+			if err := app.Save(expCollection); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, func(app core.App) error {
+		expCollection, err := app.FindCollectionByNameOrId("experience")
+		if err == nil {
+			field := expCollection.Fields.GetByName("company_group_id")
+			if field != nil {
+				expCollection.Fields.RemoveById(field.GetId())
+				app.Save(expCollection)
+			}
+		}
+
+		return nil
+	})
+}

--- a/frontend/src/components/public/ExperienceSection.svelte
+++ b/frontend/src/components/public/ExperienceSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { pb, type Experience } from '$lib/pocketbase';
+	import { groupExperiencesByCompany, type CompanyGroup, type GroupedExperienceItem } from '$lib/experienceGrouping';
 	import { formatDateRange, parseMarkdown } from '$lib/utils';
 	import { t } from 'svelte-i18n';
 
@@ -12,6 +13,9 @@
 
 	// Get translated "Present" text for date ranges
 	let presentText = $derived($t('shared.time.present'));
+
+	// Group experiences by company
+	let groupedItems = $derived(groupExperiencesByCompany(items));
 
 	function stripBulletPrefix(text: string): string {
 		return text.replace(/^\s*[•\-\*–—·●◦▪▸►]\s*/, '').replace(/^\s*\d+[.)]\s+/, '');
@@ -28,6 +32,10 @@
 			default: return '';
 		}
 	}
+
+	function isGroup(entry: GroupedExperienceItem): entry is CompanyGroup {
+		return 'type' in entry && entry.type === 'group';
+	}
 </script>
 
 <section id="experience" class="mb-16" itemscope itemtype="https://schema.org/Person">
@@ -40,67 +48,161 @@
 			<div class="absolute left-4 top-0 bottom-0 w-0.5 bg-primary-200 dark:bg-primary-800"></div>
 
 			<div class="space-y-8 pl-12">
-				{#each items as item, index (item.id)}
-					<article class="relative animate-fade-in">
-						<!-- Timeline node -->
-						<div class="absolute -left-12 w-8 h-8 bg-primary-600 rounded-full ring-4 ring-white dark:ring-gray-900 z-10"></div>
-
-						<!-- Content with optional logo as visual anchor -->
-						<div class="flex gap-4">
-							{#if item.company_logo_url || item.company_logo}
-								<div class="shrink-0 w-10 h-10 rounded-lg overflow-hidden flex items-center justify-center {getLogoBgClass(item.logo_background) || 'bg-gray-100 dark:bg-gray-800'}">
+				{#each groupedItems as entry (isGroup(entry) ? entry.groupId : entry.id)}
+					{#if isGroup(entry)}
+						<!-- Company group: header node + nested sub-items -->
+						<div class="relative animate-fade-in" itemscope itemtype="https://schema.org/Organization">
+							<!-- Larger timeline node for company group -->
+							<div class="absolute -left-12 w-8 h-8 bg-primary-700 rounded-full ring-4 ring-white dark:ring-gray-900 z-10 flex items-center justify-center">
+								{#if entry.companyLogoUrl || entry.companyLogo}
 									<img
-										src={item.company_logo_url || pb.files.getUrl(item, item.company_logo!, { thumb: '40x40' })}
-										alt="{item.company} logo"
-										class="w-8 h-8 object-contain"
+										src={entry.companyLogoUrl}
+										alt="{entry.company} logo"
+										class="w-5 h-5 object-contain"
 									/>
-								</div>
-							{/if}
-							<div class="flex-1 min-w-0">
-								<div class="pb-2">
-									<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-										{item.title}
-									</h3>
-									<span class="text-primary-600 dark:text-primary-400 font-medium">
-										{item.company}
-									</span>
-									<div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400 mt-1">
-										<span class="font-medium">{formatDateRange(item.start_date, item.end_date, presentText)}</span>
-										{#if item.location}
-											<span>• {item.location}</span>
-										{/if}
-									</div>
-								</div>
-
-								{#if item.description}
-									<div class="prose-custom text-gray-600 dark:text-gray-300 text-sm">
-										{@html parseMarkdown(item.description)}
-									</div>
-								{/if}
-
-								{#if item.bullets && item.bullets.length > 0}
-									<ul class="mt-2 space-y-1">
-										{#each item.bullets as bullet}
-											<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300 text-sm">
-												<span class="text-primary-500 mt-0.5">•</span>
-												<span>{stripBulletPrefix(bullet)}</span>
-											</li>
-										{/each}
-									</ul>
-								{/if}
-
-								{#if item.skills && item.skills.length > 0}
-									<div class="mt-3 flex flex-wrap gap-1.5">
-										{#each item.skills as skill}
-											<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
-												{skill}
-											</span>
-										{/each}
-									</div>
 								{/if}
 							</div>
+
+							<!-- Company header -->
+							<div class="flex gap-4 items-start">
+								{#if entry.companyLogoUrl || entry.companyLogo}
+									<div class="shrink-0 w-10 h-10 rounded-lg overflow-hidden flex items-center justify-center {getLogoBgClass(entry.logoBackground) || 'bg-gray-100 dark:bg-gray-800'}">
+										<img
+											src={entry.companyLogoUrl}
+											alt="{entry.company} logo"
+											class="w-8 h-8 object-contain"
+										/>
+									</div>
+								{/if}
+								<div>
+									<span class="text-base font-bold text-gray-900 dark:text-white" itemprop="name">
+										{entry.company}
+									</span>
+									<div class="text-sm text-gray-500 dark:text-gray-400">
+										{formatDateRange(entry.overallStartDate, entry.overallEndDate, presentText)}
+										<!-- TODO: i18n - "X positions" label -->
+										&nbsp;· {entry.positions.length} positions
+									</div>
+								</div>
+							</div>
+
+							<!-- Nested sub-timeline for positions -->
+							<div class="mt-4 ml-6 relative">
+								<!-- Sub-timeline line -->
+								<div class="absolute left-2 top-0 bottom-0 w-0.5 bg-primary-100 dark:bg-primary-900"></div>
+								<div class="space-y-5 pl-8">
+									{#each entry.positions as pos (pos.id)}
+										<article class="relative" itemprop="hasOccupation" itemscope itemtype="https://schema.org/Occupation">
+											<!-- Sub-timeline dot -->
+											<div class="absolute -left-8 top-1.5 w-3 h-3 bg-primary-400 dark:bg-primary-600 rounded-full ring-2 ring-white dark:ring-gray-900 z-10"></div>
+
+											<div>
+												<h3 class="text-base font-semibold text-gray-900 dark:text-white" itemprop="name">
+													{pos.title}
+												</h3>
+												<div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+													<span class="font-medium">{formatDateRange(pos.start_date, pos.end_date, presentText)}</span>
+													{#if pos.location}
+														<span>• {pos.location}</span>
+													{/if}
+												</div>
+
+												{#if pos.description}
+													<div class="mt-2 prose-custom text-gray-600 dark:text-gray-300 text-sm" itemprop="description">
+														{@html parseMarkdown(pos.description)}
+													</div>
+												{/if}
+
+												{#if pos.bullets && pos.bullets.length > 0}
+													<ul class="mt-1.5 space-y-1">
+														{#each pos.bullets as bullet}
+															<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300 text-sm">
+																<span class="text-primary-500 mt-0.5">•</span>
+																<span>{stripBulletPrefix(bullet)}</span>
+															</li>
+														{/each}
+													</ul>
+												{/if}
+
+												{#if pos.skills && pos.skills.length > 0}
+													<div class="mt-2 flex flex-wrap gap-1.5">
+														{#each pos.skills as skill}
+															<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+																{skill}
+															</span>
+														{/each}
+													</div>
+												{/if}
+											</div>
+										</article>
+									{/each}
+								</div>
+							</div>
 						</div>
-					</article>
+
+					{:else}
+						<!-- Ungrouped item: render exactly as before -->
+						<article class="relative animate-fade-in">
+							<!-- Timeline node -->
+							<div class="absolute -left-12 w-8 h-8 bg-primary-600 rounded-full ring-4 ring-white dark:ring-gray-900 z-10"></div>
+
+							<!-- Content with optional logo as visual anchor -->
+							<div class="flex gap-4">
+								{#if entry.company_logo_url || entry.company_logo}
+									<div class="shrink-0 w-10 h-10 rounded-lg overflow-hidden flex items-center justify-center {getLogoBgClass(entry.logo_background) || 'bg-gray-100 dark:bg-gray-800'}">
+										<img
+											src={entry.company_logo_url || pb.files.getUrl(entry, entry.company_logo!, { thumb: '40x40' })}
+											alt="{entry.company} logo"
+											class="w-8 h-8 object-contain"
+										/>
+									</div>
+								{/if}
+								<div class="flex-1 min-w-0">
+									<div class="pb-2">
+										<h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+											{entry.title}
+										</h3>
+										<span class="text-primary-600 dark:text-primary-400 font-medium">
+											{entry.company}
+										</span>
+										<div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400 mt-1">
+											<span class="font-medium">{formatDateRange(entry.start_date, entry.end_date, presentText)}</span>
+											{#if entry.location}
+												<span>• {entry.location}</span>
+											{/if}
+										</div>
+									</div>
+
+									{#if entry.description}
+										<div class="prose-custom text-gray-600 dark:text-gray-300 text-sm">
+											{@html parseMarkdown(entry.description)}
+										</div>
+									{/if}
+
+									{#if entry.bullets && entry.bullets.length > 0}
+										<ul class="mt-2 space-y-1">
+											{#each entry.bullets as bullet}
+												<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300 text-sm">
+													<span class="text-primary-500 mt-0.5">•</span>
+													<span>{stripBulletPrefix(bullet)}</span>
+												</li>
+											{/each}
+										</ul>
+									{/if}
+
+									{#if entry.skills && entry.skills.length > 0}
+										<div class="mt-3 flex flex-wrap gap-1.5">
+											{#each entry.skills as skill}
+												<span class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+													{skill}
+												</span>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							</div>
+						</article>
+					{/if}
 				{/each}
 			</div>
 		</div>
@@ -108,112 +210,252 @@
 	{:else if layout === 'compact'}
 		<!-- Compact Layout -->
 		<div class="divide-y divide-gray-200 dark:divide-gray-700">
-			{#each items as item (item.id)}
-				<article class="py-4 first:pt-0 animate-fade-in">
-					<div class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
-						<div class="flex-1 flex flex-wrap items-baseline gap-x-2">
-							<div class="flex items-center gap-2">
-								{#if item.company_logo_url || item.company_logo}
+			{#each groupedItems as entry (isGroup(entry) ? entry.groupId : entry.id)}
+				{#if isGroup(entry)}
+					<!-- Company group header + indented position list -->
+					<div class="py-4 first:pt-0 animate-fade-in" itemscope itemtype="https://schema.org/Organization">
+						<!-- Company header row -->
+						<div class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
+							<div class="flex-1 flex flex-wrap items-center gap-x-2">
+								{#if entry.companyLogoUrl || entry.companyLogo}
 									<img
-										src={item.company_logo_url || pb.files.getUrl(item, item.company_logo!, { thumb: '20x20' })}
-										alt="{item.company} logo"
-										class="w-4 h-4 object-contain rounded {getLogoBgClass(item.logo_background)}"
+										src={entry.companyLogoUrl}
+										alt="{entry.company} logo"
+										class="w-4 h-4 object-contain rounded {getLogoBgClass(entry.logoBackground)}"
 									/>
 								{/if}
-								<h3 class="font-semibold text-gray-900 dark:text-white">
-									{item.title}
-								</h3>
+								<span class="font-bold text-gray-900 dark:text-white" itemprop="name">
+									{entry.company}
+								</span>
+								<!-- TODO: i18n - "X positions" label -->
+								<span class="text-xs text-gray-400 dark:text-gray-500">· {entry.positions.length} positions</span>
 							</div>
-							<span class="text-gray-500 dark:text-gray-400">{$t('public.experience.at')}</span>
-							<span class="text-primary-600 dark:text-primary-400 font-medium">
-								{item.company}
+							<span class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+								{formatDateRange(entry.overallStartDate, entry.overallEndDate, presentText)}
 							</span>
 						</div>
-						<span class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-							{formatDateRange(item.start_date, item.end_date, presentText)}
-						</span>
+
+						<!-- Indented position list -->
+						<div class="mt-2 ml-4 space-y-2 border-l-2 border-gray-200 dark:border-gray-700 pl-4">
+							{#each entry.positions as pos (pos.id)}
+								<article itemprop="hasOccupation" itemscope itemtype="https://schema.org/Occupation">
+									<div class="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+										<div class="flex-1">
+											<h3 class="font-semibold text-gray-900 dark:text-white text-sm" itemprop="name">
+												{pos.title}
+											</h3>
+										</div>
+										<span class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+											{formatDateRange(pos.start_date, pos.end_date, presentText)}
+										</span>
+									</div>
+									{#if pos.location}
+										<p class="text-xs text-gray-500 dark:text-gray-400">{pos.location}</p>
+									{/if}
+									{#if pos.description}
+										<div class="mt-1 prose-custom text-gray-600 dark:text-gray-300 text-sm" itemprop="description">
+											{@html parseMarkdown(pos.description)}
+										</div>
+									{/if}
+								</article>
+							{/each}
+						</div>
 					</div>
 
-					{#if item.location}
-						<p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{item.location}</p>
-					{/if}
-
-					{#if item.description}
-						<div class="mt-2 prose-custom text-gray-600 dark:text-gray-300 text-sm">
-							{@html parseMarkdown(item.description)}
+				{:else}
+					<!-- Ungrouped item: render exactly as before -->
+					<article class="py-4 first:pt-0 animate-fade-in">
+						<div class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
+							<div class="flex-1 flex flex-wrap items-baseline gap-x-2">
+								<div class="flex items-center gap-2">
+									{#if entry.company_logo_url || entry.company_logo}
+										<img
+											src={entry.company_logo_url || pb.files.getUrl(entry, entry.company_logo!, { thumb: '20x20' })}
+											alt="{entry.company} logo"
+											class="w-4 h-4 object-contain rounded {getLogoBgClass(entry.logo_background)}"
+										/>
+									{/if}
+									<h3 class="font-semibold text-gray-900 dark:text-white">
+										{entry.title}
+									</h3>
+								</div>
+								<span class="text-gray-500 dark:text-gray-400">{$t('public.experience.at')}</span>
+								<span class="text-primary-600 dark:text-primary-400 font-medium">
+									{entry.company}
+								</span>
+							</div>
+							<span class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+								{formatDateRange(entry.start_date, entry.end_date, presentText)}
+							</span>
 						</div>
-					{/if}
-				</article>
+
+						{#if entry.location}
+							<p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{entry.location}</p>
+						{/if}
+
+						{#if entry.description}
+							<div class="mt-2 prose-custom text-gray-600 dark:text-gray-300 text-sm">
+								{@html parseMarkdown(entry.description)}
+							</div>
+						{/if}
+					</article>
+				{/if}
 			{/each}
 		</div>
 
 	{:else}
 		<!-- Default Layout (Cards) -->
 		<div class="space-y-8">
-			{#each items as item (item.id)}
-				<article class="card p-6 animate-fade-in" itemprop="hasOccupation" itemscope itemtype="https://schema.org/Occupation">
-					<div class="flex flex-col sm:flex-row sm:items-start gap-4">
-						{#if item.company_logo_url || item.company_logo}
-							<div class="flex-shrink-0">
-								<img
-									src={item.company_logo_url || pb.files.getUrl(item, item.company_logo!, { thumb: '48x48' })}
-									alt="{item.company} logo"
-									class="w-12 h-12 object-contain rounded {getLogoBgClass(item.logo_background)}"
-								/>
+			{#each groupedItems as entry (isGroup(entry) ? entry.groupId : entry.id)}
+				{#if isGroup(entry)}
+					<!-- Company group card: header + position sub-entries -->
+					<article class="card p-6 animate-fade-in" itemscope itemtype="https://schema.org/Organization">
+						<!-- Company header -->
+						<div class="flex flex-col sm:flex-row sm:items-start gap-4">
+							{#if entry.companyLogoUrl || entry.companyLogo}
+								<div class="flex-shrink-0">
+									<img
+										src={entry.companyLogoUrl}
+										alt="{entry.company} logo"
+										class="w-12 h-12 object-contain rounded {getLogoBgClass(entry.logoBackground)}"
+									/>
+								</div>
+							{/if}
+							<div class="flex-1">
+								<h3 class="text-xl font-bold text-gray-900 dark:text-white" itemprop="name">
+									{entry.company}
+								</h3>
+								<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+									<span>{formatDateRange(entry.overallStartDate, entry.overallEndDate, presentText)}</span>
+									<!-- TODO: i18n - "X positions" label -->
+									<span>· {entry.positions.length} positions</span>
+								</div>
+							</div>
+						</div>
+
+						<!-- Positions as sub-entries with thin dividers -->
+						<div class="mt-4 space-y-0">
+							{#each entry.positions as pos, posIdx (pos.id)}
+								{#if posIdx > 0}
+									<div class="border-t border-gray-100 dark:border-gray-800"></div>
+								{/if}
+								<div class="py-4" itemprop="hasOccupation" itemscope itemtype="https://schema.org/Occupation">
+									<h4 class="text-base font-semibold text-gray-900 dark:text-white" itemprop="name">
+										{pos.title}
+									</h4>
+									<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+										<span>
+											<meta itemprop="startDate" content={pos.start_date || ''} />
+											<meta itemprop="endDate" content={pos.end_date || ''} />
+											{formatDateRange(pos.start_date, pos.end_date, presentText)}
+										</span>
+										{#if pos.location}
+											<span class="flex items-center gap-1">
+												<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+												</svg>
+												{pos.location}
+											</span>
+										{/if}
+									</div>
+
+									{#if pos.description}
+										<div class="mt-3 prose-custom text-gray-600 dark:text-gray-300" itemprop="description">
+											{@html parseMarkdown(pos.description)}
+										</div>
+									{/if}
+
+									{#if pos.bullets && pos.bullets.length > 0}
+										<ul class="mt-3 space-y-2" itemprop="responsibilities">
+											{#each pos.bullets as bullet}
+												<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300">
+													<span class="text-primary-500 mt-1">•</span>
+													<span class="mt-[0.26rem]">{stripBulletPrefix(bullet)}</span>
+												</li>
+											{/each}
+										</ul>
+									{/if}
+
+									{#if pos.skills && pos.skills.length > 0}
+										<div class="mt-3 flex flex-wrap gap-2">
+											{#each pos.skills as skill}
+												<span class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full" itemprop="skills">
+													{skill}
+												</span>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</article>
+
+				{:else}
+					<!-- Ungrouped item: render exactly as before -->
+					<article class="card p-6 animate-fade-in" itemprop="hasOccupation" itemscope itemtype="https://schema.org/Occupation">
+						<div class="flex flex-col sm:flex-row sm:items-start gap-4">
+							{#if entry.company_logo_url || entry.company_logo}
+								<div class="flex-shrink-0">
+									<img
+										src={entry.company_logo_url || pb.files.getUrl(entry, entry.company_logo!, { thumb: '48x48' })}
+										alt="{entry.company} logo"
+										class="w-12 h-12 object-contain rounded {getLogoBgClass(entry.logo_background)}"
+									/>
+								</div>
+							{/if}
+							<div class="flex-1">
+								<h3 class="text-xl font-semibold text-gray-900 dark:text-white" itemprop="name">
+									{entry.title}
+								</h3>
+								<p class="text-lg text-primary-600 dark:text-primary-400 font-medium" itemprop="occupationLocation" itemscope itemtype="https://schema.org/Organization">
+									<span itemprop="name">{entry.company}</span>
+								</p>
+								<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
+									<span>
+										<meta itemprop="startDate" content={entry.start_date || ''} />
+										<meta itemprop="endDate" content={entry.end_date || ''} />
+										{formatDateRange(entry.start_date, entry.end_date, presentText)}
+									</span>
+									{#if entry.location}
+										<span class="flex items-center gap-1">
+											<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+											</svg>
+											{entry.location}
+										</span>
+									{/if}
+								</div>
+							</div>
+						</div>
+
+						{#if entry.description}
+							<div class="mt-4 prose-custom text-gray-600 dark:text-gray-300" itemprop="description">
+								{@html parseMarkdown(entry.description)}
 							</div>
 						{/if}
-						<div class="flex-1">
-							<h3 class="text-xl font-semibold text-gray-900 dark:text-white" itemprop="name">
-								{item.title}
-							</h3>
-							<p class="text-lg text-primary-600 dark:text-primary-400 font-medium" itemprop="occupationLocation" itemscope itemtype="https://schema.org/Organization">
-								<span itemprop="name">{item.company}</span>
-							</p>
-							<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
-								<span>
-									<meta itemprop="startDate" content={item.start_date || ''} />
-									<meta itemprop="endDate" content={item.end_date || ''} />
-									{formatDateRange(item.start_date, item.end_date, presentText)}
-								</span>
-								{#if item.location}
-									<span class="flex items-center gap-1">
-										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-										</svg>
-										{item.location}
+
+						{#if entry.bullets && entry.bullets.length > 0}
+							<ul class="mt-4 space-y-2" itemprop="responsibilities">
+								{#each entry.bullets as bullet}
+									<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300">
+										<span class="text-primary-500 mt-1">•</span>
+										<span class="mt-[0.26rem]">{stripBulletPrefix(bullet)}</span>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+
+						{#if entry.skills && entry.skills.length > 0}
+							<div class="mt-4 flex flex-wrap gap-2">
+								{#each entry.skills as skill}
+									<span class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full" itemprop="skills">
+										{skill}
 									</span>
-								{/if}
+								{/each}
 							</div>
-						</div>
-					</div>
-
-					{#if item.description}
-						<div class="mt-4 prose-custom text-gray-600 dark:text-gray-300" itemprop="description">
-							{@html parseMarkdown(item.description)}
-						</div>
-					{/if}
-
-					{#if item.bullets && item.bullets.length > 0}
-						<ul class="mt-4 space-y-2" itemprop="responsibilities">
-							{#each item.bullets as bullet}
-								<li class="flex items-start gap-2 text-gray-600 dark:text-gray-300">
-									<span class="text-primary-500 mt-1">•</span>
-									<span class="mt-[0.26rem]">{stripBulletPrefix(bullet)}</span>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-
-					{#if item.skills && item.skills.length > 0}
-						<div class="mt-4 flex flex-wrap gap-2">
-							{#each item.skills as skill}
-								<span class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full" itemprop="skills">
-									{skill}
-								</span>
-							{/each}
-						</div>
-					{/if}
-				</article>
+						{/if}
+					</article>
+				{/if}
 			{/each}
 		</div>
 	{/if}

--- a/frontend/src/components/public/ExperienceSection.svelte
+++ b/frontend/src/components/public/ExperienceSection.svelte
@@ -80,8 +80,7 @@
 									</span>
 									<div class="text-sm text-gray-500 dark:text-gray-400">
 										{formatDateRange(entry.overallStartDate, entry.overallEndDate, presentText)}
-										<!-- TODO: i18n - "X positions" label -->
-										&nbsp;· {entry.positions.length} positions
+										&nbsp;· {$t('public.experience.positions_count', { values: { count: entry.positions.length } })}
 									</div>
 								</div>
 							</div>
@@ -227,8 +226,7 @@
 								<span class="font-bold text-gray-900 dark:text-white" itemprop="name">
 									{entry.company}
 								</span>
-								<!-- TODO: i18n - "X positions" label -->
-								<span class="text-xs text-gray-400 dark:text-gray-500">· {entry.positions.length} positions</span>
+								<span class="text-xs text-gray-400 dark:text-gray-500">· {$t('public.experience.positions_count', { values: { count: entry.positions.length } })}</span>
 							</div>
 							<span class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
 								{formatDateRange(entry.overallStartDate, entry.overallEndDate, presentText)}
@@ -327,8 +325,7 @@
 								</h3>
 								<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
 									<span>{formatDateRange(entry.overallStartDate, entry.overallEndDate, presentText)}</span>
-									<!-- TODO: i18n - "X positions" label -->
-									<span>· {entry.positions.length} positions</span>
+									<span>· {$t('public.experience.positions_count', { values: { count: entry.positions.length } })}</span>
 								</div>
 							</div>
 						</div>

--- a/frontend/src/lib/experienceGrouping.ts
+++ b/frontend/src/lib/experienceGrouping.ts
@@ -1,0 +1,111 @@
+import type { Experience } from './pocketbase';
+
+export interface CompanyGroup {
+	type: 'group';
+	groupId: string;
+	company: string;
+	companyLogo?: string;
+	companyLogoUrl?: string;
+	companyLogoLibraryUrl?: string;
+	logoBackground?: string;
+	overallStartDate?: string;
+	overallEndDate?: string; // undefined means "present" (at least one position is current)
+	positions: Experience[];
+}
+
+export type GroupedExperienceItem = Experience | CompanyGroup;
+
+/**
+ * Groups experiences by company_group_id (if present) or by exact company name match.
+ * - Single-item groups are returned as-is (unwrapped Experience).
+ * - Multi-item groups are wrapped in a CompanyGroup.
+ * - Preserves original sort order: each group appears at the position of its first member.
+ */
+export function groupExperiencesByCompany(items: Experience[]): GroupedExperienceItem[] {
+	if (!items || items.length === 0) {
+		return [];
+	}
+
+	// Build an ordered list of group keys in first-seen order, and map key -> items
+	const groupKeyOrder: string[] = [];
+	const groupMap = new Map<string, Experience[]>();
+
+	for (const item of items) {
+		// Determine the group key: use company_group_id if set, otherwise fall back to company name
+		// Items with no company name go through as singletons using their id as the key
+		const groupKey = item.company_group_id
+			? `id:${item.company_group_id}`
+			: item.company
+				? `company:${item.company}`
+				: `singleton:${item.id}`;
+
+		if (!groupMap.has(groupKey)) {
+			groupKeyOrder.push(groupKey);
+			groupMap.set(groupKey, []);
+		}
+		groupMap.get(groupKey)!.push(item);
+	}
+
+	// Build the result array
+	const result: GroupedExperienceItem[] = [];
+
+	for (const key of groupKeyOrder) {
+		const group = groupMap.get(key)!;
+
+		if (group.length === 1) {
+			// Single item - return as-is
+			result.push(group[0]);
+		} else {
+			// Multi-item group - create a CompanyGroup
+			// Use company name and logo from the FIRST item (most recent by sort order)
+			const first = group[0];
+
+			// Calculate overall date range
+			// - overallStartDate: earliest start_date across all positions
+			// - overallEndDate: latest end_date; if ANY position has no end_date, overall has no end_date (present)
+			let overallStartDate: string | undefined;
+			let overallEndDate: string | undefined = undefined;
+			let anyPresent = false;
+
+			for (const pos of group) {
+				// Track the earliest start date
+				if (pos.start_date) {
+					if (!overallStartDate || pos.start_date < overallStartDate) {
+						overallStartDate = pos.start_date;
+					}
+				}
+				// If any position has no end_date, the group is still "present"
+				if (!pos.end_date) {
+					anyPresent = true;
+				} else if (!anyPresent) {
+					// Track the latest end date only if no position is current yet
+					if (!overallEndDate || pos.end_date > overallEndDate) {
+						overallEndDate = pos.end_date;
+					}
+				}
+			}
+
+			// If any position is present, overallEndDate stays undefined
+			if (anyPresent) {
+				overallEndDate = undefined;
+			}
+
+			const companyGroup: CompanyGroup = {
+				type: 'group',
+				groupId: key,
+				company: first.company,
+				companyLogo: first.company_logo,
+				companyLogoUrl: first.company_logo_url,
+				companyLogoLibraryUrl: first.company_logo_library_url,
+				logoBackground: first.logo_background,
+				overallStartDate,
+				overallEndDate,
+				positions: group
+			};
+
+			result.push(companyGroup);
+		}
+	}
+
+	return result;
+}

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -99,6 +99,7 @@ export interface Experience {
 	company_logo_url?: string;
 	company_logo_library_url?: string;
 	logo_background?: 'none' | 'white' | 'light-gray' | 'dark-gray' | 'black' | 'accent';
+	company_group_id?: string;
 	visibility: 'public' | 'unlisted' | 'private' | 'password';
 	view_visibility?: Record<string, boolean>;
 	is_draft: boolean;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1643,7 +1643,8 @@
 			"previous_image": "Vorheriges Bild"
 		},
 		"experience": {
-			"at": "bei"
+			"at": "bei",
+			"positions_count": "{count} Positionen"
 		},
 		"projects": {
 			"featured": "Empfohlen"

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -1643,7 +1643,8 @@
 			"previous_image": "Previous vision"
 		},
 		"experience": {
-			"at": "with"
+			"at": "with",
+			"positions_count": "{count} positions"
 		},
 		"projects": {
 			"featured": "Honored"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1643,7 +1643,8 @@
 			"previous_image": "Previous image"
 		},
 		"experience": {
-			"at": "at"
+			"at": "at",
+			"positions_count": "{count} positions"
 		},
 		"projects": {
 			"featured": "Featured"

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -1643,7 +1643,8 @@
 			"previous_image": "Previous display"
 		},
 		"experience": {
-			"at": "serving"
+			"at": "serving",
+			"positions_count": "{count} positions"
 		},
 		"projects": {
 			"featured": "Honored"

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -1643,7 +1643,8 @@
 			"previous_image": "Previus pictur"
 		},
 		"experience": {
-			"at": "at"
+			"at": "at",
+			"positions_count": "{count} pozishuns"
 		},
 		"projects": {
 			"featured": "Feechurd"


### PR DESCRIPTION
## Summary
- Adds `company_group_id` field to experience collection with auto-population from normalized company name
- Groups multiple positions at the same company under a shared company header in all 3 public layouts (timeline, compact, default)
- Single-position companies render exactly as before (no visual change)
- Supports manual grouping via `company_group_id` for edge cases (e.g., "Google" vs "Google LLC")

Fixes #244

## Changes
- **Backend**: Migration for `company_group_id` field, auto-populate hooks on create/update, resume upload and duplicate support
- **Frontend**: `experienceGrouping.ts` grouping utility, `ExperienceSection.svelte` grouped rendering, Experience type update
- **i18n**: `positions_count` key added to all locale files

## Test plan
- [x] Verified grouping works with multiple positions at same company
- [x] Single-position companies display unchanged
- [x] All 3 layouts render correctly
- [x] svelte-check passes (0 errors)
- [x] i18n validation passes (100% coverage)
- [x] Go build passes clean
- [x] Tested live on Facet Cloud (jed.facetcloud.io)