### PR TITLE
feat(design): Soft Premium ProfileNav accent underline

### DIFF
--- a/frontend/src/components/public/ProfileNav.svelte
+++ b/frontend/src/components/public/ProfileNav.svelte
@@ -161,7 +161,8 @@
 					{#if item.href}
 						<a
 							href={item.href}
-							class="flex-shrink-0 px-3 py-1.5 text-sm font-medium rounded-full transition-colors
+							aria-current={activeSection === item.id ? 'page' : undefined}
+							class="nav-item flex-shrink-0 px-3 py-1.5 text-sm font-medium rounded-full transition-colors
 								{activeSection === item.id
 									? 'bg-primary-100 dark:bg-primary-700 text-primary-700 dark:text-white'
 									: 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700'}"
@@ -175,7 +176,8 @@
 						<button
 							type="button"
 							onclick={() => scrollToSection(item.id)}
-							class="flex-shrink-0 px-3 py-1.5 text-sm font-medium rounded-full transition-colors
+							aria-current={activeSection === item.id ? 'page' : undefined}
+							class="nav-item flex-shrink-0 px-3 py-1.5 text-sm font-medium rounded-full transition-colors
 								{activeSection === item.id
 									? 'bg-primary-100 dark:bg-primary-700 text-primary-700 dark:text-white'
 									: 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700'}"
@@ -196,5 +198,42 @@
 	}
 	.scrollbar-hide::-webkit-scrollbar {
 		display: none;
+	}
+
+	/*
+	 * Soft Premium only: replace the filled active pill with a warm-bar
+	 * accent underline. Classic is untouched - these rules never match
+	 * without [data-design='soft-premium'] on the document root, so the
+	 * Tailwind pill classes render exactly as today in classic.
+	 *
+	 * The accessible state stays the aria-current="page" attribute the
+	 * markup sets; the underline is purely decorative.
+	 */
+	:global([data-design='soft-premium']) .nav-item {
+		position: relative;
+		/* Square off the corners so the pill shape reads as classic. */
+		border-radius: 0;
+	}
+
+	/* Neutralize the filled active pill (Tailwind bg-primary utilities). */
+	:global([data-design='soft-premium']) .nav-item[aria-current='page'] {
+		background-color: transparent;
+		color: var(--color-primary-700);
+	}
+
+	:global([data-design='soft-premium'].dark) .nav-item[aria-current='page'] {
+		color: var(--color-primary-300);
+	}
+
+	/* 2px accent underline bar on the active item. */
+	:global([data-design='soft-premium']) .nav-item[aria-current='page']::after {
+		content: '';
+		position: absolute;
+		left: 0.75rem;
+		right: 0.75rem;
+		bottom: -0.25rem;
+		height: 2px;
+		border-radius: 1px;
+		background-color: var(--color-primary-600);
 	}
 </style>

--- a/frontend/src/components/public/ProfileNav.svelte
+++ b/frontend/src/components/public/ProfileNav.svelte
@@ -236,4 +236,10 @@
 		border-radius: 1px;
 		background-color: var(--color-primary-600);
 	}
+
+	/* On dark surfaces the 600 underline is too dim for some accents; the lighter
+	   400 reads clearly. (Decorative — aria-current carries the active state.) */
+	:global([data-design='soft-premium'].dark) .nav-item[aria-current='page']::after {
+		background-color: var(--color-primary-400);
+	}
 </style>


### PR DESCRIPTION
Ports the public **ProfileNav** scrollspy bar to the Soft Premium redesign. Under soft-premium the active section item drops the filled pill and reads as a 2px accent underline (\`--color-primary-600\`) on the warm bar. Classic is byte-identical (pill untouched).

## What changed
- Added \`aria-current=\"page\"\` to the active nav link/button (a11y + the CSS hook for the underline). This is the accessible active state; the underline is purely decorative.
- Added \`nav-item\` class as a stable scoped-style hook.
- Soft-premium-only \`<style>\` rules, all gated by \`:global([data-design='soft-premium'])\`: neutralize the Tailwind \`bg-primary\` pill, square the radius, and paint a 2px \`::after\` accent bar. Dark variant via \`[data-design='soft-premium'].dark\`.

## Preserved
- IntersectionObserver scrollspy, keyboard access, i18n labels.
- Classic mode: no rule matches without \`data-design='soft-premium'\` on \`<html>\`, so the pill renders exactly as today.
- No new i18n strings (\`aria-current\` uses the standard \`page\` token).

## Certification
- \`npm run check\`: 0 errors, 0 warnings
- \`npm run build\`: succeeds; grep confirms the underline rule (\`height:2px; background-color:var(--color-primary-600)\`) ships in the client bundle, Svelte-scoped to this component.

Scope: only \`frontend/src/components/public/ProfileNav.svelte\` touched.