### PR TITLE
fix(frontend): restore SSR favicon rendering on public pages

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -96,13 +96,12 @@ let accentStyleEl: HTMLStyleElement | null = $state(null);
 let fontStyleEl: HTMLStyleElement | null = $state(null);
 let fontLinkEl: HTMLLinkElement | null = $state(null);
 let customPaletteLocked = false;
-// Initialize from server-loaded data for correct SSR
-let faviconUrl = $state<string | null>(null);
-
-// Update faviconUrl when data changes (SSR or client-side navigation)
-$effect(() => {
-	faviconUrl = data.faviconUrl;
-});
+// Initialize from server-loaded data so SSR renders the correct favicon.
+// A $state(null) + $effect pattern is broken here because $effect never
+// runs during SSR, so the server-rendered HTML would always fall back to
+// /favicon.png even when a custom favicon is configured. $state-with-initial
+// is writable, so onMount/event-handlers below can still reassign it.
+let faviconUrl = $state<string | null>(data.faviconUrl);
 
 function applyPaletteFromCSS(css: string) {
 	if (!browser || !css) return;


### PR DESCRIPTION
## Summary

Fixes #432 — favicon missing on public pages (still shown on admin backend).

**Root cause:** commit 8b01708 ("feat: eliminate FOUC with SSR accent color, plan config, and palette generation", Mar 28 2026) replaced the direct data-init of faviconUrl with a null + `$effect` pattern:

```diff
-// Initialize from server-loaded data for correct SSR
-let faviconUrl = $state<string | null>(data.faviconUrl);
+let faviconUrl = $state<string | null>(null);
+
+$effect(() => {
+    faviconUrl = data.faviconUrl;
+});
```

`$effect` never runs during SSR, so the server-rendered HTML always contained the fallback `<link rel="icon" href="/favicon.png">` even when a custom favicon was configured. The regression was hidden on admin routes because admin hydrates and navigates as an SPA, so the `$effect` fires after hydration and patches svelte:head client-side. Public pages are hit more often as fresh SSR loads (direct links, search, social), where the fallback was visible.

## Fix

Restore `$state(data.faviconUrl)` so the initial value is picked up during SSR. `$state` remains writable, so the existing `onMount` settings-load (line 274) and `handleFaviconChange` event handler (line 355) keep working unchanged.

This restores the intent of PR #345 (commit e0a123b), whose comment `// Initialize from server-loaded data for correct SSR` was preserved through the regression while the line it described was silently gutted.

## Test plan

- [ ] `cd frontend && npm run check` — svelte-check passes (verified, no errors in `+layout.svelte`)
- [ ] Run `make dev`, upload a custom favicon via `/admin/settings`, hard-reload `/` and view page source — SSR HTML contains `<link rel="icon" type="image/x-icon" href="/api/favicon">`, not the `/favicon.png` fallback
- [ ] Navigate client-side between `/` and `/admin` — favicon remains correct (writable `$state` still updated by onMount/event handler)
- [ ] Clear the custom favicon in admin settings and hard-reload `/` — falls back to `/favicon.png` as expected

Fixes #432