### PR TITLE
fix(frontend): restore custom CSS application + clean up preexisting type errors

### DIFF
--- a/frontend/src/components/public/ProfileNav.svelte
+++ b/frontend/src/components/public/ProfileNav.svelte
@@ -16,7 +16,9 @@
 		hasSkills?: boolean;
 		hasPosts?: boolean;
 		hasTalks?: boolean;
+		hasCourses?: boolean;
 		hasTestimonials?: boolean;
+		hasNewsletter?: boolean;
 		hasContacts?: boolean;
 		viewSlug?: string;
 		sectionOrder?: string[];
@@ -32,7 +34,9 @@
 		hasSkills = false,
 		hasPosts = false,
 		hasTalks = false,
+		hasCourses = false,
 		hasTestimonials = false,
+		hasNewsletter = false,
 		hasContacts = false,
 		viewSlug = '',
 		sectionOrder = [],
@@ -98,12 +102,14 @@
 		skills: { getShow: () => hasSkills },
 		posts: { href: buildUrl('/posts'), getShow: () => hasPosts },
 		talks: { href: buildUrl('/talks'), getShow: () => hasTalks },
+		courses: { getShow: () => hasCourses },
 		testimonials: { getShow: () => hasTestimonials },
+		newsletter: { getShow: () => hasNewsletter },
 		contacts: { getShow: () => hasContacts }
 	};
 
 	// Default order (used when no sectionOrder provided)
-	const DEFAULT_NAV_ORDER = ['experience', 'projects', 'education', 'certifications', 'awards', 'skills', 'posts', 'talks', 'testimonials', 'contacts'];
+	const DEFAULT_NAV_ORDER = ['experience', 'projects', 'education', 'certifications', 'awards', 'skills', 'posts', 'talks', 'courses', 'testimonials', 'newsletter', 'contacts'];
 
 	// Build nav items respecting the provided section order
 	let navItems = $derived.by(() => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -2694,6 +2694,7 @@
 			"skills": "Fähigkeiten",
 			"talks": "Vorträge",
 			"posts": "Beiträge",
+			"courses": "Kurse",
 			"awards": "Auszeichnungen",
 			"certifications": "Zertifizierungen",
 			"testimonials": "Referenzen",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -2694,6 +2694,7 @@
 			"skills": "Crafts",
 			"talks": "Orations",
 			"posts": "Writings",
+			"courses": "Teachings",
 			"awards": "Honors",
 			"certifications": "Accreditations",
 			"testimonials": "Testimonies",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2695,6 +2695,7 @@
 			"skills": "Skills",
 			"talks": "Talks",
 			"posts": "Posts",
+			"courses": "Courses",
 			"awards": "Awards",
 			"certifications": "Certifications",
 			"testimonials": "Testimonials",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -2694,6 +2694,7 @@
 			"skills": "Combat Skills",
 			"talks": "Speeches",
 			"posts": "Battle Logs",
+			"courses": "Combat Drills",
 			"awards": "Medals",
 			"certifications": "Commendations",
 			"testimonials": "Testimonials",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -2694,6 +2694,7 @@
 			"skills": "Skillz",
 			"talks": "Talkz",
 			"posts": "Posts",
+			"courses": "Korsez",
 			"awards": "Awardz",
 			"certifications": "Sertificashunz",
 			"testimonials": "Testimonialz",

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -89,7 +89,11 @@
 	});
 
 	let themeColor = $state('#0ea5e9'); // Default sky-500
-	let customCSS = $state('');
+	// Seed from SSR data so the $effect at the bottom of <script> applies the
+	// admin-configured CSS on mount. Without this, the effect would call
+	// applyCustomCSS('') and wipe the <style id="custom-css"> element
+	// immediately after onMount injected it (regression in v2.21.15).
+	let customCSS = $state(data.customCSS ?? '');
 	let lastCustomCSS = $state('');
 	let mounted = $state(false);
 let gaMeasurementId = $state('');
@@ -288,11 +292,10 @@ onMount(() => {
 		}
 		// SSR provides locale and custom CSS from +layout.server.ts.
 		// Fall back to client-side loadSiteSettings() if SSR didn't provide them.
+		// customCSS is already seeded from data.customCSS via the $state initializer;
+		// the $effect at the bottom of <script> applies it on mount.
 		if (data.defaultLocale || data.customCSS) {
 			initI18n(data.defaultLocale || undefined);
-			if (data.customCSS) {
-				applyCustomCSS(data.customCSS);
-			}
 		} else {
 			const serverLocale = await loadSiteSettings();
 			initI18n(serverLocale);

--- a/frontend/src/routes/admin/settings/webhooks/+page.svelte
+++ b/frontend/src/routes/admin/settings/webhooks/+page.svelte
@@ -212,8 +212,8 @@
 		const ok = await confirm({
 			title: $t('admin.webhooks.delete_title'),
 			message: $t('admin.webhooks.delete_message', { values: { label: wh.label } }),
-			confirmLabel: $t('shared.actions.delete'),
-			variant: 'danger'
+			confirmText: $t('shared.actions.delete'),
+			danger: true
 		});
 		if (!ok) return;
 

--- a/frontend/src/routes/posts/[slug]/+page.svelte
+++ b/frontend/src/routes/posts/[slug]/+page.svelte
@@ -41,7 +41,7 @@ import { getCanonicalUrl, generateOpenGraphTags, generateArticleJsonLd, serializ
 	// JSON-LD Article schema for rich-results / share previews. Emitted in
 	// <svelte:head>; serializer escapes `</` to avoid breaking out of the tag.
 	let articleJsonLd = $derived(
-		serializeJsonLd(generateArticleJsonLd(data.post, baseUrl, data.profile ?? null))
+		serializeJsonLd(generateArticleJsonLd(data.post as unknown as RecordModel, baseUrl, data.profile ?? null))
 	);
 	let postThumb = $derived((data.post as Record<string, string>).cover_image_thumb_url ?? data.post.cover_image_url);
 	let postLarge = $derived((data.post as Record<string, string>).cover_image_large_url ?? data.post.cover_image_url);


### PR DESCRIPTION
## Summary

Two related fixes shipped together:

### 1. Restore custom CSS application on mount (regression in v2.21.15)

Commit 5ca5637 ("fix(frontend): forward +layout.server data through +layout.ts") wired `data.customCSS` from `+layout.server.ts` through to `+layout.svelte` so SSR-provided custom CSS would reach the component. The intent was correct, but it exposed a latent bug:

- `+layout.svelte` initializes `let customCSS = $state('')`
- `onMount()` synchronously sets `mounted = true`, then asynchronously calls `applyCustomCSS(data.customCSS)` — this writes `<style id="custom-css">` to `document.head` and sets `lastCustomCSS = data.customCSS`
- A `$effect` tracking `mounted` and `customCSS` then fires with `customCSS` still equal to `''` (the IIFE applied `data.customCSS` to the DOM but never synced it to local state)
- `applyCustomCSS('')` removes the `<style>` element AND resets `lastCustomCSS = ''`

**Net result:** admin-configured custom CSS is wiped immediately after onMount injects it. Users on v2.21.15 see no custom CSS at all.

**Fix:** seed the `customCSS` `$state` from `data.customCSS` so the `$effect` runs `applyCustomCSS(data.customCSS)` and the style sticks. Removed the now-redundant explicit `applyCustomCSS(data.customCSS)` call in `onMount` since the effect handles it.

### 2. Resolve four preexisting svelte-check type errors

While diagnosing the regression, `svelte-check` flagged four unrelated preexisting errors. Cleaned them up in the same PR:

- **ProfileNav.svelte:** `Props` was missing `hasCourses` and `hasNewsletter` even though `+page.svelte` and `[slug=slug]/+page.svelte` pass them. The component's `sectionConfig` map and `DEFAULT_NAV_ORDER` also didn't include `courses` or `newsletter`, so they didn't render in the nav even when admins configured them. Added Props + sectionConfig + DEFAULT_NAV_ORDER, plus `public.sections.courses` i18n key in all 5 locale files (newsletter already existed).
- **webhooks/+page.svelte:** Caller used the wrong `ConfirmOptions` field names — `confirmLabel` and `variant: 'danger'` don't exist on the type. `ConfirmDialog` actually reads `confirmText` and `danger`, so the destructive Delete button was silently showing the generic "Confirm" label without `btn-danger` styling. Fixed.
- **posts/[slug]/+page.svelte:** `data.post` is a sanitized subset lacking PocketBase's `collectionId` / `collectionName`, but `generateArticleJsonLd` expects a full `RecordModel`. Cast at call site — function never reads those fields, output JSON-LD is byte-for-byte identical.

## Verification

- `npm run i18n:validate` — 100% coverage across all 5 locales
- `npx svelte-check` — 0 errors (was 4), 13 warnings (unchanged)
- `npx vite build` — successful production build
- Accessibility-lead reviewed both diffs: approved as-is, net positive (restores admin-intended styling; restores correct destructive-button label/styling)

## Test plan

- [ ] Set custom CSS in admin (e.g., `body { background: red; }`)
- [ ] Reload public page — verify red background applies (was missing in v2.21.15)
- [ ] Inspect DOM — verify `<style id="custom-css">` is present and has the right content
- [ ] Hard-refresh after editing CSS in admin — verify the new CSS applies
- [ ] Trigger a webhook delete confirmation — verify the button reads "Delete" with red styling