### PR TITLE
fix: update Vite 7.3.2 (CVE-2026-39363)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "svelte-check": "^4.0.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.5.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.2"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -5817,9 +5817,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "svelte-check": "^4.0.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.2"
   },
   "dependencies": {
     "@tiptap/core": "^3.21.0",


### PR DESCRIPTION
Patch bump Vite 7.3.1 -> 7.3.2 to fix CVE-2026-39363 (arbitrary file read via dev server WebSocket).

Dev-server-only vulnerability - no production impact. Semver patch release.