### PR TITLE
feat(design): Soft Premium font pack (B3)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -100,6 +100,12 @@
 		--e-out: cubic-bezier(0.16, 1, 0.3, 1);
 		/* Accent-independent focus ring (WCAG 2.4.13 / 1.4.11). */
 		--focus-ring: #b45309;
+
+		/* Soft Premium editorial accent face. --font-heading/--font-body come from
+		   the 'soft-premium' font pack injected inline by hooks.server.ts (inline
+		   wins over this attribute rule); --font-accent is not part of the pack, so
+		   it is safe to set here. Newsreader loads via the pack's font URL. */
+		--font-accent: 'Newsreader', Georgia, 'Times New Roman', serif;
 	}
 
 	/* Dark soft-premium: authored warm browns (consumed via semantic vars). */

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -19,6 +19,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 	let accentCSSVars = '';
 	let fontCSSVars = '';
 	let fontPack = '';
+	let operatorFontPack = '';
 	try {
 		const homepageRes = await fetch(`${pbUrl}/api/homepage`, {
 			headers: { 'X-Internal': 'true' }
@@ -29,8 +30,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 				homepage.profile?.accent_color,
 				homepage.profile?.custom_hex_color
 			);
-			fontCSSVars = generateFontCSSVars(homepage.profile?.font_pack);
-			fontPack = homepage.profile?.font_pack || '';
+			operatorFontPack = homepage.profile?.font_pack || '';
 		}
 	} catch { /* silent - fallback to client-side application */ }
 
@@ -47,6 +47,17 @@ export const handle: Handle = async ({ event, resolve }) => {
 			if (settings.design === 'soft-premium') design = 'soft-premium';
 		}
 	} catch { /* silent - fallback to classic */ }
+
+	// Soft Premium ships its own font pack (Hanken Grotesk + Newsreader) as the
+	// default, but an operator who explicitly picked a pack keeps it — the classic
+	// escape hatch. Emitted inline below, which (unlike a :root[data-design] rule)
+	// correctly overrides the static defaults.
+	const effectiveFontPack =
+		design === 'soft-premium' && (!operatorFontPack || operatorFontPack === DEFAULT_FONT_PACK)
+			? 'soft-premium'
+			: operatorFontPack;
+	fontCSSVars = generateFontCSSVars(effectiveFontPack);
+	fontPack = effectiveFontPack;
 
 	const response = await resolve(event, {
 		transformPageChunk: ({ html }) => {

--- a/frontend/src/lib/fonts.ts
+++ b/frontend/src/lib/fonts.ts
@@ -6,7 +6,7 @@
  * pre-built Google Fonts URLs for performance.
  */
 
-export type FontPack = 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric';
+export type FontPack = 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | 'soft-premium';
 
 export interface FontPackInfo {
   name: FontPack;
@@ -105,12 +105,25 @@ export const FONT_PACKS: Record<FontPack, FontPackInfo> = {
     code: 'DM Mono',
     codeFallback: 'monospace',
     googleFontsUrl: 'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=DM+Mono:wght@400;500&display=swap'
+  },
+  'soft-premium': {
+    name: 'soft-premium',
+    label: 'Soft Premium',
+    description: 'Warm geometric sans with a serif accent — the redesign pairing',
+    heading: 'Hanken Grotesk',
+    headingFallback: "'Plus Jakarta Sans', system-ui, sans-serif",
+    body: 'Hanken Grotesk',
+    bodyFallback: "'Plus Jakarta Sans', system-ui, sans-serif",
+    code: 'JetBrains Mono',
+    codeFallback: 'monospace',
+    // Includes Newsreader for the --font-accent editorial flourishes.
+    googleFontsUrl: 'https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&family=Newsreader:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap'
   }
 };
 
 export const DEFAULT_FONT_PACK: FontPack = 'editorial';
 
-export const FONT_PACK_LIST: FontPack[] = ['editorial', 'modern', 'classic', 'technical', 'editorial-bold', 'humanist', 'geometric'];
+export const FONT_PACK_LIST: FontPack[] = ['editorial', 'modern', 'classic', 'technical', 'editorial-bold', 'humanist', 'geometric', 'soft-premium'];
 
 export function getFontPack(name?: string | null): FontPackInfo {
   if (name && name in FONT_PACKS) {

--- a/frontend/tests/soft-premium-fonts.spec.ts
+++ b/frontend/tests/soft-premium-fonts.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// B3: soft-premium swaps the type to Hanken Grotesk; classic keeps Plus Jakarta.
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const LOGIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const LOGIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'changeme123';
+
+async function login(page: Page) {
+	await page.goto(`${BASE_URL}/admin/login`);
+	await page.waitForSelector('input[type="email"]', { timeout: 10_000 });
+	await page.fill('input[type="email"]', LOGIN_EMAIL);
+	await page.fill('input[type="password"]', LOGIN_PASSWORD);
+	await page.click('button[type="submit"]');
+	await page.waitForURL((url) => /\/admin(\/|$)/.test(url.pathname) && !url.pathname.includes('/login'), {
+		timeout: 15_000
+	});
+}
+async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
+	await page.goto(`${BASE_URL}/admin/settings/site`);
+	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
+	const radio = page.locator('[role="radio"]', { hasText: label }).first();
+	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		await radio.click();
+		await expect(radio).toHaveAttribute('aria-checked', 'true');
+	}
+}
+const bodyFont = (page: Page) =>
+	page.evaluate(() => getComputedStyle(document.body).fontFamily.toLowerCase());
+
+test.describe('Soft Premium fonts', () => {
+	test.beforeEach(async ({ page }) => login(page));
+	test.afterEach(async ({ page }) => setDesign(page, 'Classic'));
+
+	test('classic uses Plus Jakarta (no Hanken)', async ({ page }) => {
+		await setDesign(page, 'Classic');
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+		const font = await bodyFont(page);
+		expect(font).toContain('jakarta');
+		expect(font).not.toContain('hanken');
+	});
+
+	test('soft-premium leads with Hanken Grotesk', async ({ page }) => {
+		await setDesign(page, 'Soft Premium');
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+		const font = await bodyFont(page);
+		expect(font).toContain('hanken');
+		// Hanken is the primary (precedes the Jakarta fallback).
+		expect(font.indexOf('hanken')).toBeLessThan(font.indexOf('jakarta'));
+	});
+});


### PR DESCRIPTION
Stacked on #450. Adds a **`soft-premium` font pack** (Hanken Grotesk + Newsreader) and makes it the default when `design=soft-premium` — unless the operator explicitly picked a pack (classic escape hatch).

Fonts flow through the existing pack pipeline, which `hooks.server.ts` injects **inline** on `<html>` — required because an inline `--font-*` var wins over a `:root[data-design]` rule (same caveat as the accent vars). The pack's font URL is injected **only when active**, so classic instances load nothing extra (verified). `--font-accent` (Newsreader) is set via the attribute rule for B5's editorial flourishes.

### Certification
- svelte-check 0/0, build OK
- `tests/soft-premium-fonts.spec.ts`: classic=Plus Jakarta / soft-premium=Hanken Grotesk through the real product
- Verified the Hanken link loads only under soft-premium (zero classic cost).