### PR TITLE
feat(design): Soft Premium editorial utilities (B5)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -18,14 +18,24 @@
 	letter-spacing: -0.01em;
 }
 .text-gradient {
+	/* Light surface: dark accent stops (700/600) so clipped text clears 3:1
+	   large-text on white (the 400 stop was only ~2.1:1). */
 	background-image: linear-gradient(
 		135deg,
-		rgb(var(--color-primary-600-rgb)),
-		rgb(var(--color-primary-400-rgb))
+		rgb(var(--color-primary-700-rgb)),
+		rgb(var(--color-primary-600-rgb))
 	);
 	-webkit-background-clip: text;
 	background-clip: text;
 	color: transparent;
+}
+/* Dark surface: flip to light accent stops so the text stays legible on dark. */
+.dark .text-gradient {
+	background-image: linear-gradient(
+		135deg,
+		rgb(var(--color-primary-400-rgb)),
+		rgb(var(--color-primary-300-rgb))
+	);
 }
 .divider-editorial {
 	height: 1px;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -2,6 +2,53 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ==========================================================================
+   Soft Premium editorial utilities (UNLAYERED on purpose).
+   These are authored semantic classes consumed by the redesigned public
+   surfaces. They live outside @layer utilities so Tailwind's content-based
+   purge never strips them before a Track C component references them.
+   Degrade gracefully in classic: .font-accent falls back to the heading font
+   (--font-accent is only defined under soft-premium), .text-gradient/.divider
+   use the accent ramp (present in both modes), and .grain only paints under
+   [data-design="soft-premium"] so classic is never touched.
+   ========================================================================== */
+.font-accent {
+	font-family: var(--font-accent, var(--font-heading));
+	font-style: italic;
+	letter-spacing: -0.01em;
+}
+.text-gradient {
+	background-image: linear-gradient(
+		135deg,
+		rgb(var(--color-primary-600-rgb)),
+		rgb(var(--color-primary-400-rgb))
+	);
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+}
+.divider-editorial {
+	height: 1px;
+	border: 0;
+	background-image: linear-gradient(
+		90deg,
+		transparent,
+		rgb(var(--color-primary-500-rgb) / 0.35),
+		transparent
+	);
+}
+:root[data-design='soft-premium'] .grain {
+	position: relative;
+}
+:root[data-design='soft-premium'] .grain::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	opacity: 0.025;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
 @layer base {
 	/* ==========================================================================
 	   Accent Color CSS Custom Properties

--- a/frontend/tests/soft-premium-utils.spec.ts
+++ b/frontend/tests/soft-premium-utils.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// B5: editorial utilities. .font-accent uses Newsreader under soft-premium and
+// falls back to the heading font in classic; .grain only paints under soft-premium.
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const LOGIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const LOGIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'changeme123';
+
+async function login(page: Page) {
+	await page.goto(`${BASE_URL}/admin/login`);
+	await page.waitForSelector('input[type="email"]', { timeout: 10_000 });
+	await page.fill('input[type="email"]', LOGIN_EMAIL);
+	await page.fill('input[type="password"]', LOGIN_PASSWORD);
+	await page.click('button[type="submit"]');
+	await page.waitForURL((url) => /\/admin(\/|$)/.test(url.pathname) && !url.pathname.includes('/login'), {
+		timeout: 15_000
+	});
+}
+async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
+	await page.goto(`${BASE_URL}/admin/settings/site`);
+	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
+	const radio = page.locator('[role="radio"]', { hasText: label }).first();
+	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		await radio.click();
+		await expect(radio).toHaveAttribute('aria-checked', 'true');
+	}
+}
+// Inject a probe element and read computed values for the editorial utilities.
+const probe = (page: Page) =>
+	page.evaluate(() => {
+		const wrap = document.createElement('div');
+		wrap.innerHTML =
+			'<span class="font-accent">x</span><span class="text-gradient">y</span><hr class="divider-editorial"/>';
+		document.body.appendChild(wrap);
+		const accent = getComputedStyle(wrap.querySelector('.font-accent')!);
+		const gradient = getComputedStyle(wrap.querySelector('.text-gradient')!);
+		const r = {
+			font: accent.fontFamily.toLowerCase(),
+			style: accent.fontStyle,
+			// text-gradient clips a gradient to the text → transparent fill + a bg image.
+			gradientFill: gradient.webkitTextFillColor || gradient.color,
+			gradientImg: gradient.backgroundImage
+		};
+		wrap.remove();
+		return r;
+	});
+
+test.describe('Soft Premium editorial utilities', () => {
+	test.beforeEach(async ({ page }) => login(page));
+	test.afterEach(async ({ page }) => setDesign(page, 'Classic'));
+
+	test('classic: font-accent falls back to heading serif (no Newsreader)', async ({ page }) => {
+		await setDesign(page, 'Classic');
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+		const r = await probe(page);
+		expect(r.font).not.toContain('newsreader');
+		expect(r.font).toContain('lora'); // classic heading fallback
+		// text-gradient is mode-independent (uses the accent ramp).
+		expect(r.gradientImg).toContain('gradient');
+	});
+
+	test('soft-premium: font-accent is Newsreader italic; gradient clips', async ({ page }) => {
+		await setDesign(page, 'Soft Premium');
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+		const r = await probe(page);
+		expect(r.font).toContain('newsreader');
+		expect(r.style).toBe('italic');
+		expect(r.gradientImg).toContain('gradient');
+	});
+});


### PR DESCRIPTION
Stacked on #452. Adds the editorial utility classes Track C surfaces consume: `.font-accent` (Newsreader italic), `.text-gradient`, `.divider-editorial`, `.grain` (soft-premium only).

**Gotcha handled:** authored `@layer utilities` rules are stripped by Tailwind's content purge when unused — so these are authored **unlayered** to guarantee they ship before a Track C component references them (verified all 4 in the production CSS).

Certified: svelte-check 0/0, build OK; soft-premium-utils.spec.ts proves font-accent=Newsreader / classic serif fallback through the real product.