### PR TITLE
ci(auto-tag): serialize runs + resilient CHANGELOG push

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -26,6 +26,13 @@ on:
           - minor
           - major
 
+# Serialize tag runs so two PRs merged close together never push main
+# concurrently (which caused non-fast-forward rejections). Queue, never cancel:
+# each merged PR must still get its changelog entry + tag.
+concurrency:
+  group: auto-tag-main
+  cancel-in-progress: false
+
 jobs:
   tag:
     # Only run if PR was merged (not just closed)
@@ -420,7 +427,21 @@ jobs:
             echo "No changelog changes to commit"
           else
             git commit -m "docs: update CHANGELOG for $NEW_TAG"
-            git push origin main
+            # Resilient push: if another run pushed main between our checkout and
+            # now, rebase onto it and retry. concurrency:group serializes runs so
+            # this should rarely fire, but it guards against any stray push.
+            for attempt in 1 2 3; do
+              if git push origin main; then
+                echo "Pushed CHANGELOG on attempt $attempt"
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::Failed to push CHANGELOG after 3 attempts"
+                exit 1
+              fi
+              echo "Push rejected, rebasing onto latest main (attempt $attempt)..."
+              git pull --rebase origin main
+            done
             echo "## Changelog Updated" >> $GITHUB_STEP_SUMMARY
             if [ "$AI_SUCCESS" = true ]; then
               echo "Generated with AI assistance" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

Two PRs merged ~5s apart (#444, #445) both triggered **Auto Tag on Merge**. Both branched from `main@v2.21.18` and raced to `git push origin main` the CHANGELOG commit. The loser was rejected:

```
! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs
##[error]Process completed with exit code 1.
```

(Run [27047297263](https://github.com/jesposito/Facet/actions/runs/27047297263) — #444 `fix` → v2.21.19 lost to #445 `feat` → v2.22.0.)

**Outcome that time was harmless** — the winning run documented both PRs, so `main@v2.22.0` is correct and complete. But the red X recurs on every batched merge, and batched merges are routine here.

## Root cause

`auto-tag.yml` had no race protection on the CHANGELOG push:
- No `concurrency` group → two `pull_request: closed` events run simultaneously.
- The CHANGELOG `git push origin main` had no pull/rebase/retry (the tag step has a half-measure `git pull`, but the CHANGELOG push had nothing).

## Fix

1. **Top-level `concurrency` group** (`auto-tag-main`, `cancel-in-progress: false`) — merge-triggered runs queue instead of pushing `main` concurrently. `false` because every merged PR must still get its changelog entry + tag; we serialize, never drop.
2. **Resilient CHANGELOG push** — `git push` with `pull --rebase` + 3x retry, mirroring the tag step. Defense-in-depth against any stray concurrent push; with the concurrency group it should rarely fire.

No behavior change for single (non-batched) merges.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML OK.
- `concurrency` is top-level (sibling of `on:`/`jobs:`), retry loop nested correctly in the existing `else` branch.
- Logic-only CI change; exercised on the next merge to main.

## Known follow-up (out of scope)

The "document all undocumented PRs" + "always tag" design means serialized batched merges can still produce a trailing near-empty tag (e.g. v2.21.19 then v2.22.0). Pre-existing; not addressed here. Worth a guard to skip tagging when no new PRs were documented.