### PR TITLE
polish(a11y): design polish epic — touch targets, autocomplete, i18n, lightbox

### DIFF
--- a/frontend/src/components/public/Lightbox.svelte
+++ b/frontend/src/components/public/Lightbox.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import { t } from 'svelte-i18n';
+	import { isFilename } from '$lib/utils';
+
+	interface LightboxImage {
+		url?: string;
+		title?: string;
+		alt_text?: string;
+	}
+
+	interface Props {
+		/** Two-way bound open state. Set to false to close. */
+		open: boolean;
+		/** Images to display. Lightbox renders nothing when empty. */
+		images: LightboxImage[];
+		/** Index to show when opening; reset each time `open` transitions to true. */
+		startIndex?: number;
+	}
+
+	let { open = $bindable(), images, startIndex = 0 }: Props = $props();
+
+	let index = $state(startIndex);
+	let dialogEl: HTMLDivElement | undefined = $state();
+	let closeBtnEl: HTMLButtonElement | undefined = $state();
+	let prevFocus: HTMLElement | null = null;
+	const titleId = `lightbox-title-${Math.random().toString(36).slice(2, 10)}`;
+
+	$effect(() => {
+		if (!open) return;
+		prevFocus = (document.activeElement as HTMLElement | null) ?? null;
+		index = startIndex;
+		queueMicrotask(() => closeBtnEl?.focus());
+		const prevOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = prevOverflow;
+			// Restore focus to the element that opened the lightbox (WCAG 2.4.3)
+			if (prevFocus && typeof prevFocus.focus === 'function') {
+				prevFocus.focus();
+			}
+			prevFocus = null;
+		};
+	});
+
+	function close() {
+		open = false;
+	}
+
+	function next() {
+		if (images.length > 0) index = (index + 1) % images.length;
+	}
+
+	function prev() {
+		if (images.length > 0) index = (index - 1 + images.length) % images.length;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (!open) return;
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			close();
+		} else if (e.key === 'ArrowRight') {
+			e.preventDefault();
+			next();
+		} else if (e.key === 'ArrowLeft') {
+			e.preventDefault();
+			prev();
+		} else if (e.key === 'Tab') {
+			// Focus trap inside the dialog
+			const focusables = dialogEl?.querySelectorAll<HTMLElement>('button:not([disabled])');
+			if (!focusables || focusables.length === 0) return;
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			const active = document.activeElement;
+			if (e.shiftKey && active === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && active === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) close();
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open && images[index]}
+	{@const current = images[index]}
+	{@const showTitle = !!current.title && !isFilename(current.title)}
+	<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+	<div
+		bind:this={dialogEl}
+		role="dialog"
+		aria-modal="true"
+		aria-label={$t('public.lightbox.title')}
+		aria-labelledby={showTitle ? titleId : undefined}
+		class="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
+		onclick={handleBackdropClick}
+		oncontextmenu={(e) => e.preventDefault()}
+	>
+		<!-- Close button -->
+		<button
+			bind:this={closeBtnEl}
+			type="button"
+			onclick={close}
+			class="absolute top-4 right-4 min-w-11 min-h-11 inline-flex items-center justify-center p-2 text-white/70 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-white rounded-md transition-colors"
+			aria-label={$t('public.lightbox.close')}
+		>
+			<svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+			</svg>
+		</button>
+
+		{#if images.length > 1}
+			<button
+				type="button"
+				onclick={(e) => { e.stopPropagation(); prev(); }}
+				class="absolute left-4 min-w-11 min-h-11 inline-flex items-center justify-center p-2 text-white/70 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-white rounded-md transition-colors"
+				aria-label={$t('public.lightbox.previous_image')}
+			>
+				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+				</svg>
+			</button>
+
+			<button
+				type="button"
+				onclick={(e) => { e.stopPropagation(); next(); }}
+				class="absolute right-4 min-w-11 min-h-11 inline-flex items-center justify-center p-2 text-white/70 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-white rounded-md transition-colors"
+				aria-label={$t('public.lightbox.next_image')}
+			>
+				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+				</svg>
+			</button>
+		{/if}
+
+		<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
+		<img
+			src={current.url || ''}
+			alt={current.title || current.alt_text || ''}
+			class="max-h-[90vh] max-w-[90vw] object-contain"
+			onclick={(e) => e.stopPropagation()}
+			oncontextmenu={(e) => e.preventDefault()}
+		/>
+
+		<div class="absolute bottom-4 left-1/2 -translate-x-1/2 text-center text-white">
+			{#if showTitle}
+				<p id={titleId} class="text-lg font-medium mb-1">{current.title}</p>
+			{/if}
+			{#if images.length > 1}
+				<p class="text-sm text-white/70">{index + 1} / {images.length}</p>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/frontend/src/components/shared/ThemeToggle.svelte
+++ b/frontend/src/components/shared/ThemeToggle.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <button
-	class="p-2 rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm shadow-sm border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+	class="p-2 min-w-11 min-h-11 inline-flex items-center justify-center rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm shadow-sm border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 	onclick={() => theme.toggle()}
 	aria-label={$theme === 'dark' ? $t('shared.theme.switch_to_light') : $t('shared.theme.switch_to_dark')}
 >

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -2756,7 +2756,8 @@
 		"lightbox": {
 			"close": "Lightbox schließen",
 			"next_image": "Nächstes Bild",
-			"previous_image": "Vorheriges Bild"
+			"previous_image": "Vorheriges Bild",
+			"title": "Bildansicht"
 		},
 		"experience": {
 			"at": "bei",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -2424,7 +2424,7 @@
 			"opens": "{count} Öffnungen",
 			"clicks": "{count} Klicks",
 			"smtp_not_configured": "SMTP nicht konfiguriert",
-"smtp_not_configured_hint": "Konfigurieren Sie SMTP in den Einstellungen, um Newsletter zu versenden. Sie können weiterhin Abonnenten sammeln.",
+			"smtp_not_configured_hint": "Konfigurieren Sie SMTP in den Einstellungen, um Newsletter zu versenden. Sie können weiterhin Abonnenten sammeln.",
 			"hub_title": "Newsletter",
 			"hub_description": "Verwalten Sie Abonnenten, segmentieren Sie sie in Listen und senden Sie Rundschreiben.",
 			"card_subscribers_title": "Abonnenten",
@@ -2793,7 +2793,19 @@
 		},
 		"posts": {
 			"read_more": "Weiterlesen",
-			"featured": "Empfohlen"
+			"featured": "Empfohlen",
+			"title_all": "Alle Beiträge",
+			"title_tagged": "Beiträge mit Tag „{tag}“",
+			"back_to_profile": "Zurück zum Profil",
+			"by_author": "von {name}",
+			"subscribe_rss": "Beiträge abonnieren (RSS)",
+			"filter_by_tag": "Nach Tag filtern",
+			"filter_all": "Alle",
+			"empty": "Noch keine Beiträge",
+			"empty_tagged": "Keine Beiträge mit Tag „{tag}“ gefunden",
+			"view_all": "Alle Beiträge anzeigen",
+			"hidden_title": "Beiträge sind derzeit ausgeblendet",
+			"profile_setup_default": "Dieses Profil wird gerade eingerichtet."
 		},
 		"testimonials": {
 			"photo_alt": "Foto von {name}",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -2756,7 +2756,8 @@
 		"lightbox": {
 			"close": "Close vision",
 			"next_image": "Next vision",
-			"previous_image": "Previous vision"
+			"previous_image": "Previous vision",
+			"title": "Vision of pictures"
 		},
 		"experience": {
 			"at": "with",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -2424,7 +2424,7 @@
 			"opens": "{count} opened",
 			"clicks": "{count} followed links",
 			"smtp_not_configured": "The messenger pigeons are not prepared",
-"smtp_not_configured_hint": "Configure SMTP to send scrolls. You may still gather listeners.",
+			"smtp_not_configured_hint": "Configure SMTP to send scrolls. You may still gather listeners.",
 			"hub_title": "Postar Annon",
 			"hub_description": "Lerno palthaneri, lestath nín, ar suilad i thent.",
 			"card_subscribers_title": "Palthaneri",
@@ -2793,7 +2793,19 @@
 		},
 		"posts": {
 			"read_more": "Read further",
-			"featured": "Honored"
+			"featured": "Honored",
+			"title_all": "Ilye Parmar",
+			"title_tagged": "Parmar marked with \"{tag}\"",
+			"back_to_profile": "Return to the chronicle",
+			"by_author": "penned by {name}",
+			"subscribe_rss": "Heed the herald (RSS)",
+			"filter_by_tag": "Sift by sigil",
+			"filter_all": "All",
+			"empty": "No tales told yet",
+			"empty_tagged": "No tales bearing the sigil \"{tag}\"",
+			"view_all": "Behold all tales",
+			"hidden_title": "The tales are veiled at this hour",
+			"profile_setup_default": "This chronicle is being prepared."
 		},
 		"testimonials": {
 			"photo_alt": "Canthui o {name}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -584,7 +584,6 @@
 			"content": "Content",
 			"features": "Features",
 			"audience": "Audience",
-			"analytics": "Analytics",
 			"comments": "Comments",
 			"subscribers": "Subscribers",
 			"newsletter": "Newsletter",
@@ -2794,7 +2793,19 @@
 		},
 		"posts": {
 			"read_more": "Read more",
-			"featured": "Featured"
+			"featured": "Featured",
+			"title_all": "All Posts",
+			"title_tagged": "Posts tagged \"{tag}\"",
+			"back_to_profile": "Back to Profile",
+			"by_author": "by {name}",
+			"subscribe_rss": "Subscribe to posts (RSS)",
+			"filter_by_tag": "Filter by tag",
+			"filter_all": "All",
+			"empty": "No posts yet",
+			"empty_tagged": "No posts found with tag \"{tag}\"",
+			"view_all": "View all posts",
+			"hidden_title": "Posts are hidden right now",
+			"profile_setup_default": "This profile is being set up."
 		},
 		"testimonials": {
 			"photo_alt": "Photo of {name}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2756,7 +2756,8 @@
 		"lightbox": {
 			"close": "Close lightbox",
 			"next_image": "Next image",
-			"previous_image": "Previous image"
+			"previous_image": "Previous image",
+			"title": "Image viewer"
 		},
 		"experience": {
 			"at": "at",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -2424,7 +2424,7 @@
 			"opens": "{count} opened",
 			"clicks": "{count} acted",
 			"smtp_not_configured": "Communications array offline",
-"smtp_not_configured_hint": "Configure SMTP to send dispatches. Warriors can still enlist.",
+			"smtp_not_configured_hint": "Configure SMTP to send dispatches. Warriors can still enlist.",
 			"hub_title": "War Dispatch",
 			"hub_description": "Command your warriors, divide them into squads, and broadcast dispatches.",
 			"card_subscribers_title": "loDnI'pu'",
@@ -2793,7 +2793,19 @@
 		},
 		"posts": {
 			"read_more": "Continue reading",
-			"featured": "Honored"
+			"featured": "Honored",
+			"title_all": "Hoch ghItlhmey",
+			"title_tagged": "ghItlhmey {tag}",
+			"back_to_profile": "profile-Daq chegh",
+			"by_author": "qonta' {name}",
+			"subscribe_rss": "ghItlhmey tlhob (RSS)",
+			"filter_by_tag": "tag wIv",
+			"filter_all": "Hoch",
+			"empty": "ghItlh tu'lu'be'",
+			"empty_tagged": "\"{tag}\" rurbogh ghItlh tu'lu'be'",
+			"view_all": "Hoch ghItlhmey legh",
+			"hidden_title": "DaH So'lu'bogh ghItlhmey",
+			"profile_setup_default": "cherta'lu'taH profile."
 		},
 		"testimonials": {
 			"photo_alt": "mIllogh {name}",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -2756,7 +2756,8 @@
 		"lightbox": {
 			"close": "Close viewscreen",
 			"next_image": "Next display",
-			"previous_image": "Previous display"
+			"previous_image": "Previous display",
+			"title": "naghHom Sech"
 		},
 		"experience": {
 			"at": "serving",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -2756,7 +2756,8 @@
 		"lightbox": {
 			"close": "Cloze litebox",
 			"next_image": "Nekst pictur",
-			"previous_image": "Previus pictur"
+			"previous_image": "Previus pictur",
+			"title": "Pictur viewr"
 		},
 		"experience": {
 			"at": "at",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -2424,7 +2424,7 @@
 			"opens": "{count} openz",
 			"clicks": "{count} clickz",
 			"smtp_not_configured": "SMTP nawt configurrd",
-"smtp_not_configured_hint": "Configur SMTP in Settingz 2 send newsletterz. U can still collect peepz tho!",
+			"smtp_not_configured_hint": "Configur SMTP in Settingz 2 send newsletterz. U can still collect peepz tho!",
 			"hub_title": "Mewzlettr",
 			"hub_description": "Boss ur peepz, sort em into litterz, n yeet noozez owt 2 dem.",
 			"card_subscribers_title": "Peepz",
@@ -2793,7 +2793,19 @@
 		},
 		"posts": {
 			"read_more": "Moar plz",
-			"featured": "Speshul"
+			"featured": "Speshul",
+			"title_all": "All Da Posts",
+			"title_tagged": "Posts taggd \"{tag}\"",
+			"back_to_profile": "Bak 2 Profile",
+			"by_author": "by {name}",
+			"subscribe_rss": "Subscrybe 2 posts (RSS)",
+			"filter_by_tag": "Filtr by tag",
+			"filter_all": "All",
+			"empty": "No posts yit",
+			"empty_tagged": "No posts wit tag \"{tag}\" oh noes",
+			"view_all": "Vyu all posts",
+			"hidden_title": "Posts r hyd rite naow",
+			"profile_setup_default": "Dis profile is bein set up."
 		},
 		"testimonials": {
 			"photo_alt": "Picshur of {name}",

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -405,7 +405,7 @@ $effect(() => {
 
 <!-- Skip link for keyboard navigation -->
 <a href="#main-content" class="skip-link">
-	Skip to main content
+	{$t('shared.aria.skip_to_content')}
 </a>
 
 {@render children?.()}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -388,7 +388,7 @@
 			<button
 				bind:this={printMenuTriggerEl}
 				onclick={() => showPrintMenu = !showPrintMenu}
-				class="p-2 rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
+				class="p-2 min-w-11 min-h-11 inline-flex items-center justify-center rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
 				title={$t('public.homepage.print_options')}
 				aria-label={$t('public.homepage.print_options')}
 				aria-expanded={showPrintMenu}
@@ -440,7 +440,7 @@
 			{#if $currentUser}
 				<button
 					onclick={handleLogout}
-					class="px-3 py-2 rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors text-sm font-medium text-stone-700 dark:text-stone-300"
+					class="px-3 py-2 min-h-11 inline-flex items-center rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors text-sm font-medium text-stone-700 dark:text-stone-300"
 					title={$t('public.homepage.log_in_account')}
 					aria-label={$t('public.homepage.log_in_account')}
 				>
@@ -449,7 +449,7 @@
 			{:else}
 				<a
 					href="/admin/login"
-					class="px-3 py-2 rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors text-sm font-medium text-stone-700 dark:text-stone-300"
+					class="px-3 py-2 min-h-11 inline-flex items-center rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors text-sm font-medium text-stone-700 dark:text-stone-300"
 					title={$t('public.homepage.log_in')}
 					aria-label={$t('public.homepage.log_in')}
 				>

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -286,7 +286,7 @@
 				<button
 					bind:this={printMenuTriggerEl}
 					onclick={() => showPrintMenu = !showPrintMenu}
-					class="p-2 rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
+					class="p-2 min-w-11 min-h-11 inline-flex items-center justify-center rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
 					title={$t('public.aria.print_options')}
 					aria-label={$t('public.aria.print_options')}
 					aria-expanded={showPrintMenu}
@@ -342,7 +342,7 @@
 			{#if pb.authStore.isValid}
 				<a
 					href="/admin"
-					class="p-2 rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
+					class="p-2 min-w-11 min-h-11 inline-flex items-center justify-center rounded-lg bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm shadow-sm border border-stone-200 dark:border-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
 					title="Go to Admin"
 					aria-label={$t('public.aria.go_to_admin')}
 				>

--- a/frontend/src/routes/admin/login/+page.svelte
+++ b/frontend/src/routes/admin/login/+page.svelte
@@ -261,6 +261,7 @@
 						bind:value={email}
 						class="input"
 						placeholder="admin@example.com"
+						autocomplete="username"
 						disabled={loading}
 					/>
 				</div>
@@ -273,6 +274,7 @@
 						bind:value={password}
 						class="input"
 						placeholder="••••••••"
+						autocomplete="current-password"
 						disabled={loading}
 					/>
 				</div>

--- a/frontend/src/routes/posts/+page.svelte
+++ b/frontend/src/routes/posts/+page.svelte
@@ -16,7 +16,7 @@
 
 	// Compute back navigation URL based on where user came from
 	let backUrl = $derived(data.fromView ? `/${data.fromView}` : '/');
-	let landingMessage = $derived(data.landingPageMessage || 'This profile is being set up.');
+	let landingMessage = $derived(data.landingPageMessage || $t('public.posts.profile_setup_default'));
 	let rssUrl = $derived(browser ? new URL('/rss.xml', pb.baseUrl).toString() : '/rss.xml');
 
 	onMount(() => {
@@ -42,7 +42,7 @@
 			<ThemeToggle />
 		</div>
 		<div class="max-w-2xl w-full bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 p-8 text-center space-y-4">
-			<h1 class="text-2xl font-semibold text-gray-900 dark:text-white">Posts are hidden right now</h1>
+			<h1 class="text-2xl font-semibold text-gray-900 dark:text-white">{$t('public.posts.hidden_title')}</h1>
 			<p class="text-gray-600 dark:text-gray-300 leading-relaxed whitespace-pre-wrap">{landingMessage}</p>
 		</div>
 	</div>
@@ -67,20 +67,20 @@
 				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
 				</svg>
-				<span>Back to Profile</span>
+				<span>{$t('public.posts.back_to_profile')}</span>
 			</a>
 
 			<h1 class="text-3xl sm:text-4xl font-bold">
 				{#if data.selectedTag}
-					Posts tagged "{data.selectedTag}"
+					{$t('public.posts.title_tagged', { values: { tag: data.selectedTag } })}
 				{:else}
-					All Posts
+					{$t('public.posts.title_all')}
 				{/if}
 			</h1>
 
 			{#if data.profile?.name}
 				<p class="mt-2 text-gray-300">
-					by {data.profile.name}
+					{$t('public.posts.by_author', { values: { name: data.profile.name } })}
 				</p>
 			{/if}
 
@@ -92,7 +92,7 @@
 					<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
 						<path d="M4.5 14.5a1.5 1.5 0 10.001 3.001A1.5 1.5 0 004.5 14.5zM3 4a1 1 0 011-1c6.075 0 11 4.925 11 11a1 1 0 01-1 1h-1a1 1 0 01-1-1 9 9 0 00-9-9 1 1 0 01-1-1V4zm0 5a1 1 0 011-1c3.866 0 7 3.134 7 7a1 1 0 01-1 1h-1a1 1 0 01-1-1 5 5 0 00-5-5 1 1 0 01-1-1V9z" />
 					</svg>
-					<span class="text-sm font-medium">Subscribe to posts (RSS)</span>
+					<span class="text-sm font-medium">{$t('public.posts.subscribe_rss')}</span>
 				</a>
 			</div>
 		</div>
@@ -103,7 +103,7 @@
 		<!-- Tag filter -->
 		{#if data.allTags.length > 0}
 			<div class="mb-8">
-				<h2 class="sr-only">Filter by tag</h2>
+				<h2 class="sr-only">{$t('public.posts.filter_by_tag')}</h2>
 				<div class="flex flex-wrap gap-2">
 					<a
 						href="/posts"
@@ -111,7 +111,7 @@
 							? 'bg-primary-600 text-white'
 							: 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'}"
 					>
-						All
+						{$t('public.posts.filter_all')}
 					</a>
 					{#each data.allTags as tag}
 						<a
@@ -200,14 +200,14 @@
 				</svg>
 				<p class="text-gray-500 dark:text-gray-400 text-lg">
 					{#if data.selectedTag}
-						No posts found with tag "{data.selectedTag}"
+						{$t('public.posts.empty_tagged', { values: { tag: data.selectedTag } })}
 					{:else}
-						No posts yet
+						{$t('public.posts.empty')}
 					{/if}
 				</p>
 				{#if data.selectedTag}
 					<a href="/posts" class="mt-4 inline-block text-primary-600 dark:text-primary-400 hover:underline">
-						View all posts
+						{$t('public.posts.view_all')}
 					</a>
 				{/if}
 			</div>

--- a/frontend/src/routes/posts/[slug]/+page.svelte
+++ b/frontend/src/routes/posts/[slug]/+page.svelte
@@ -9,6 +9,7 @@ import ShareButton from '$components/shared/ShareButton.svelte';
 import VisibilityBadge from '$components/shared/VisibilityBadge.svelte';
 import Footer from '$components/public/Footer.svelte';
 import Comments from '$components/public/Comments.svelte';
+import Lightbox from '$components/public/Lightbox.svelte';
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { onMount } from 'svelte';
@@ -63,29 +64,6 @@ import { getCanonicalUrl, generateOpenGraphTags, generateArticleJsonLd, serializ
 	function openLightbox(index: number) {
 		lightboxIndex = index;
 		lightboxOpen = true;
-	}
-
-	function closeLightbox() {
-		lightboxOpen = false;
-	}
-
-	function nextImage() {
-		if (imageMedia.length > 0) {
-			lightboxIndex = (lightboxIndex + 1) % imageMedia.length;
-		}
-	}
-
-	function prevImage() {
-		if (imageMedia.length > 0) {
-			lightboxIndex = (lightboxIndex - 1 + imageMedia.length) % imageMedia.length;
-		}
-	}
-
-	function handleLightboxKeydown(e: KeyboardEvent) {
-		if (!lightboxOpen) return;
-		if (e.key === 'Escape') closeLightbox();
-		if (e.key === 'ArrowRight') nextImage();
-		if (e.key === 'ArrowLeft') prevImage();
 	}
 
 	let referrerPath = $state('');
@@ -405,71 +383,4 @@ const getHost = (url?: string) => {
 </div>
 
 <!-- Lightbox Modal -->
-<svelte:window onkeydown={handleLightboxKeydown} />
-
-{#if lightboxOpen && imageMedia[lightboxIndex]}
-	<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
-	<div
-		class="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
-		onclick={closeLightbox}
-		oncontextmenu={(e) => e.preventDefault()}
-	>
-		<!-- Close button -->
-		<button
-			type="button"
-			onclick={closeLightbox}
-			class="absolute top-4 right-4 p-2 text-white/70 hover:text-white transition-colors"
-			aria-label={$t('public.lightbox.close')}
-		>
-			<svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-			</svg>
-		</button>
-
-		<!-- Previous button -->
-		{#if imageMedia.length > 1}
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); prevImage(); }}
-				class="absolute left-4 p-2 text-white/70 hover:text-white transition-colors"
-				aria-label={$t('public.lightbox.previous_image')}
-			>
-				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-				</svg>
-			</button>
-
-			<!-- Next button -->
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); nextImage(); }}
-				class="absolute right-4 p-2 text-white/70 hover:text-white transition-colors"
-				aria-label={$t('public.lightbox.next_image')}
-			>
-				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-				</svg>
-			</button>
-		{/if}
-
-		<!-- Image container -->
-		<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
-		<img
-			src={imageMedia[lightboxIndex].url || ''}
-			alt={imageMedia[lightboxIndex].title || imageMedia[lightboxIndex].alt_text || ''}
-			class="max-h-[90vh] max-w-[90vw] object-contain"
-			onclick={(e) => e.stopPropagation()}
-			oncontextmenu={(e) => e.preventDefault()}
-		/>
-
-		<!-- Image counter and title -->
-		<div class="absolute bottom-4 left-1/2 -translate-x-1/2 text-center text-white">
-			{#if imageMedia[lightboxIndex].title && !isFilename(imageMedia[lightboxIndex].title)}
-				<p class="text-lg font-medium mb-1">{imageMedia[lightboxIndex].title}</p>
-			{/if}
-			{#if imageMedia.length > 1}
-				<p class="text-sm text-white/70">{lightboxIndex + 1} / {imageMedia.length}</p>
-			{/if}
-		</div>
-	</div>
-{/if}
+<Lightbox bind:open={lightboxOpen} images={imageMedia} startIndex={lightboxIndex} />

--- a/frontend/src/routes/projects/[slug]/+page.svelte
+++ b/frontend/src/routes/projects/[slug]/+page.svelte
@@ -10,6 +10,7 @@ import { goto } from '$app/navigation';
 import ThemeToggle from '$components/shared/ThemeToggle.svelte';
 import ShareButton from '$components/shared/ShareButton.svelte';
 import VisibilityBadge from '$components/shared/VisibilityBadge.svelte';
+import Lightbox from '$components/public/Lightbox.svelte';
 import Footer from '$components/public/Footer.svelte';
 import type { RecordModel } from 'pocketbase';
 import { getCanonicalUrl, generateOpenGraphTags } from '$lib/seo';
@@ -51,29 +52,6 @@ let mediaRefs = $derived(((data as any).media_refs as Array<RecordModel & {
 	function openLightbox(index: number) {
 		lightboxIndex = index;
 		lightboxOpen = true;
-	}
-
-	function closeLightbox() {
-		lightboxOpen = false;
-	}
-
-	function nextImage() {
-		if (imageMedia.length > 0) {
-			lightboxIndex = (lightboxIndex + 1) % imageMedia.length;
-		}
-	}
-
-	function prevImage() {
-		if (imageMedia.length > 0) {
-			lightboxIndex = (lightboxIndex - 1 + imageMedia.length) % imageMedia.length;
-		}
-	}
-
-	function handleLightboxKeydown(e: KeyboardEvent) {
-		if (!lightboxOpen) return;
-		if (e.key === 'Escape') closeLightbox();
-		if (e.key === 'ArrowRight') nextImage();
-		if (e.key === 'ArrowLeft') prevImage();
 	}
 
 	onMount(() => {
@@ -407,71 +385,4 @@ const getFileName = (url?: string) => {
 </div>
 
 <!-- Lightbox Modal -->
-<svelte:window onkeydown={handleLightboxKeydown} />
-
-{#if lightboxOpen && imageMedia[lightboxIndex]}
-	<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
-	<div
-		class="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
-		onclick={closeLightbox}
-		oncontextmenu={(e) => e.preventDefault()}
-	>
-		<!-- Close button -->
-		<button
-			type="button"
-			onclick={closeLightbox}
-			class="absolute top-4 right-4 p-2 text-white/70 hover:text-white transition-colors"
-			aria-label={$t('public.lightbox.close')}
-		>
-			<svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-			</svg>
-		</button>
-
-		<!-- Previous button -->
-		{#if imageMedia.length > 1}
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); prevImage(); }}
-				class="absolute left-4 p-2 text-white/70 hover:text-white transition-colors"
-				aria-label={$t('public.lightbox.previous_image')}
-			>
-				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-				</svg>
-			</button>
-
-			<!-- Next button -->
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); nextImage(); }}
-				class="absolute right-4 p-2 text-white/70 hover:text-white transition-colors"
-				aria-label={$t('public.lightbox.next_image')}
-			>
-				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-				</svg>
-			</button>
-		{/if}
-
-		<!-- Image container -->
-		<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
-		<img
-			src={imageMedia[lightboxIndex].url || ''}
-			alt={imageMedia[lightboxIndex].title || imageMedia[lightboxIndex].alt_text || ''}
-			class="max-h-[90vh] max-w-[90vw] object-contain"
-			onclick={(e) => e.stopPropagation()}
-			oncontextmenu={(e) => e.preventDefault()}
-		/>
-
-		<!-- Image counter and title -->
-		<div class="absolute bottom-4 left-1/2 -translate-x-1/2 text-center text-white">
-			{#if imageMedia[lightboxIndex].title && !isFilename(imageMedia[lightboxIndex].title)}
-				<p class="text-lg font-medium mb-1">{imageMedia[lightboxIndex].title}</p>
-			{/if}
-			{#if imageMedia.length > 1}
-				<p class="text-sm text-white/70">{lightboxIndex + 1} / {imageMedia.length}</p>
-			{/if}
-		</div>
-	</div>
-{/if}
+<Lightbox bind:open={lightboxOpen} images={imageMedia} startIndex={lightboxIndex} />

--- a/frontend/src/routes/talks/[slug]/+page.svelte
+++ b/frontend/src/routes/talks/[slug]/+page.svelte
@@ -8,6 +8,7 @@
 	import ShareButton from '$components/shared/ShareButton.svelte';
 import VisibilityBadge from '$components/shared/VisibilityBadge.svelte';
 	import Footer from '$components/public/Footer.svelte';
+	import Lightbox from '$components/public/Lightbox.svelte';
 	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
@@ -81,29 +82,6 @@ import VisibilityBadge from '$components/shared/VisibilityBadge.svelte';
 	function openLightbox(index: number) {
 		lightboxIndex = index;
 		lightboxOpen = true;
-	}
-
-	function closeLightbox() {
-		lightboxOpen = false;
-	}
-
-	function nextImage() {
-		if (imageMedia.length > 0) {
-			lightboxIndex = (lightboxIndex + 1) % imageMedia.length;
-		}
-	}
-
-	function prevImage() {
-		if (imageMedia.length > 0) {
-			lightboxIndex = (lightboxIndex - 1 + imageMedia.length) % imageMedia.length;
-		}
-	}
-
-	function handleLightboxKeydown(e: KeyboardEvent) {
-		if (!lightboxOpen) return;
-		if (e.key === 'Escape') closeLightbox();
-		if (e.key === 'ArrowRight') nextImage();
-		if (e.key === 'ArrowLeft') prevImage();
 	}
 
 	let referrerPath = $state('');
@@ -431,71 +409,4 @@ import VisibilityBadge from '$components/shared/VisibilityBadge.svelte';
 </div>
 
 <!-- Lightbox Modal -->
-<svelte:window onkeydown={handleLightboxKeydown} />
-
-{#if lightboxOpen && imageMedia[lightboxIndex]}
-	<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
-	<div
-		class="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
-		onclick={closeLightbox}
-		oncontextmenu={(e) => e.preventDefault()}
-	>
-		<!-- Close button -->
-		<button
-			type="button"
-			onclick={closeLightbox}
-			class="absolute top-4 right-4 p-2 text-white/70 hover:text-white transition-colors"
-			aria-label={$t('public.lightbox.close')}
-		>
-			<svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-			</svg>
-		</button>
-
-		<!-- Previous button -->
-		{#if imageMedia.length > 1}
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); prevImage(); }}
-				class="absolute left-4 p-2 text-white/70 hover:text-white transition-colors"
-				aria-label={$t('public.lightbox.previous_image')}
-			>
-				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-				</svg>
-			</button>
-
-			<!-- Next button -->
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); nextImage(); }}
-				class="absolute right-4 p-2 text-white/70 hover:text-white transition-colors"
-				aria-label={$t('public.lightbox.next_image')}
-			>
-				<svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-				</svg>
-			</button>
-		{/if}
-
-		<!-- Image container -->
-		<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
-		<img
-			src={imageMedia[lightboxIndex].url || ''}
-			alt={imageMedia[lightboxIndex].title || imageMedia[lightboxIndex].alt_text || ''}
-			class="max-h-[90vh] max-w-[90vw] object-contain"
-			onclick={(e) => e.stopPropagation()}
-			oncontextmenu={(e) => e.preventDefault()}
-		/>
-
-		<!-- Image counter and title -->
-		<div class="absolute bottom-4 left-1/2 -translate-x-1/2 text-center text-white">
-			{#if imageMedia[lightboxIndex].title && !isFilename(imageMedia[lightboxIndex].title)}
-				<p class="text-lg font-medium mb-1">{imageMedia[lightboxIndex].title}</p>
-			{/if}
-			{#if imageMedia.length > 1}
-				<p class="text-sm text-white/70">{lightboxIndex + 1} / {imageMedia.length}</p>
-			{/if}
-		</div>
-	</div>
-{/if}
+<Lightbox bind:open={lightboxOpen} images={imageMedia} startIndex={lightboxIndex} />


### PR DESCRIPTION
## Summary

Five-commit accessibility + design polish pass driven by parallel
audit (accessibility-lead agent + live screenshots at localhost:18091).
Each commit is atomic and revertible.

### Commits

1. **`fix(a11y): enforce 44px minimum touch target on public header buttons`**
   Print menu trigger, theme toggle, and Log In / Admin links in the
   public header were 38px tall. Adds `min-w-11 min-h-11 inline-flex
   items-center justify-center` (44×44 WCAG 2.5.5 minimum). Touches
   `ThemeToggle.svelte`, `routes/+page.svelte`, `routes/[slug=slug]/+page.svelte`.

2. **`fix(a11y): add autocomplete attributes to admin login inputs`**
   Email gets `autocomplete="username"`, password gets
   `autocomplete="current-password"` (WCAG 1.3.5).

3. **`fix(a11y): translate skip-to-content link via existing i18n key`**
   Skip link in the root layout was hardcoded English. Switched to
   `\$t('shared.aria.skip_to_content')` — translations already existed.

4. **`fix(i18n,a11y): translate hardcoded strings on /posts page`**
   ~11 user-visible strings on the public posts index (h1s, filter
   labels, empty state, RSS subscribe, back nav, byline, hidden-posts
   state). New `public.posts.*` keys added to en/de/elvish/klingon/lolcat.
   `npm run i18n:validate` is 100%.

5. **`fix(a11y): extract Lightbox component with dialog semantics + focus trap`**
   `routes/posts/[slug]`, `projects/[slug]`, and `talks/[slug]` had
   three byte-identical inline modals with no `role=dialog`, no
   `aria-modal`, no focus trap, no focus restoration, and 32px nav
   buttons. Extracted to `components/public/Lightbox.svelte`:
   - `role="dialog"` + `aria-modal="true"` + translated `aria-label`
   - `aria-labelledby` when image has a presentable title
   - `\$effect` captures `document.activeElement` on open and refocuses
     it on close (WCAG 2.4.3)
   - Tab/Shift+Tab focus trap cycles within the dialog
   - Body scroll locked while open
   - Buttons 44×44 with `focus-visible` outline
   - Escape / ArrowLeft / ArrowRight keys handled
   - New `public.lightbox.title` key in all 5 locales

### Verification

- `npx svelte-check`: 0 errors (15 preexisting warnings unrelated)
- `npm run i18n:validate`: 100% coverage in all 5 locales
- Touch targets confirmed via headless browser DOM query (theme
  toggle now 44×44)
- Login autocomplete attrs confirmed in rendered DOM
  (`autocomplete: "username"` and `"current-password"`)
- Print button + Log In link visual verification deferred — backend
  on :8090 wasn't running during this session, so :5173 served the
  welcome-page branch. Source pattern is identical to the verified
  ThemeToggle fix.

### Not in this PR (intentionally deferred)

- Hardcoded `aria-label` strings across 14+ admin pages (large scope
  — separate PR or lint rule)
- YouTube/Vimeo iframe caption placeholders
- Print menu role=menu arrow-key navigation (would be a separate
  pattern fix)
- DropZone `aria-live` announcement on file drop
- Issues #404, #405, #406 (already filed, in flight)

### Test plan

- [ ] Visit a profile with attached images (project, post, or talk).
      Open the gallery lightbox. Confirm:
  - [ ] Focus moves to the close button on open
  - [ ] Tab + Shift+Tab cycle within the dialog (don't escape to page)
  - [ ] Escape closes the lightbox
  - [ ] Focus returns to the thumbnail that opened it
  - [ ] Screen reader announces "Image viewer dialog"
- [ ] Visit `/admin/login`. Confirm browser/password manager offers
      to fill the email + password fields.
- [ ] Switch locale to de/elvish/klingon/lolcat and visit `/posts`.
      Confirm h1, back link, filter labels, RSS button, and empty
      state are translated.
- [ ] On the homepage, confirm print/theme/login header buttons hit
      a minimum 44×44px touch target on mobile.