### PR TITLE
feat(design): Soft Premium serif section headings (resume sections)

### DIFF
--- a/frontend/src/components/public/AwardsSection.svelte
+++ b/frontend/src/components/public/AwardsSection.svelte
@@ -25,7 +25,8 @@
 </script>
 
 <section id="awards" class="mb-16" data-layout={layout}>
-	<h2 class="section-title">{$t('public.sections.awards')}</h2>
+	<h2 class="section-title section-heading">{$t('public.sections.awards')}</h2>
+	<hr class="divider-editorial section-divider" aria-hidden="true" />
 
 	{#if layout === 'timeline'}
 		<div class="space-y-6">
@@ -143,3 +144,19 @@
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: editorial serif heading + divider. Classic untouched. */
+	:global([data-design='soft-premium']) .section-heading {
+		font-family: var(--font-accent);
+		font-style: italic;
+	}
+	.section-divider {
+		display: none;
+	}
+	:global([data-design='soft-premium']) .section-divider {
+		display: block;
+		margin-top: -1rem;
+		margin-bottom: 1.5rem;
+	}
+</style>

--- a/frontend/src/components/public/CertificationsSection.svelte
+++ b/frontend/src/components/public/CertificationsSection.svelte
@@ -44,7 +44,8 @@
 </script>
 
 <section id="certifications" class="mb-16">
-	<h2 class="section-title">{$t('public.sections.certifications')}</h2>
+	<h2 class="section-title section-heading">{$t('public.sections.certifications')}</h2>
+	<hr class="divider-editorial section-divider" aria-hidden="true" />
 
 	{#if layout === 'timeline'}
 		<div class="relative">
@@ -185,3 +186,19 @@
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: editorial serif heading + divider. Classic untouched. */
+	:global([data-design='soft-premium']) .section-heading {
+		font-family: var(--font-accent);
+		font-style: italic;
+	}
+	.section-divider {
+		display: none;
+	}
+	:global([data-design='soft-premium']) .section-divider {
+		display: block;
+		margin-top: -1rem;
+		margin-bottom: 1.5rem;
+	}
+</style>

--- a/frontend/src/components/public/EducationSection.svelte
+++ b/frontend/src/components/public/EducationSection.svelte
@@ -27,7 +27,8 @@
 </script>
 
 <section id="education" class="mb-16" itemscope itemtype="https://schema.org/Person">
-	<h2 class="section-title">{$t('public.sections.education')}</h2>
+	<h2 class="section-title section-heading">{$t('public.sections.education')}</h2>
+	<hr class="divider-editorial section-divider" aria-hidden="true" />
 
 	{#if layout === 'timeline'}
 		<!-- Timeline Layout -->
@@ -129,3 +130,19 @@
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: editorial serif heading + divider. Classic untouched. */
+	:global([data-design='soft-premium']) .section-heading {
+		font-family: var(--font-accent);
+		font-style: italic;
+	}
+	.section-divider {
+		display: none;
+	}
+	:global([data-design='soft-premium']) .section-divider {
+		display: block;
+		margin-top: -1rem;
+		margin-bottom: 1.5rem;
+	}
+</style>

--- a/frontend/src/components/public/ExperienceSection.svelte
+++ b/frontend/src/components/public/ExperienceSection.svelte
@@ -39,7 +39,8 @@
 </script>
 
 <section id="experience" class="mb-16" itemscope itemtype="https://schema.org/Person">
-	<h2 class="section-title">{$t('public.sections.experience')}</h2>
+	<h2 class="section-title section-heading">{$t('public.sections.experience')}</h2>
+	<hr class="divider-editorial section-divider" aria-hidden="true" />
 
 	{#if layout === 'timeline'}
 		<!-- Timeline Layout -->
@@ -457,3 +458,19 @@
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: editorial serif heading + divider. Classic untouched. */
+	:global([data-design='soft-premium']) .section-heading {
+		font-family: var(--font-accent);
+		font-style: italic;
+	}
+	.section-divider {
+		display: none;
+	}
+	:global([data-design='soft-premium']) .section-divider {
+		display: block;
+		margin-top: -1rem;
+		margin-bottom: 1.5rem;
+	}
+</style>

--- a/frontend/src/components/public/SkillsSection.svelte
+++ b/frontend/src/components/public/SkillsSection.svelte
@@ -102,7 +102,8 @@
 </script>
 
 <section id="skills" class="mb-16" itemscope itemtype="https://schema.org/Person">
-	<h2 class="section-title">{$t('public.sections.skills')}</h2>
+	<h2 class="section-title section-heading">{$t('public.sections.skills')}</h2>
+	<hr class="divider-editorial section-divider" aria-hidden="true" />
 
 	{#if layout === 'cloud'}
 		<!-- Tag Cloud Layout -->
@@ -213,3 +214,19 @@
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: editorial serif heading + divider. Classic untouched. */
+	:global([data-design='soft-premium']) .section-heading {
+		font-family: var(--font-accent);
+		font-style: italic;
+	}
+	.section-divider {
+		display: none;
+	}
+	:global([data-design='soft-premium']) .section-divider {
+		display: block;
+		margin-top: -1rem;
+		margin-bottom: 1.5rem;
+	}
+</style>

--- a/frontend/src/components/public/TestimonialsSection.svelte
+++ b/frontend/src/components/public/TestimonialsSection.svelte
@@ -105,7 +105,8 @@
 </script>
 
 <section id="testimonials" class="mb-16">
-	<h2 class="section-title">{$t('public.sections.testimonials')}</h2>
+	<h2 class="section-title section-heading">{$t('public.sections.testimonials')}</h2>
+	<hr class="divider-editorial section-divider" aria-hidden="true" />
 
 	{#if layout === 'wall'}
 		<div class="columns-1 md:columns-2 gap-4 space-y-4">
@@ -264,5 +265,18 @@
 	}
 	.scrollbar-hide::-webkit-scrollbar {
 		display: none;
+	}
+	/* Soft Premium only: editorial serif heading + divider. Classic untouched. */
+	:global([data-design='soft-premium']) .section-heading {
+		font-family: var(--font-accent);
+		font-style: italic;
+	}
+	.section-divider {
+		display: none;
+	}
+	:global([data-design='soft-premium']) .section-divider {
+		display: block;
+		margin-top: -1rem;
+		margin-bottom: 1.5rem;
 	}
 </style>


### PR DESCRIPTION
## Summary

Ports the remaining public resume-section surfaces to the Soft Premium redesign with editorial serif section headings. Applies to 6 components in \`frontend/src/components/public/\`: Experience, Education, Certifications, Awards, Testimonials, Skills.

Each section \`<h2>\` gets a \`section-heading\` marker class plus a soft-premium-gated serif treatment (\`font-family: var(--font-accent); font-style: italic\`), and an editorial divider (\`.divider-editorial\`) beneath it. All styling is gated to \`[data-design='soft-premium']\` via scoped \`:global()\` rules.

## Zero-regression

- Classic mode is visually byte-identical: heading serif and divider only paint under \`[data-design='soft-premium']\`. The divider \`<hr>\` is \`display: none\` by default.
- The \`section-heading\` marker is applied via a scoped rule, NOT \`class="font-accent"\`, so the classic serif heading is never italicized.
- **SkillsSection proficiency dots preserved exactly** — the non-color a11y signal (1-3 filled dots) is untouched; only the heading treatment was added.
- Props, layouts, a11y, i18n, and SEO microdata unchanged. No new strings.

## Verification

- \`npm run check\`: 0 errors, 0 warnings
- \`npm run build\`: succeeds

## Files

- ExperienceSection.svelte, EducationSection.svelte, CertificationsSection.svelte, AwardsSection.svelte, TestimonialsSection.svelte, SkillsSection.svelte