### PR TITLE
feat(design): Soft Premium AdminHeader glass treatment

### DIFF
--- a/frontend/src/components/admin/AdminHeader.svelte
+++ b/frontend/src/components/admin/AdminHeader.svelte
@@ -23,7 +23,9 @@
 	}
 </script>
 
-<header class="fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 z-40">
+<header
+	class="admin-header fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 z-40"
+>
 	<div class="flex items-center justify-between h-full px-4">
 		<div class="flex items-center gap-4">
 			<button
@@ -81,3 +83,23 @@
 		</div>
 	</div>
 </header>
+
+<style>
+	/* Soft Premium ONLY: turn the admin top bar into a refined translucent glass
+	   surface. Classic receives no rule here, so its bg-white/dark:bg-gray-800 +
+	   gray borders render byte-identical to today. The [data-design] attribute
+	   lives on <html>, outside this component, so the selector is wrapped in
+	   :global(). The translucent fill is derived from the warm --surface token
+	   (auto light/dark) via color-mix; --border-hairline supplies a soft warm
+	   bottom edge. Contrast of header text/icons is unchanged: --ink (#2a2522 on
+	   light, #f4eee4 on dark) stays well above 4.5:1 against the ~80%-opaque warm
+	   surface, and a hard fallback keeps a solid surface where backdrop-filter is
+	   unsupported. */
+	:global([data-design='soft-premium']) .admin-header {
+		background-color: var(--surface);
+		background-color: color-mix(in srgb, var(--surface) 80%, transparent);
+		border-bottom-color: var(--border-hairline);
+		-webkit-backdrop-filter: blur(20px) saturate(1.4);
+		backdrop-filter: blur(20px) saturate(1.4);
+	}
+</style>


### PR DESCRIPTION
## Summary
Applies a subtle glass treatment to the admin top header **under Soft Premium only**. The header becomes a translucent, warm, backdrop-blurred sticky surface so it reads as a refined editorial chrome. Classic stays byte-identical.

## Changes
- `frontend/src/components/admin/AdminHeader.svelte`: added an `admin-header` class hook and a scoped `:global([data-design='soft-premium']) .admin-header` style block. Translucent fill derived from the warm `--surface` token via `color-mix` (auto light/dark), warm `--border-hairline` bottom edge, and `backdrop-filter: blur(20px) saturate(1.4)` (with `-webkit-` prefix + solid `--surface` fallback for non-supporting browsers).

## Scope / guardrails
- Visual only. No structure, nav, behavior, store, aria, i18n, or string changes.
- No live-preview toggle / brand / plan logic (explicitly out of scope).
- Classic mode receives no rule -> renders exactly as today.
- Header text/icons use `--ink` (#2a2522 light / #f4eee4 dark) over the ~80%-opaque warm surface, preserving >=4.5:1 contrast.
- Sticky (`fixed`), keyboard access, and aria attributes untouched.

## Certification
- `npm run check`: 0 errors, 0 warnings
- `npm run build`: succeeds