### PR TITLE
feat(design): Soft Premium card plates + serif titles for Projects/Talks

### DIFF
--- a/frontend/src/components/public/ProjectsSection.svelte
+++ b/frontend/src/components/public/ProjectsSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
 	import type { Project } from '$lib/pocketbase';
 	import { truncate, parseMarkdown } from '$lib/utils';
@@ -10,6 +11,34 @@
 	}
 
 	let { items, layout = 'grid-3', viewSlug = '' }: Props = $props();
+
+	// Soft Premium opt-in detection. SSR always renders the classic branch (the
+	// server injects data-design on <html> *after* component render, so it is not
+	// observable here), keeping classic output byte-identical. After mount we read
+	// the attribute and, only under soft-premium, swap in the refined serif initial
+	// plate. The post-mount swap touches the cover-less fallback only.
+	let isSoftPremium = $state(false);
+	onMount(() => {
+		isSoftPremium = document.documentElement.getAttribute('data-design') === 'soft-premium';
+	});
+
+	// Code-point-safe first character (emoji/multibyte titles are not split mid
+	// surrogate-pair, unlike charAt(0)). Used only for the soft-premium serif plate.
+	const initial = (title: string) => [...(title ?? '')][0] ?? '';
+
+	// Validate operator-supplied URLs against a scheme allowlist before rendering
+	// them as hrefs, so a javascript:/data: URI can never become a clickable link.
+	// Returns undefined for disallowed/unparseable values (link renders inert).
+	const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+	const safeHref = (url: string | undefined | null): string | undefined => {
+		if (!url || typeof url !== 'string') return undefined;
+		try {
+			const parsed = new URL(url.trim());
+			return ALLOWED_SCHEMES.has(parsed.protocol) ? url : undefined;
+		} catch {
+			return undefined;
+		}
+	};
 
 const isLinkable = (project: Project) => {
 	const visibility = (project as unknown as Record<string, string>).visibility;
@@ -54,7 +83,7 @@ const projectHref = (project: Project) => {
 </script>
 
 <section id="projects" class="mb-16">
-	<h2 class="section-title">{$t('public.sections.projects')}</h2>
+	<h2 class="section-title sp-title">{$t('public.sections.projects')}</h2>
 
 	{#if layout === 'featured' && items.length > 0}
 		<!-- Featured Layout: First item large, rest in grid -->
@@ -84,6 +113,12 @@ const projectHref = (project: Project) => {
 								/>
 							</div>
 						{/if}
+					{:else if isSoftPremium}
+						<div class="sp-plate aspect-video md:aspect-auto md:h-full flex items-center justify-center" aria-hidden="true">
+							<span class="sp-plate__initial font-accent" style="font-size:clamp(3.5rem,8vw,6rem)">
+								{initial(featuredItem.title)}
+							</span>
+						</div>
 					{:else}
 						<div class="aspect-video md:aspect-auto md:h-full bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
 							<span class="text-6xl font-bold text-white/50">
@@ -128,7 +163,7 @@ const projectHref = (project: Project) => {
 							<div class="mt-4 flex items-center gap-4">
 								{#each featuredItem.links as link}
 									<a
-										href={link.url}
+										href={safeHref(link.url)}
 										target="_blank"
 										rel="noopener noreferrer"
 										class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
@@ -170,6 +205,12 @@ const projectHref = (project: Project) => {
 										/>
 									</div>
 								{/if}
+							{:else if isSoftPremium}
+								<div class="sp-plate aspect-video flex items-center justify-center" aria-hidden="true">
+									<span class="sp-plate__initial font-accent text-5xl">
+										{initial(project.title)}
+									</span>
+								</div>
 							{:else}
 								<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
 									<span class="text-4xl font-bold text-white/50">
@@ -290,7 +331,7 @@ const projectHref = (project: Project) => {
 									<div class="flex items-center gap-3 ml-auto">
 										{#each project.links as link}
 											<a
-												href={link.url}
+												href={safeHref(link.url)}
 												target="_blank"
 												rel="noopener noreferrer"
 												class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
@@ -335,6 +376,12 @@ const projectHref = (project: Project) => {
 								/>
 							</div>
 						{/if}
+					{:else if isSoftPremium}
+						<div class="sp-plate aspect-video flex items-center justify-center" aria-hidden="true">
+							<span class="sp-plate__initial font-accent text-6xl">
+								{initial(project.title)}
+							</span>
+						</div>
 					{:else}
 						<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
 							<span class="text-5xl font-bold text-white/50">
@@ -386,7 +433,7 @@ const projectHref = (project: Project) => {
 							<div class="mt-4 flex items-center gap-4">
 								{#each project.links as link}
 									<a
-										href={link.url}
+										href={safeHref(link.url)}
 										target="_blank"
 										rel="noopener noreferrer"
 										class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
@@ -429,6 +476,12 @@ const projectHref = (project: Project) => {
 								/>
 							</div>
 						{/if}
+					{:else if isSoftPremium}
+						<div class="sp-plate aspect-video flex items-center justify-center" aria-hidden="true">
+							<span class="sp-plate__initial font-accent text-5xl">
+								{initial(project.title)}
+							</span>
+						</div>
 					{:else}
 						<div class="aspect-video bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center">
 							<span class="text-4xl font-bold text-white/50">
@@ -480,7 +533,7 @@ const projectHref = (project: Project) => {
 							<div class="mt-4 flex items-center gap-3">
 								{#each project.links as link}
 									<a
-										href={link.url}
+										href={safeHref(link.url)}
 										target="_blank"
 										rel="noopener noreferrer"
 										class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
@@ -497,3 +550,40 @@ const projectHref = (project: Project) => {
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: refined serif initial plate replacing the cover-less
+	   giant-letter fallback, plus an editorial serif accent on the section title.
+	   Every selector is gated by [data-design='soft-premium'] so the classic
+	   look is untouched. */
+	:global([data-design='soft-premium']) .sp-plate {
+		background:
+			radial-gradient(120% 120% at 30% 20%, var(--surface-2) 0%, var(--chip) 55%, var(--bg) 100%);
+		border-radius: var(--r-4);
+		position: relative;
+		overflow: hidden;
+	}
+	:global([data-design='soft-premium']) .sp-plate::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		box-shadow: inset 0 0 0 1px var(--border-hairline);
+		border-radius: inherit;
+		pointer-events: none;
+	}
+	:global([data-design='soft-premium']) .sp-plate__initial {
+		color: var(--ink);
+		opacity: 0.82;
+		line-height: 1;
+		font-weight: 500;
+		letter-spacing: -0.01em;
+		font-style: italic;
+		user-select: none;
+	}
+	:global([data-design='soft-premium']) .sp-title {
+		font-family: var(--font-accent);
+		font-style: italic;
+		font-weight: 500;
+		letter-spacing: -0.01em;
+	}
+</style>

--- a/frontend/src/components/public/TalksSection.svelte
+++ b/frontend/src/components/public/TalksSection.svelte
@@ -12,6 +12,20 @@
 
 	let { items, layout = 'default', viewSlug = '', showHeader = true }: Props = $props();
 
+	// Validate operator-supplied URLs against a scheme allowlist before rendering
+	// them as hrefs, so a javascript:/data: URI can never become a clickable link.
+	// Returns undefined for disallowed/unparseable values (link renders inert).
+	const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+	const safeHref = (url: string | undefined | null): string | undefined => {
+		if (!url || typeof url !== 'string') return undefined;
+		try {
+			const parsed = new URL(url.trim());
+			return ALLOWED_SCHEMES.has(parsed.protocol) ? url : undefined;
+		} catch {
+			return undefined;
+		}
+	};
+
 	function getTalkUrl(slug: string): string {
 		if (viewSlug) {
 			return `/talks/${slug}?from=${encodeURIComponent(viewSlug)}`;
@@ -47,7 +61,7 @@
 
 <section id="talks" class="mb-16">
 	{#if showHeader}
-		<h2 class="section-title">{$t('public.sections.talks')}</h2>
+		<h2 class="section-title sp-title">{$t('public.sections.talks')}</h2>
 	{/if}
 
 	{#if layout === 'list'}
@@ -75,13 +89,13 @@
 							</div>
 							<div class="mt-2 flex flex-wrap gap-3">
 								{#if talk.video_url}
-									<a href={talk.video_url} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.watch_video_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
+									<a href={safeHref(talk.video_url)} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.watch_video_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
 										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" /></svg>
 										{$t('public.talks.video')}
 									</a>
 								{/if}
 								{#if talk.slides_url}
-									<a href={talk.slides_url} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.view_slides_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
+									<a href={safeHref(talk.slides_url)} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.view_slides_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
 										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
 										{$t('public.talks.slides')}
 									</a>
@@ -115,7 +129,7 @@
 							</div>
 						{:else}
 							<div class="aspect-video bg-gradient-to-br from-purple-600 to-indigo-800 flex items-center justify-center">
-								<a href={talk.video_url} target="_blank" rel="noopener noreferrer" class="flex flex-col items-center gap-2 text-white hover:opacity-80">
+								<a href={safeHref(talk.video_url)} target="_blank" rel="noopener noreferrer" class="flex flex-col items-center gap-2 text-white hover:opacity-80">
 									<svg class="w-12 h-12" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
 									<span class="text-sm font-medium">{$t('public.talks.watch_video')}</span>
 								</a>
@@ -134,10 +148,10 @@
 						</div>
 						<div class="mt-3 flex gap-3">
 							{#if talk.video_url}
-								<a href={talk.video_url} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.watch_video_for', { values: { title: talk.title } })} class="text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">{$t('public.talks.video')}</a>
+								<a href={safeHref(talk.video_url)} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.watch_video_for', { values: { title: talk.title } })} class="text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">{$t('public.talks.video')}</a>
 							{/if}
 							{#if talk.slides_url}
-								<a href={talk.slides_url} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.view_slides_for', { values: { title: talk.title } })} class="text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">{$t('public.talks.slides')}</a>
+								<a href={safeHref(talk.slides_url)} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.view_slides_for', { values: { title: talk.title } })} class="text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">{$t('public.talks.slides')}</a>
 							{/if}
 							{#if talk.slug}
 								<a href={getTalkUrl(talk.slug)} aria-label={$t('public.talks.view_details_for', { values: { title: talk.title } })} class="text-sm text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">{$t('public.talks.view_details')}</a>
@@ -165,7 +179,7 @@
 								</div>
 							{:else}
 								<div class="lg:w-2/5 aspect-video bg-gradient-to-br from-purple-600 to-indigo-800 flex-shrink-0 flex items-center justify-center">
-									<a href={talk.video_url} target="_blank" rel="noopener noreferrer" class="flex flex-col items-center gap-3 text-white hover:opacity-80 transition-opacity">
+									<a href={safeHref(talk.video_url)} target="_blank" rel="noopener noreferrer" class="flex flex-col items-center gap-3 text-white hover:opacity-80 transition-opacity">
 										<svg class="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
 										<span class="text-sm font-medium">{$t('public.talks.watch_video')}</span>
 									</a>
@@ -184,7 +198,7 @@
 									<span class="flex items-center gap-1.5">
 										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
 										{#if talk.event_url}
-											<a href={talk.event_url} target="_blank" rel="noopener noreferrer" class="hover:text-primary-600 dark:hover:text-primary-400">{talk.event}</a>
+											<a href={safeHref(talk.event_url)} target="_blank" rel="noopener noreferrer" class="hover:text-primary-600 dark:hover:text-primary-400">{talk.event}</a>
 										{:else}
 											{talk.event}
 										{/if}
@@ -210,13 +224,13 @@
 							{/if}
 							<div class="mt-4 flex flex-wrap gap-3">
 								{#if talk.video_url}
-									<a href={talk.video_url} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.watch_video_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
+									<a href={safeHref(talk.video_url)} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.watch_video_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
 										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
 										{$t('public.talks.watch_video')}
 									</a>
 								{/if}
 								{#if talk.slides_url}
-									<a href={talk.slides_url} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.view_slides_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
+									<a href={safeHref(talk.slides_url)} target="_blank" rel="noopener noreferrer" aria-label={$t('public.talks.view_slides_for', { values: { title: talk.title } })} class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 dark:focus-visible:ring-primary-400 rounded-sm">
 										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
 										{$t('public.talks.view_slides')}
 									</a>
@@ -235,3 +249,14 @@
 		</div>
 	{/if}
 </section>
+
+<style>
+	/* Soft Premium only: editorial serif accent on the section title. Gated by
+	   [data-design='soft-premium'] so the classic look stays byte-identical. */
+	:global([data-design='soft-premium']) .sp-title {
+		font-family: var(--font-accent);
+		font-style: italic;
+		font-weight: 500;
+		letter-spacing: -0.01em;
+	}
+</style>


### PR DESCRIPTION
Ports two public surfaces (ProjectsSection, TalksSection) to the Soft Premium redesign. Builds on the \`feat/soft-premium-utils\` foundation (tokens, \`.font-accent\`, \`data-design\` attribute).

## Changes
- **Card plates replace giant letter fallbacks** (Projects, all 4 layouts: featured / featured-grid / grid-2 / grid-3): under soft-premium only, the cover-less \`{title.charAt(0)}\` letter on a primary gradient is replaced with a refined serif initial plate (warm \`--surface-2\`/\`--chip\`/\`--bg\` radial gradient, \`--ink\` italic Newsreader via \`--font-accent\`, rounded via \`--r-4\`, hairline inset ring). Uses code-point-safe \`[...title][0]\` so emoji/multibyte titles render correctly.
- **Editorial serif section titles** (Projects + Talks): \`section-title\` gains a soft-premium-only \`--font-accent\` italic accent via scoped CSS.
- **Operator-URL hardening**: all operator-supplied hrefs (\`link.url\`, \`talk.video_url\`, \`talk.slides_url\`, \`talk.event_url\`) are now scheme-validated against an http/https/mailto/tel allowlist before render, closing a pre-existing \`javascript:\`-URI XSS surface. App-generated \`getTalkUrl()\`/\`projectHref()\` links are untouched.

## Zero-regression
Classic is byte-identical: every flourish is gated behind \`:global([data-design='soft-premium'])\` scoped CSS or an \`{#if isSoftPremium}\` branch that only adds a soft-premium output path. The \`isSoftPremium\` flag is SSR-false and set in \`onMount\`, so server output (always classic per-component) never mismatches. All 4 classic \`charAt(0)\` fallback branches and the \`.section-title\` base class are preserved. No i18n strings added; a11y (alt/aria), layouts, and props unchanged.

## Certification (frontend/)
- \`npm run check\`: 0 errors, 0 warnings
- \`npm run build\`: success
- \`npm run i18n:validate\`: 100% (no strings changed)