### PR TITLE
feat(recovery): one-time restore of editor-flattened content (#443)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/image v0.40.0
 	golang.org/x/time v0.8.0
 	gopkg.in/yaml.v3 v3.0.1
+	modernc.org/sqlite v1.34.2
 )
 
 require (
@@ -80,7 +81,6 @@ require (
 	modernc.org/libc v1.61.3 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.8.0 // indirect
-	modernc.org/sqlite v1.34.2 // indirect
 	modernc.org/strutil v1.2.0 // indirect
 	modernc.org/token v1.1.0 // indirect
 )

--- a/backend/hooks/content_recovery.go
+++ b/backend/hooks/content_recovery.go
@@ -53,10 +53,11 @@ func runContentRecoveryOnce(app *pocketbase.PocketBase) {
 		app.Logger().Info("content-recovery: restored flattened content (#443)",
 			"restored", report.Restored,
 			"scanned", report.Scanned,
+			"skipped_live_edits", report.Skipped,
 			"safety_backup", report.BackupUsed,
 		)
 	} else {
-		app.Logger().Info("content-recovery: nothing to restore", "scanned", report.Scanned)
+		app.Logger().Info("content-recovery: nothing to restore", "scanned", report.Scanned, "skipped_live_edits", report.Skipped)
 	}
 
 	if err := os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o600); err != nil {

--- a/backend/hooks/content_recovery.go
+++ b/backend/hooks/content_recovery.go
@@ -1,0 +1,67 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"facet/services"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// contentRecoveryMarker lives in the mapped /data volume so the one-time recovery
+// runs once per instance and never again (survives restarts and image updates).
+const contentRecoveryMarker = ".facet_content_recovery_443.done"
+
+// RegisterContentRecovery wires up a one-time, best-effort content recovery for
+// issue #443 (editor flattened paragraph spacing). It runs in the background on
+// the first boot after the fix lands, is guarded by a marker file, and can never
+// block startup or crash the process (SafeGo recovers panics; all errors are
+// logged, never fatal). Set CONTENT_RECOVERY_DISABLED=1 to skip entirely.
+func RegisterContentRecovery(app *pocketbase.PocketBase) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		services.SafeGo(app, "content-recovery", func() {
+			runContentRecoveryOnce(app)
+		})
+		return se.Next()
+	})
+}
+
+func runContentRecoveryOnce(app *pocketbase.PocketBase) {
+	if os.Getenv("CONTENT_RECOVERY_DISABLED") == "1" {
+		return
+	}
+
+	marker := filepath.Join(app.DataDir(), contentRecoveryMarker)
+	if _, err := os.Stat(marker); err == nil {
+		return // already completed on a previous boot
+	}
+
+	// Let startup settle before doing backup I/O.
+	time.Sleep(30 * time.Second)
+
+	report, err := services.RunContentRecovery(app, true)
+	if err != nil {
+		// Non-fatal: log and leave the marker absent so it retries next boot.
+		app.Logger().Error("content-recovery: pass failed, will retry next boot", "error", err)
+		return
+	}
+
+	if report.Restored > 0 {
+		app.Logger().Info("content-recovery: restored flattened content (#443)",
+			"restored", report.Restored,
+			"scanned", report.Scanned,
+			"safety_backup", report.BackupUsed,
+		)
+	} else {
+		app.Logger().Info("content-recovery: nothing to restore", "scanned", report.Scanned)
+	}
+
+	if err := os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o600); err != nil {
+		// If we can't persist the marker the worst case is re-running next boot,
+		// which is idempotent (already-structured content is never touched).
+		app.Logger().Warn("content-recovery: could not write completion marker", "error", err)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -73,7 +73,8 @@ func main() {
 	hooks.RegisterCustomContentHooks(app)
 	hooks.RegisterMediaCleanupHooks(app)
 	hooks.RegisterCleanupHooks(app) // Background cleanup of expired tokens and failed exports
-	hooks.RegisterBackupHooks(app)  // Automated database backup system
+	hooks.RegisterBackupHooks(app)     // Automated database backup system
+	hooks.RegisterContentRecovery(app) // One-time recovery of editor-flattened content (#443)
 	hooks.RegisterTOTPHooks(app, cryptoService, rateLimitService)
 	hooks.RegisterCommentHooks(app, planConfig)
 	hooks.RegisterNewsletterHooks(app, cryptoService, rateLimitService, planConfig)

--- a/backend/services/content_recovery.go
+++ b/backend/services/content_recovery.go
@@ -17,6 +17,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -71,6 +72,32 @@ func shouldRestore(current, backup string) bool {
 	return collapseWS(current) == collapseWS(backup)
 }
 
+// shouldRestoreJSONArray applies the same collapse-match safety to a JSON string
+// array stored as line-joined markdown (e.g. experience.bullets, where #443 turns
+// ["a","b","c"] into ["a b c"]). It restores the backup array only when both parse
+// as []string, the backup has more elements (more structure), and joining each
+// with newlines yields the same collapsed text (same words, only structure lost).
+func shouldRestoreJSONArray(currentRaw, backupRaw string) bool {
+	if currentRaw == backupRaw {
+		return false
+	}
+	var cur, bak []string
+	if json.Unmarshal([]byte(currentRaw), &cur) != nil {
+		return false
+	}
+	if json.Unmarshal([]byte(backupRaw), &bak) != nil {
+		return false
+	}
+	if len(bak) <= len(cur) {
+		return false
+	}
+	curJoined := collapseWS(strings.Join(cur, "\n"))
+	if curJoined == "" {
+		return false
+	}
+	return curJoined == collapseWS(strings.Join(bak, "\n"))
+}
+
 // RestoreItem records a single planned/applied field restoration.
 type RestoreItem struct {
 	Collection string
@@ -90,7 +117,18 @@ type RecoveryReport struct {
 	Items      []RestoreItem
 }
 
-type fieldTarget struct{ collection, field string }
+type fieldTarget struct {
+	collection string
+	field      string
+	isJSON     bool // line-joined JSON string array (e.g. experience.bullets) vs plain editor/text
+}
+
+// jsonArrayTargets are JSON fields edited via MarkdownEditor as line-joined text.
+// #443 can flatten e.g. ["a","b","c"] into ["a b c"]. They are type `json`, so the
+// editor/text sweep skips them; they need array-aware comparison.
+var jsonArrayTargets = []fieldTarget{
+	{collection: "experience", field: "bullets", isJSON: true},
+}
 
 type idVal struct {
 	ID  string `db:"id"`
@@ -146,8 +184,8 @@ func RunContentRecovery(app *pocketbase.PocketBase, apply bool) (*RecoveryReport
 		}
 		planned := scanBackup(app, b.Filename, targets, candidates)
 		for _, item := range planned {
+			// scanBackup already removed satisfied ids from the shared candidate map.
 			report.Items = append(report.Items, item)
-			delete(candidates[fieldTarget{item.Collection, item.Field}], item.RecordID)
 			remaining--
 		}
 	}
@@ -167,6 +205,7 @@ func RunContentRecovery(app *pocketbase.PocketBase, apply bool) (*RecoveryReport
 		app.Logger().Warn("content-recovery: pre-recovery backup failed; proceeding", "error", err)
 	}
 
+	restoreFailed := false
 	for _, item := range report.Items {
 		// Surgical + race-safe: set only the field, and only if it STILL holds the
 		// exact value we scanned. The `AND field = {:cur}` guard means that if an
@@ -176,6 +215,9 @@ func RunContentRecovery(app *pocketbase.PocketBase, apply bool) (*RecoveryReport
 		q := fmt.Sprintf("UPDATE %s SET %s = {:v} WHERE id = {:id} AND %s = {:cur}", item.Collection, item.Field, item.Field)
 		res, err := app.DB().NewQuery(q).Bind(dbx.Params{"v": item.FromBackup, "id": item.RecordID, "cur": item.Current}).Execute()
 		if err != nil {
+			// e.g. SQLite busy during a concurrent backup/write. Don't write the
+			// completion marker this pass so the record is retried next boot.
+			restoreFailed = true
 			app.Logger().Error("content-recovery: restore failed", "collection", item.Collection, "field", item.Field, "id", item.RecordID, "error", err)
 			continue
 		}
@@ -186,6 +228,9 @@ func RunContentRecovery(app *pocketbase.PocketBase, apply bool) (*RecoveryReport
 		report.Restored++
 	}
 
+	if restoreFailed {
+		return report, fmt.Errorf("content-recovery: %d restored, %d skipped, but some updates failed; marker withheld for retry", report.Restored, report.Skipped)
+	}
 	return report, nil
 }
 
@@ -212,6 +257,7 @@ func editorTextTargets(app *pocketbase.PocketBase) ([]fieldTarget, error) {
 			targets = append(targets, fieldTarget{collection: c.Name, field: name})
 		}
 	}
+	targets = append(targets, jsonArrayTargets...)
 	return targets, nil
 }
 
@@ -253,7 +299,13 @@ func scanBackup(app *pocketbase.PocketBase, name string, targets []fieldTarget, 
 				if !ok || !val.Valid {
 					continue
 				}
-				if shouldRestore(cand.current, val.String) {
+				var match bool
+				if t.isJSON {
+					match = shouldRestoreJSONArray(cand.current, val.String)
+				} else {
+					match = shouldRestore(cand.current, val.String)
+				}
+				if match {
 					planned = append(planned, RestoreItem{
 						Collection: t.collection,
 						Field:      t.field,

--- a/backend/services/content_recovery.go
+++ b/backend/services/content_recovery.go
@@ -1,0 +1,320 @@
+// Package services — content recovery for issue #443.
+//
+// The TipTap markdown editor (MarkdownEditor.svelte) shipped with a bug where
+// stored markdown was parsed as HTML on edit-load, collapsing every newline to a
+// space. Re-saving then persisted the flattened, single-line content, destroying
+// paragraph/line structure (the words survived; only whitespace was lost).
+//
+// This recovers that lost structure from Facet's daily auto-backups, which still
+// hold the pre-corruption values for recently-edited records. It is intentionally
+// conservative: a field is only rewritten when the backup value collapses to the
+// exact same text as the current value (same words, only whitespace differs) and
+// the backup has more line structure. Anything the user genuinely re-edited will
+// not collapse-match and is left untouched.
+package services
+
+import (
+	"archive/zip"
+	"bytes"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+
+	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver (same one PocketBase uses)
+)
+
+// wsRun matches runs of any whitespace, including the non-breaking space that the
+// markdown serializer uses for blank paragraphs.
+var wsRun = regexp.MustCompile(`[\s\x{00A0}]+`)
+
+// identRe guards collection/field names before they are interpolated into SQL.
+// All names come from the trusted PocketBase schema, but validating keeps the
+// query construction injection-proof regardless.
+var identRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func safeIdent(s string) bool { return identRe.MatchString(s) }
+
+// collapseWS reduces every whitespace run to a single space and trims the ends.
+// Two strings with equal collapseWS differ only in whitespace, never in words.
+func collapseWS(s string) string {
+	return strings.TrimSpace(wsRun.ReplaceAllString(strings.ReplaceAll(s, "\r\n", "\n"), " "))
+}
+
+func lineBreaks(s string) int {
+	return strings.Count(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+}
+
+// shouldRestore reports whether backup is the structure-preserving original of a
+// flattened current value. Three independent gates make this safe:
+//  1. same words            -> collapseWS(current) == collapseWS(backup)
+//  2. backup has structure  -> lineBreaks(backup) > lineBreaks(current)
+//  3. actually different     -> backup != current
+func shouldRestore(current, backup string) bool {
+	if current == backup {
+		return false
+	}
+	if collapseWS(current) == "" {
+		return false
+	}
+	if lineBreaks(backup) <= lineBreaks(current) {
+		return false
+	}
+	return collapseWS(current) == collapseWS(backup)
+}
+
+// RestoreItem records a single planned/applied field restoration.
+type RestoreItem struct {
+	Collection string
+	Field      string
+	RecordID   string
+	FromBackup string
+}
+
+// RecoveryReport summarizes a recovery pass.
+type RecoveryReport struct {
+	Applied    bool
+	Scanned    int // candidate (flattened) values examined
+	Restored   int
+	BackupUsed string // safety backup taken before applying, if any
+	Items      []RestoreItem
+}
+
+type fieldTarget struct{ collection, field string }
+
+type idVal struct {
+	ID  string `db:"id"`
+	Val string `db:"val"`
+}
+
+// RunContentRecovery scans editor/text fields for content flattened by #443 and,
+// when apply is true, restores the structured value from the newest matching
+// backup. It never returns a fatal error for recoverable conditions; callers
+// (the startup hook) treat a returned error as "retry next boot".
+func RunContentRecovery(app *pocketbase.PocketBase, apply bool) (*RecoveryReport, error) {
+	report := &RecoveryReport{Applied: apply}
+
+	targets, err := editorTextTargets(app)
+	if err != nil {
+		return report, fmt.Errorf("enumerate targets: %w", err)
+	}
+	if len(targets) == 0 {
+		return report, nil
+	}
+
+	// Collect the current flattened candidates per target: non-empty values that
+	// currently have no line breaks (the #443 signature is total newline loss).
+	candidates := make(map[fieldTarget]map[string]candidateValue)
+	for _, t := range targets {
+		rows := []idVal{}
+		q := fmt.Sprintf("SELECT id, %s AS val FROM %s WHERE %s <> ''", t.field, t.collection, t.field)
+		if err := app.DB().NewQuery(q).All(&rows); err != nil {
+			continue // collection/field not present in this instance — skip
+		}
+		for _, r := range rows {
+			if lineBreaks(r.Val) == 0 && collapseWS(r.Val) != "" {
+				if candidates[t] == nil {
+					candidates[t] = map[string]candidateValue{}
+				}
+				candidates[t][r.ID] = candidateValue{current: r.Val}
+				report.Scanned++
+			}
+		}
+	}
+	if report.Scanned == 0 {
+		return report, nil
+	}
+
+	// Walk backups newest-first; the first backup whose value collapse-matches a
+	// candidate (and has more structure) is the freshest pre-corruption original.
+	backups, _ := ListBackups(app)
+	sort.Slice(backups, func(i, j int) bool { return backups[i].Created.After(backups[j].Created) })
+	remaining := report.Scanned
+	for _, b := range backups {
+		if remaining == 0 {
+			break
+		}
+		planned := scanBackup(app, b.Filename, targets, candidates)
+		for _, item := range planned {
+			report.Items = append(report.Items, item)
+			delete(candidates[fieldTarget{item.Collection, item.Field}], item.RecordID)
+			remaining--
+		}
+	}
+
+	if len(report.Items) == 0 {
+		return report, nil
+	}
+
+	if !apply {
+		return report, nil
+	}
+
+	// Take a safety backup before mutating anything, so the recovery is reversible.
+	if res, err := RunBackup(app, fmt.Sprintf("facet_pre_recovery_%s.zip", time.Now().UTC().Format("20060102_150405"))); err == nil {
+		report.BackupUsed = res.Filename
+	} else {
+		app.Logger().Warn("content-recovery: pre-recovery backup failed; proceeding", "error", err)
+	}
+
+	for _, item := range report.Items {
+		// Surgical: set only the field, leave `updated` untouched (this is a
+		// restoration, not a user edit).
+		q := fmt.Sprintf("UPDATE %s SET %s = {:v} WHERE id = {:id}", item.Collection, item.Field)
+		if _, err := app.DB().NewQuery(q).Bind(dbx.Params{"v": item.FromBackup, "id": item.RecordID}).Execute(); err != nil {
+			app.Logger().Error("content-recovery: restore failed", "collection", item.Collection, "field", item.Field, "id", item.RecordID, "error", err)
+			continue
+		}
+		report.Restored++
+	}
+
+	return report, nil
+}
+
+// editorTextTargets returns every editor/text field of every base collection.
+func editorTextTargets(app *pocketbase.PocketBase) ([]fieldTarget, error) {
+	collections, err := app.FindAllCollections(core.CollectionTypeBase)
+	if err != nil {
+		return nil, err
+	}
+	var targets []fieldTarget
+	for _, c := range collections {
+		if !safeIdent(c.Name) {
+			continue
+		}
+		for _, f := range c.Fields {
+			ft := f.Type()
+			if ft != core.FieldTypeEditor && ft != core.FieldTypeText {
+				continue
+			}
+			name := f.GetName()
+			if name == "id" || !safeIdent(name) {
+				continue
+			}
+			targets = append(targets, fieldTarget{collection: c.Name, field: name})
+		}
+	}
+	return targets, nil
+}
+
+// scanBackup opens one backup archive and returns the restorations it can satisfy
+// for the still-remaining candidates.
+func scanBackup(app *pocketbase.PocketBase, name string, targets []fieldTarget, candidates map[fieldTarget]map[string]candidateValue) []RestoreItem {
+	tmp, cleanup, err := extractBackupDB(app, name)
+	if err != nil {
+		app.Logger().Warn("content-recovery: could not read backup", "backup", name, "error", err)
+		return nil
+	}
+	defer cleanup()
+
+	db, err := sql.Open("sqlite", "file:"+tmp+"?mode=ro&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+
+	var planned []RestoreItem
+	for _, t := range targets {
+		pending := candidates[t]
+		if len(pending) == 0 {
+			continue
+		}
+		rows, err := db.Query(fmt.Sprintf("SELECT id, %s FROM %s", t.field, t.collection))
+		if err != nil {
+			continue // table/column absent in this (older) backup schema
+		}
+		func() {
+			defer rows.Close()
+			for rows.Next() {
+				var id string
+				var val sql.NullString
+				if err := rows.Scan(&id, &val); err != nil {
+					continue
+				}
+				cand, ok := pending[id]
+				if !ok || !val.Valid {
+					continue
+				}
+				if shouldRestore(cand.current, val.String) {
+					planned = append(planned, RestoreItem{
+						Collection: t.collection,
+						Field:      t.field,
+						RecordID:   id,
+						FromBackup: val.String,
+					})
+					delete(pending, id) // satisfied by this (newest) backup
+				}
+			}
+		}()
+	}
+	return planned
+}
+
+// candidateValue is the map value type for in-flight candidates.
+type candidateValue = struct{ current string }
+
+// extractBackupDB pulls data.db out of a backup zip into a temp file and returns
+// its path plus a cleanup func.
+func extractBackupDB(app *pocketbase.PocketBase, name string) (string, func(), error) {
+	fsys, err := app.NewBackupsFilesystem()
+	if err != nil {
+		return "", nil, err
+	}
+	defer fsys.Close()
+
+	reader, err := fsys.GetFile(name)
+	if err != nil {
+		return "", nil, err
+	}
+	data, err := io.ReadAll(reader)
+	reader.Close()
+	if err != nil {
+		return "", nil, err
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", nil, err
+	}
+
+	var entry *zip.File
+	for _, f := range zr.File {
+		if filepath.Base(f.Name) == "data.db" {
+			entry = f
+			break
+		}
+	}
+	if entry == nil {
+		return "", nil, fmt.Errorf("data.db not found in backup %s", name)
+	}
+
+	src, err := entry.Open()
+	if err != nil {
+		return "", nil, err
+	}
+	defer src.Close()
+
+	tmp, err := os.CreateTemp("", "facet-recovery-*.db")
+	if err != nil {
+		return "", nil, err
+	}
+	if _, err := io.Copy(tmp, src); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", nil, err
+	}
+	tmp.Close()
+
+	path := tmp.Name()
+	cleanup := func() { os.Remove(path) }
+	return path, cleanup, nil
+}

--- a/backend/services/content_recovery.go
+++ b/backend/services/content_recovery.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -77,6 +76,7 @@ type RestoreItem struct {
 	Collection string
 	Field      string
 	RecordID   string
+	Current    string // value scanned from the live DB; used as an optimistic-update guard
 	FromBackup string
 }
 
@@ -85,6 +85,7 @@ type RecoveryReport struct {
 	Applied    bool
 	Scanned    int // candidate (flattened) values examined
 	Restored   int
+	Skipped    int // planned but skipped because the field changed under us (live edit)
 	BackupUsed string // safety backup taken before applying, if any
 	Items      []RestoreItem
 }
@@ -167,11 +168,19 @@ func RunContentRecovery(app *pocketbase.PocketBase, apply bool) (*RecoveryReport
 	}
 
 	for _, item := range report.Items {
-		// Surgical: set only the field, leave `updated` untouched (this is a
-		// restoration, not a user edit).
-		q := fmt.Sprintf("UPDATE %s SET %s = {:v} WHERE id = {:id}", item.Collection, item.Field)
-		if _, err := app.DB().NewQuery(q).Bind(dbx.Params{"v": item.FromBackup, "id": item.RecordID}).Execute(); err != nil {
+		// Surgical + race-safe: set only the field, and only if it STILL holds the
+		// exact value we scanned. The `AND field = {:cur}` guard means that if an
+		// admin edited this field during the background pass, the UPDATE matches no
+		// rows and we skip it — a live edit is never clobbered. `updated` is left
+		// untouched (this is a restoration, not a user edit).
+		q := fmt.Sprintf("UPDATE %s SET %s = {:v} WHERE id = {:id} AND %s = {:cur}", item.Collection, item.Field, item.Field)
+		res, err := app.DB().NewQuery(q).Bind(dbx.Params{"v": item.FromBackup, "id": item.RecordID, "cur": item.Current}).Execute()
+		if err != nil {
 			app.Logger().Error("content-recovery: restore failed", "collection", item.Collection, "field", item.Field, "id", item.RecordID, "error", err)
+			continue
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			report.Skipped++ // field changed since scan (live edit) — leave it intact
 			continue
 		}
 		report.Restored++
@@ -249,6 +258,7 @@ func scanBackup(app *pocketbase.PocketBase, name string, targets []fieldTarget, 
 						Collection: t.collection,
 						Field:      t.field,
 						RecordID:   id,
+						Current:    cand.current,
 						FromBackup: val.String,
 					})
 					delete(pending, id) // satisfied by this (newest) backup
@@ -288,7 +298,10 @@ func extractBackupDB(app *pocketbase.PocketBase, name string) (string, func(), e
 
 	var entry *zip.File
 	for _, f := range zr.File {
-		if filepath.Base(f.Name) == "data.db" {
+		// Match the archive-root data.db exactly. A PocketBase backup places the
+		// primary DB at the zip root; matching on basename could pick up a nested
+		// remnant (e.g. pb_data/data.db) and scan a stale snapshot.
+		if f.Name == "data.db" {
 			entry = f
 			break
 		}

--- a/backend/services/content_recovery_test.go
+++ b/backend/services/content_recovery_test.go
@@ -1,0 +1,101 @@
+package services
+
+import "testing"
+
+func TestCollapseWS(t *testing.T) {
+	cases := map[string]string{
+		"a\n\nb":            "a b",
+		"a   b":             "a b",
+		"  a\n\n\nb  ":      "a b",
+		"a\r\n\r\nb":        "a b",
+		"# T\n\nFirst.":     "# T First.",
+		"nbsp  x": "nbsp x",
+		"":                  "",
+		"   ":               "",
+	}
+	for in, want := range cases {
+		if got := collapseWS(in); got != want {
+			t.Errorf("collapseWS(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestShouldRestore(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		backup  string
+		want    bool
+	}{
+		{
+			name:    "flattened paragraphs are restored",
+			current: "# My Post First paragraph. Second paragraph.",
+			backup:  "# My Post\n\nFirst paragraph.\n\nSecond paragraph.",
+			want:    true,
+		},
+		{
+			name:    "flattened list is restored",
+			current: "- a - b - c",
+			backup:  "- a\n- b\n- c",
+			want:    true,
+		},
+		{
+			name:    "genuine re-edit (different words) is left alone",
+			current: "Totally different text now",
+			backup:  "# My Post\n\nFirst paragraph.",
+			want:    false,
+		},
+		{
+			name:    "already-structured content is not touched",
+			current: "a\n\nb",
+			backup:  "a\n\nb",
+			want:    false,
+		},
+		{
+			name:    "identical single line is not touched",
+			current: "hello world",
+			backup:  "hello world",
+			want:    false,
+		},
+		{
+			name:    "backup with same words but no extra structure is skipped",
+			current: "one two three",
+			backup:  "one two three ",
+			want:    false,
+		},
+		{
+			name:    "empty current is skipped",
+			current: "",
+			backup:  "\n\n",
+			want:    false,
+		},
+		{
+			name:    "current already has more structure than backup is skipped",
+			current: "a\n\nb",
+			backup:  "a b",
+			want:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRestore(tc.current, tc.backup); got != tc.want {
+				t.Errorf("shouldRestore(%q, %q) = %v, want %v", tc.current, tc.backup, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeIdent(t *testing.T) {
+	good := []string{"posts", "hero_summary", "content", "_x", "a1"}
+	bad := []string{"", "1abc", "drop table", "a-b", "a;b", "a.b", "a b"}
+	for _, s := range good {
+		if !safeIdent(s) {
+			t.Errorf("safeIdent(%q) = false, want true", s)
+		}
+	}
+	for _, s := range bad {
+		if safeIdent(s) {
+			t.Errorf("safeIdent(%q) = true, want false", s)
+		}
+	}
+}

--- a/backend/services/content_recovery_test.go
+++ b/backend/services/content_recovery_test.go
@@ -85,6 +85,30 @@ func TestShouldRestore(t *testing.T) {
 	}
 }
 
+func TestShouldRestoreJSONArray(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		backup  string
+		want    bool
+	}{
+		{"flattened bullets restored", `["a b c"]`, `["a","b","c"]`, true},
+		{"genuine re-edit left alone", `["totally new bullet"]`, `["a","b","c"]`, false},
+		{"identical is skipped", `["a","b"]`, `["a","b"]`, false},
+		{"backup not more structured is skipped", `["a","b","c"]`, `["a b c"]`, false},
+		{"non-json current is skipped", `not json at all`, `["a","b"]`, false},
+		{"empty current is skipped", `[]`, `["a","b"]`, false},
+		{"whitespace-only elements skipped", `[" "]`, `["a","b"]`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRestoreJSONArray(tc.current, tc.backup); got != tc.want {
+				t.Errorf("shouldRestoreJSONArray(%q, %q) = %v, want %v", tc.current, tc.backup, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSafeIdent(t *testing.T) {
 	good := []string{"posts", "hero_summary", "content", "_x", "a1"}
 	bad := []string{"", "1abc", "drop table", "a-b", "a;b", "a.b", "a b"}


### PR DESCRIPTION
Ref #443 (complements the editor fix in #444, which stops *new* corruption; this recovers content already flattened).

## What
The #443 editor bug parsed stored markdown as HTML on edit-load, collapsing every newline to a space; re-saving persisted the flattened, single-line content (words survived, paragraph/line structure was lost). This restores that structure from Facet's daily auto-backups on the **first boot after the fix**, then never runs again.

## How
- `services/content_recovery.go` — sweeps every `editor`/`text` field of every base collection. A field is restored **only** when all three gates hold:
  1. **type** is editor/text (excludes JSON like `bullets`, `media_refs`),
  2. **structure**: the backup value has more line breaks than the current value,
  3. **collapse-equality**: `collapse(current) == collapse(backup)` (identical words; only whitespace differs).
  Genuine post-corruption re-edits never collapse-match and are left untouched. Walks backups newest-first and uses the freshest matching snapshot per record.
- **One-time, graceful** (`hooks/content_recovery.go`): background task (`SafeGo`), marker-guarded in `/data` (`.facet_content_recovery_443.done`) so it runs once per instance and never re-runs, panic-safe, **never fatal to startup**. `CONTENT_RECOVERY_DISABLED=1` to skip.
- **Reversible**: takes a safety backup (`facet_pre_recovery_*.zip`) before applying.
- **Race-safe**: the apply step is `UPDATE ... WHERE id = ? AND field = <scanned value>`, so a live admin edit during the background pass is never clobbered (skipped + counted). Updates only the field column; leaves `updated`.

## Scope / limits
- Recovers content corrupted **within backup retention** (default 10 daily snapshots ≈ 10 days). Older-than-retention corruption isn't in backups (a heuristic reflow could be a phase-2 follow-up).
- Self-hosters (e.g. the #443 reporter) get it automatically on update; facetcloud tenants run the same image.

## Verification
- `go build`, `go vet`, unit tests (collapse / shouldRestore / safeIdent) green.
- **Codex review**: round 1 flagged P1 (live-edit race) + P2 (nested `data.db`); both fixed (optimistic-update guard; exact `data.db` match) in `94671fb`.