### PR TITLE
fix(editor): preserve paragraph spacing on markdown round-trip (#443)

### DIFF
--- a/frontend/src/components/admin/MarkdownEditor.svelte
+++ b/frontend/src/components/admin/MarkdownEditor.svelte
@@ -117,7 +117,11 @@
 		const initialContent = markdownText || value || '';
 		if (initialContent) {
 			isUpdatingFromProp = true;
-			editor.commands.setContent(initialContent, false, { preserveWhitespace: 'full' });
+			// TipTap v3: pass content as a string with `contentType: 'markdown'` so the
+			// Markdown extension parses it (preserving blank-line/paragraph spacing).
+			// The old v2 3-arg form `(content, false, { preserveWhitespace })` silently
+			// fell back to HTML parsing, collapsing spacing on edit-load (#443).
+			editor.commands.setContent(initialContent, { contentType: 'markdown', emitUpdate: false });
 			isUpdatingFromProp = false;
 		}
 	}
@@ -135,7 +139,7 @@
 		// Normalize both values to avoid false positives from whitespace differences
 		if (currentValue?.trim() !== editorMd?.trim()) {
 			isUpdatingFromProp = true;
-			editor.commands.setContent(currentValue || '', false, { preserveWhitespace: 'full' });
+			editor.commands.setContent(currentValue || '', { contentType: 'markdown', emitUpdate: false });
 			markdownText = currentValue || '';
 			isUpdatingFromProp = false;
 		}


### PR DESCRIPTION
Fixes #443

## Symptom
Create a post (or project description, etc.) with blank-line spacing between paragraphs. Save and view: fine. Re-open in the editor: paragraphs are bunched together. Re-save: the spacing is permanently lost. Markdown syntax (`#`, `**`) survives; only spacing dies. Reported across posts **and** project descriptions.

## Root cause
`MarkdownEditor.svelte` called TipTap's **v2** `setContent` signature against the installed **TipTap v3.21**:

```js
editor.commands.setContent(content, false, { preserveWhitespace: 'full' }); // v2 3-arg form
```

In v3 the signature is `setContent(content, optionsObject)`, and markdown parsing requires `options.contentType: 'markdown'`. So the second positional arg (`false`) was read as the options object:

1. `@tiptap/markdown`'s `setContent` override sees `!false?.contentType` → `true` → **skips `markdown.parse()`** and delegates to core.
2. Core destructures `false` → `parseOptions = {}` → `preserveWhitespace !== 'full'` → `createDocument(markdownString)` parses the **markdown string as HTML**.
3. ProseMirror's HTML parse collapses `\n\n` whitespace; markdown syntax chars survive as literal text → bunched into one block.
4. `getMarkdown()` on the bunched doc is what gets re-saved → spacing gone for good.

Not a TipTap-upgrade regression: the editor and these v2-style calls were introduced together in #419 (the "big update") with `@tiptap/core ^3.21.0` — written against v3 using the old v2 call shape. Broken since the editor shipped.

## Fix
Pass the v3 signature with `contentType: 'markdown'` at both call sites (initial content + the external-value `$effect` sync) so content round-trips through the Markdown extension's parser. `emitUpdate: false` preserves the prior no-emit behavior; the `isUpdatingFromProp` guard is unchanged. Two lines, shared component → fixes all 9 admin editor surfaces at once.

## Verification
Ran the real TipTap stack (`@tiptap/core` + `starter-kit` + `markdown` @3.21) through both call paths:

| | distinct paragraph blocks |
|---|---|
| Original markdown | 4 |
| OLD `setContent(md, false, {preserveWhitespace})` | **1** (collapsed — bug reproduced) |
| NEW `setContent(md, {contentType:'markdown', emitUpdate:false})` | **4** (preserved) |

`svelte-check`: 0 errors, 0 warnings. Accessibility-lead gate: PASS (logic-only, no markup/ARIA/CSS change).

### Notes
- The fix preserves paragraph breaks; it still normalizes 3+ consecutive blank lines to a single break (standard ProseMirror/markdown behavior — rendered output is identical).
- Content already re-saved through the broken editor is already flattened and not auto-recoverable; this prevents further loss.
- No automated regression test added: the frontend has no component-test runner (no vitest), and the e2e suite is API/public-page only with no authed admin-editor-UI pattern. Happy to add a vitest + happy-dom round-trip guard as a follow-up if wanted.