### PR TITLE
feat(design): terracotta default accent for Soft Premium (B4)

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import type { Handle } from '@sveltejs/kit';
 import PocketBase from 'pocketbase';
 import { PB_COOKIE_NAME } from '$lib/pocketbase';
-import { generateAccentCSSVars } from '$lib/colors';
+import { generateAccentCSSVars, SOFT_PREMIUM_DEFAULT_ACCENT } from '$lib/colors';
 import { generateFontCSSVars, getGoogleFontsUrl, DEFAULT_FONT_PACK } from '$lib/fonts';
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -20,16 +20,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 	let fontCSSVars = '';
 	let fontPack = '';
 	let operatorFontPack = '';
+	let operatorAccent = '';
+	let operatorCustomHex = '';
 	try {
 		const homepageRes = await fetch(`${pbUrl}/api/homepage`, {
 			headers: { 'X-Internal': 'true' }
 		});
 		if (homepageRes.ok) {
 			const homepage = await homepageRes.json();
-			accentCSSVars = generateAccentCSSVars(
-				homepage.profile?.accent_color,
-				homepage.profile?.custom_hex_color
-			);
+			operatorAccent = homepage.profile?.accent_color || '';
+			operatorCustomHex = homepage.profile?.custom_hex_color || '';
 			operatorFontPack = homepage.profile?.font_pack || '';
 		}
 	} catch { /* silent - fallback to client-side application */ }
@@ -58,6 +58,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 			: operatorFontPack;
 	fontCSSVars = generateFontCSSVars(effectiveFontPack);
 	fontPack = effectiveFontPack;
+
+	// Accent: Soft Premium defaults to a warm terracotta when the operator hasn't
+	// set an accent, so the accent harmonizes with the stone surfaces. An operator
+	// accent (named or custom hex) always wins; classic keeps the static default.
+	if (design === 'soft-premium' && !operatorAccent && !operatorCustomHex) {
+		accentCSSVars = generateAccentCSSVars(null, SOFT_PREMIUM_DEFAULT_ACCENT);
+	} else {
+		accentCSSVars = generateAccentCSSVars(operatorAccent, operatorCustomHex);
+	}
 
 	const response = await resolve(event, {
 		transformPageChunk: ({ html }) => {

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -280,6 +280,13 @@ export const ACCENT_COLORS: Record<AccentColor, AccentColorInfo> = {
 export const DEFAULT_ACCENT_COLOR: AccentColor = 'sky';
 
 /**
+ * Default accent for the Soft Premium design when the operator hasn't chosen
+ * one — a warm terracotta that harmonizes with the stone surfaces. Operators
+ * who set an accent keep it; classic is unaffected.
+ */
+export const SOFT_PREMIUM_DEFAULT_ACCENT = '#c2410c';
+
+/**
  * List of available accent colors for UI iteration
  */
 export const ACCENT_COLOR_LIST: AccentColor[] = ['sky', 'indigo', 'emerald', 'rose', 'amber', 'slate'];

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -10,6 +10,7 @@
 import type { LayoutServerLoad } from './$types';
 import type { PlanConfig } from '$lib/stores/plan';
 import { logger } from '$lib/logger';
+import { SOFT_PREMIUM_DEFAULT_ACCENT } from '$lib/colors';
 
 export const load: LayoutServerLoad = async ({ fetch }) => {
 	const pbUrl = process.env.POCKETBASE_URL || 'http://localhost:8090';
@@ -20,6 +21,7 @@ export const load: LayoutServerLoad = async ({ fetch }) => {
 	let defaultLocale: string | null = null;
 	let showAvatar = true;
 	let defaultThemeMode = 'system';
+	let design = 'classic';
 	try {
 		const siteSettingsResponse = await fetch(`${pbUrl}/api/site-settings`, {
 			headers: { 'X-Internal': 'true' }
@@ -31,6 +33,7 @@ export const load: LayoutServerLoad = async ({ fetch }) => {
 			defaultLocale = siteSettings.default_locale || null;
 			showAvatar = siteSettings.show_avatar !== false;
 			defaultThemeMode = siteSettings.default_theme_mode || 'system';
+			if (siteSettings.design === 'soft-premium') design = 'soft-premium';
 		}
 	} catch (error) {
 		logger.debug('[LAYOUT SSR] Failed to load site settings:', error);
@@ -92,6 +95,13 @@ export const load: LayoutServerLoad = async ({ fetch }) => {
 		logger.debug('[LAYOUT SSR] Failed to load accent color:', error);
 	}
 
+	// Soft Premium defaults the accent to a warm terracotta when the operator
+	// hasn't chosen one (mirrors hooks.server.ts so the client matches SSR). An
+	// operator accent always wins; classic is unaffected.
+	if (design === 'soft-premium' && !accentColor && !customHexColor) {
+		customHexColor = SOFT_PREMIUM_DEFAULT_ACCENT;
+	}
+
 	return {
 		faviconUrl,
 		planConfig,
@@ -103,6 +113,7 @@ export const load: LayoutServerLoad = async ({ fetch }) => {
 		customCSS,
 		defaultLocale,
 		showAvatar,
-		defaultThemeMode
+		defaultThemeMode,
+		design
 	};
 };

--- a/frontend/tests/soft-premium-accent-default.spec.ts
+++ b/frontend/tests/soft-premium-accent-default.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// B4: Soft Premium defaults the accent to warm terracotta when the operator
+// hasn't set one; classic keeps the static sky default. (Assumes the seeded
+// profile has no explicit accent — the dev seed does not.)
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const LOGIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const LOGIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'changeme123';
+const TERRACOTTA = '#c2410c';
+
+async function login(page: Page) {
+	await page.goto(`${BASE_URL}/admin/login`);
+	await page.waitForSelector('input[type="email"]', { timeout: 10_000 });
+	await page.fill('input[type="email"]', LOGIN_EMAIL);
+	await page.fill('input[type="password"]', LOGIN_PASSWORD);
+	await page.click('button[type="submit"]');
+	await page.waitForURL((url) => /\/admin(\/|$)/.test(url.pathname) && !url.pathname.includes('/login'), {
+		timeout: 15_000
+	});
+}
+async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
+	await page.goto(`${BASE_URL}/admin/settings/site`);
+	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
+	const radio = page.locator('[role="radio"]', { hasText: label }).first();
+	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		await radio.click();
+		await expect(radio).toHaveAttribute('aria-checked', 'true');
+	}
+}
+const accent500 = (page: Page) =>
+	page.evaluate(() =>
+		getComputedStyle(document.documentElement).getPropertyValue('--color-primary-500').trim().toLowerCase()
+	);
+
+test.describe('Soft Premium default accent', () => {
+	test.beforeEach(async ({ page }) => login(page));
+	test.afterEach(async ({ page }) => setDesign(page, 'Classic'));
+
+	test('soft-premium defaults to terracotta when no operator accent', async ({ page }) => {
+		await setDesign(page, 'Soft Premium');
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+		expect(await accent500(page)).toBe(TERRACOTTA);
+	});
+
+	test('classic keeps the sky default accent', async ({ page }) => {
+		await setDesign(page, 'Classic');
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+		expect(await accent500(page)).not.toBe(TERRACOTTA);
+		expect(await accent500(page)).toBe('#0ea5e9');
+	});
+});


### PR DESCRIPTION
Stacked on #453. Completes **Track B**. When `design=soft-premium` and the operator hasn't chosen an accent, defaults to a warm terracotta (#c2410c). Operator accent always wins; classic keeps sky. Applied in both SSR (hooks.server) and client (+layout.server) paths — no flash. Certified: svelte-check 0/0, build OK, soft-premium-accent-default.spec.ts 2/2.