### PR TITLE
fix(a11y): normalize admin page titles to "{Page} | {brand}"

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1923,7 +1923,9 @@
 			"keyboard_shortcut_prev_row": "Vorherige Zeile",
 			"keyboard_shortcut_open_row": "Fokussierte Zeile öffnen",
 			"keyboard_shortcut_delete_row": "Fokussierte Zeile löschen",
-			"keyboard_shortcut_help": "Diese Hilfe anzeigen"
+			"keyboard_shortcut_help": "Diese Hilfe anzeigen",
+			"create_page_title": "Facette erstellen",
+			"edit_page_title": "Facette bearbeiten"
 		},
 		"media": {
 			"page_title": "Medienbibliothek | Facet Admin",
@@ -2292,7 +2294,8 @@
 			"loading_sections": "Abschnitte werden geladen …",
 			"custom_content_note": "<strong>Hinweis:</strong> Hier erscheinen nur benutzerdefinierte Inhalte, die als <strong>öffentlich</strong> und <strong>nicht im Entwurf</strong> markiert sind. Um die Sichtbarkeit zu ändern, gehe zu <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Benutzerdefinierte Inhalte</a>.",
 			"section_width_title": "Abschnittsbreite",
-			"section_layout_title": "Abschnittslayout"
+			"section_layout_title": "Abschnittslayout",
+			"page_title": "Startseite"
 		},
 		"import": {
 			"resume_dropzone_label": "Lebenslauf-Datei-Ablagebereich",
@@ -2367,7 +2370,8 @@
 			"modal_success_toast": "Lebenslauf importiert! Wähle Einträge für deine Facette aus."
 		},
 		"testimonials": {
-			"delete_request": "Anfrage löschen"
+			"delete_request": "Anfrage löschen",
+			"requests_page_title": "Anfrage-Links"
 		},
 		"comments": {
 			"title": "Kommentare",
@@ -2725,6 +2729,9 @@
 			"loading": "Lädt…",
 			"empty": "Noch keine Newsletter-Listen.",
 			"footer_unlimited": "Unbegrenzte Newsletter-Listen. {count} in Verwendung."
+		},
+		"review": {
+			"page_title": "Import überprüfen"
 		}
 	},
 	"public": {

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -1923,7 +1923,9 @@
 			"keyboard_shortcut_prev_row": "Former row",
 			"keyboard_shortcut_open_row": "Behold the row",
 			"keyboard_shortcut_delete_row": "Unmake the row",
-			"keyboard_shortcut_help": "Reveal this counsel"
+			"keyboard_shortcut_help": "Reveal this counsel",
+			"create_page_title": "Forge a Facet",
+			"edit_page_title": "Reshape a Facet"
 		},
 		"media": {
 			"page_title": "Archives of Memory | Facet Admin",
@@ -2292,7 +2294,8 @@
 			"loading_sections": "Summoning chapters …",
 			"custom_content_note": "<strong>Heed:</strong> Only wrought tales marked <strong>open to all</strong> and <strong>not yet a draft</strong> appear here. To change who may behold them, journey to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Wrought Tales</a>.",
 			"section_width_title": "Breadth of the chapter",
-			"section_layout_title": "Weave of the chapter"
+			"section_layout_title": "Weave of the chapter",
+			"page_title": "Homepage"
 		},
 		"import": {
 			"resume_dropzone_label": "Chronicle scroll waypoint",
@@ -2367,7 +2370,8 @@
 			"modal_success_toast": "Life-scroll gathered! Choose the tales to weave into your facet."
 		},
 		"testimonials": {
-			"delete_request": "Remove petition"
+			"delete_request": "Remove petition",
+			"requests_page_title": "Request Links"
 		},
 		"comments": {
 			"title": "Quettar Formen",
@@ -2725,6 +2729,9 @@
 			"loading": "Hentho…",
 			"empty": "Lestath Postar û peren.",
 			"footer_unlimited": "Lestath Postar pen-bandor. {count} mil."
+		},
+		"review": {
+			"page_title": "Review Import"
 		}
 	},
 	"public": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2098,7 +2098,9 @@
 			"keyboard_shortcut_prev_row": "Previous row",
 			"keyboard_shortcut_open_row": "Open focused row",
 			"keyboard_shortcut_delete_row": "Delete focused row",
-			"keyboard_shortcut_help": "Show this help"
+			"keyboard_shortcut_help": "Show this help",
+			"create_page_title": "Create Facet",
+			"edit_page_title": "Edit Facet"
 		},
 		"media": {
 			"page_title": "Media Library | Facet Admin",
@@ -2440,7 +2442,8 @@
 			"loading_sections": "Loading sections...",
 			"custom_content_note": "<strong>Note:</strong> Only custom content marked as <strong>public</strong> and <strong>not in draft</strong> appears here. To change visibility, go to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Custom Content</a>.",
 			"section_width_title": "Section width",
-			"section_layout_title": "Section layout"
+			"section_layout_title": "Section layout",
+			"page_title": "Homepage"
 		},
 		"import": {
 			"resume_dropzone_label": "Resume file drop zone",
@@ -2515,7 +2518,8 @@
 			"modal_success_toast": "Resume imported! Select items to include in your facet."
 		},
 		"testimonials": {
-			"delete_request": "Delete request"
+			"delete_request": "Delete request",
+			"requests_page_title": "Request Links"
 		},
 		"comments": {
 			"title": "Comments",
@@ -2726,6 +2730,9 @@
 			"loading": "Loading...",
 			"empty": "No newsletter lists yet.",
 			"footer_unlimited": "Unlimited newsletter lists. {count} in use."
+		},
+		"review": {
+			"page_title": "Review Import"
 		}
 	},
 	"public": {

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -1923,7 +1923,9 @@
 			"keyboard_shortcut_prev_row": "Previous position",
 			"keyboard_shortcut_open_row": "Engage focused position",
 			"keyboard_shortcut_delete_row": "Destroy focused position",
-			"keyboard_shortcut_help": "Display this briefing"
+			"keyboard_shortcut_help": "Display this briefing",
+			"create_page_title": "Forge Facet",
+			"edit_page_title": "Edit Facet"
 		},
 		"media": {
 			"page_title": "War Archive | Facet Command",
@@ -2292,7 +2294,8 @@
 			"loading_sections": "Retrieving divisions …",
 			"custom_content_note": "<strong>Attend:</strong> Only custom records marked <strong>public</strong> and <strong>not in draft</strong> stand here. To change who may see them, advance to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Custom Records</a>.",
 			"section_width_title": "Division breadth",
-			"section_layout_title": "Division formation"
+			"section_layout_title": "Division formation",
+			"page_title": "Homepage"
 		},
 		"import": {
 			"resume_dropzone_label": "Battle record upload zone",
@@ -2367,7 +2370,8 @@
 			"modal_success_toast": "Record imported! Choose entries to deploy in your facet."
 		},
 		"testimonials": {
-			"delete_request": "Destroy request"
+			"delete_request": "Destroy request",
+			"requests_page_title": "Request Links"
 		},
 		"comments": {
 			"title": "Battle Reports",
@@ -2725,6 +2729,9 @@
 			"loading": "Summoning…",
 			"empty": "No war squads yet.",
 			"footer_unlimited": "Unlimited war squads. {count} mustered."
+		},
+		"review": {
+			"page_title": "Review Import"
 		}
 	},
 	"public": {

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -1923,7 +1923,9 @@
 			"keyboard_shortcut_prev_row": "Prev row",
 			"keyboard_shortcut_open_row": "Opin teh row",
 			"keyboard_shortcut_delete_row": "Eat teh row",
-			"keyboard_shortcut_help": "Show dis halp"
+			"keyboard_shortcut_help": "Show dis halp",
+			"create_page_title": "Makez a Faycet",
+			"edit_page_title": "Edit Faycet"
 		},
 		"media": {
 			"page_title": "Pikchur Box | Facet Admin",
@@ -2292,7 +2294,8 @@
 			"loading_sections": "Loadin sekshunz...",
 			"custom_content_note": "<strong>Note:</strong> Only custom stuffz markd <strong>public</strong> an <strong>not in draft</strong> showz here. To chanj who can haz, go to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Custom Content</a>.",
 			"section_width_title": "Sekshun wideness",
-			"section_layout_title": "Sekshun layout"
+			"section_layout_title": "Sekshun layout",
+			"page_title": "Homepaej"
 		},
 		"import": {
 			"resume_dropzone_label": "Rezume file drop zone",
@@ -2367,7 +2370,8 @@
 			"modal_success_toast": "Rezoom importd! Pik itemz 2 put in ur facet."
 		},
 		"testimonials": {
-			"delete_request": "Deleet request"
+			"delete_request": "Deleet request",
+			"requests_page_title": "Rekwest Linx"
 		},
 		"comments": {
 			"title": "Commentz",
@@ -2725,6 +2729,9 @@
 			"loading": "Lodin…",
 			"empty": "No litterz yet, srsly.",
 			"footer_unlimited": "Unlimitd litterz. {count} in use."
+		},
+		"review": {
+			"page_title": "Reviuu Import"
 		}
 	},
 	"public": {

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -4,6 +4,7 @@
 	import { toasts } from '$lib/stores';
 	import { onMount, onDestroy } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 
 	let stats = $state({
 		projects: 0,
@@ -123,7 +124,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.dashboard.title')} | Facet</title>
+	<title>{$t('admin.dashboard.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-6xl mx-auto">

--- a/frontend/src/routes/admin/alerts/+page.svelte
+++ b/frontend/src/routes/admin/alerts/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 
@@ -213,7 +214,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.alerts_page.title')}</title>
+	<title>{$t('admin.alerts_page.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="sr-only" role="status" aria-live="polite" aria-atomic="true">{liveMessage}</div>

--- a/frontend/src/routes/admin/analytics/+page.svelte
+++ b/frontend/src/routes/admin/analytics/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { hasFeature } from '$lib/stores/plan';
 
 	const hasAdvancedAnalytics = hasFeature('analytics');
@@ -80,7 +81,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.analytics_page.title')} | Facet</title>
+	<title>{$t('admin.analytics_page.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/api/+page.svelte
+++ b/frontend/src/routes/admin/api/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 
@@ -247,7 +248,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.api_keys.title')}</title>
+	<title>{$t('admin.api_keys.title')} | {$brandName}</title>
 </svelte:head>
 
 <!-- Live region for clipboard announcements -->

--- a/frontend/src/routes/admin/awards/+page.svelte
+++ b/frontend/src/routes/admin/awards/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 	import { pb, type Award } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -291,7 +292,7 @@ onMount(loadAwards);
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.awards.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.awards.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/certifications/+page.svelte
+++ b/frontend/src/routes/admin/certifications/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 	import { pb, type Certification } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -330,7 +331,7 @@ onMount(loadCertifications);
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.certifications.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.certifications.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/comments/+page.svelte
+++ b/frontend/src/routes/admin/comments/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 	import { hasFeature } from '$lib/stores/plan';
@@ -255,7 +256,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.comments.title')} | Facet</title>
+	<title>{$t('admin.comments.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto space-y-6">

--- a/frontend/src/routes/admin/contacts/+page.svelte
+++ b/frontend/src/routes/admin/contacts/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 	import { pb, type ContactMethod, type ContactMethodType, type ProtectionLevel, type View } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -348,7 +349,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.contacts.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.contacts.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/custom/+page.svelte
+++ b/frontend/src/routes/admin/custom/+page.svelte
@@ -7,6 +7,7 @@
 	import ReorderAnnouncer from '$lib/components/admin/ReorderAnnouncer.svelte';
 	import { pb, type CustomContent, getFileUrl } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -451,7 +452,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.custom.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.custom.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/education/+page.svelte
+++ b/frontend/src/routes/admin/education/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 	import { pb, type Education } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -362,7 +363,7 @@ afterNavigate(() => {
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.education.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.education.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/experience/+page.svelte
+++ b/frontend/src/routes/admin/experience/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 	import { pb, type Experience } from '$lib/pocketbase';
 	import { t, locale } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -463,7 +464,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.experience.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.experience.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/homepage/+page.svelte
+++ b/frontend/src/routes/admin/homepage/+page.svelte
@@ -4,6 +4,7 @@
 	import { browser } from '$app/environment';
 	import { onMount, onDestroy } from 'svelte';
 import { t } from 'svelte-i18n';
+import { brandName } from '$lib/stores/plan';
 	import { flip } from 'svelte/animate';
 	import { pb, type View, type CustomContent, VALID_LAYOUTS } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
@@ -897,7 +898,7 @@ import { t } from 'svelte-i18n';
 </script>
 
 <svelte:head>
-	<title>Homepage | Facet</title>
+	<title>{$t('admin.homepage.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-3xl mx-auto">

--- a/frontend/src/routes/admin/import/+page.svelte
+++ b/frontend/src/routes/admin/import/+page.svelte
@@ -5,6 +5,7 @@
 	import { icon } from '$lib/icons';
 	import PageHelp from '$components/admin/PageHelp.svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 
 	// ---------- Resume upload + review state ----------
 	let resumeFile: File | null = $state(null);
@@ -429,7 +430,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.import.page_title')} | Facet</title>
+	<title>{$t('admin.import.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-3xl mx-auto">

--- a/frontend/src/routes/admin/login/+page.svelte
+++ b/frontend/src/routes/admin/login/+page.svelte
@@ -6,6 +6,7 @@
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { get } from 'svelte/store';
 	import type { PageData } from './$types';
 
@@ -172,7 +173,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.login.title')} | Facet</title>
+	<title>{$t('admin.login.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">

--- a/frontend/src/routes/admin/media/+page.svelte
+++ b/frontend/src/routes/admin/media/+page.svelte
@@ -14,6 +14,7 @@
 	import DropZone from '$lib/components/admin/DropZone.svelte';
 	import MediaPreviewModal from '$lib/components/admin/MediaPreviewModal.svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 
 	type MediaUsageItem = {
 		collection: string;
@@ -1055,7 +1056,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.media.page_title')}</title>
+	<title>{$t('admin.media.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-6xl mx-auto">

--- a/frontend/src/routes/admin/newsletter/+page.svelte
+++ b/frontend/src/routes/admin/newsletter/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 
 	type Stats = {
@@ -65,7 +66,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.newsletter.hub_title')} | Facet</title>
+	<title>{$t('admin.newsletter.hub_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto space-y-6">

--- a/frontend/src/routes/admin/newsletter/compose/+page.svelte
+++ b/frontend/src/routes/admin/newsletter/compose/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { beforeNavigate } from '$app/navigation';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 	import { marked } from 'marked';
@@ -381,7 +382,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.newsletter.compose_title')} | Facet</title>
+	<title>{$t('admin.newsletter.compose_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto space-y-6">

--- a/frontend/src/routes/admin/newsletter/lists/+page.svelte
+++ b/frontend/src/routes/admin/newsletter/lists/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 
@@ -270,7 +271,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.newsletter_lists.page_title')} | Facet</title>
+	<title>{$t('admin.newsletter_lists.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="mx-auto max-w-5xl space-y-6">

--- a/frontend/src/routes/admin/posts/+page.svelte
+++ b/frontend/src/routes/admin/posts/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 import { pb, type Post, getFileUrl } from '$lib/pocketbase';
 import { t } from 'svelte-i18n';
+import { brandName } from '$lib/stores/plan';
 import { collection } from '$lib/stores/demo';
 import { toasts, confirm } from '$lib/stores';
 import { createAutosave } from '$lib/stores/autosave';
@@ -400,7 +401,7 @@ function openEditForm(post: Post) {
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.posts.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.posts.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/projects/+page.svelte
+++ b/frontend/src/routes/admin/projects/+page.svelte
@@ -8,6 +8,7 @@
 	import ReorderAnnouncer from '$lib/components/admin/ReorderAnnouncer.svelte';
 	import { pb, type Project, type Experience, type Education, getFileUrl } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -589,7 +590,7 @@ let filteredProjects = $derived(
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.projects.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.projects.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/review/[id]/+page.svelte
+++ b/frontend/src/routes/admin/review/[id]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
@@ -171,7 +173,7 @@
 </script>
 
 <svelte:head>
-	<title>Review Import | Facet</title>
+	<title>{$t('admin.review.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/settings/about/+page.svelte
+++ b/frontend/src/routes/admin/settings/about/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import {
 		latestVersion,
@@ -242,7 +243,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.about_page.page_title')}</title>
+	<title>{$t('admin.about_page.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto p-6">

--- a/frontend/src/routes/admin/settings/account/+page.svelte
+++ b/frontend/src/routes/admin/settings/account/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { toasts } from '$lib/stores';
 	import QRCode from 'qrcode';
 	import PageHelp from '$components/admin/PageHelp.svelte';
@@ -221,7 +222,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.settings_page.account.section_title')} - {$t('admin.settings_page.page_title_suffix')}</title>
+	<title>{$t('admin.settings_page.account.section_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/settings/features/+page.svelte
+++ b/frontend/src/routes/admin/settings/features/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { toasts } from '$lib/stores';
 
 	let loading = $state(true);
@@ -86,7 +87,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.settings.features.title')} - Facet</title>
+	<title>{$t('admin.settings.features.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-3xl mx-auto">

--- a/frontend/src/routes/admin/settings/integrations/+page.svelte
+++ b/frontend/src/routes/admin/settings/integrations/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { toasts, confirm } from '$lib/stores';
 	import PageHelp from '$components/admin/PageHelp.svelte';
 	import { icon } from '$lib/icons';
@@ -248,7 +249,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.settings_page.integrations.section_title')} - {$t('admin.settings_page.page_title_suffix')}</title>
+	<title>{$t('admin.settings_page.integrations.section_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/settings/payments/+page.svelte
+++ b/frontend/src/routes/admin/settings/payments/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { toasts } from '$lib/stores';
 	import { hasFeature } from '$lib/stores/plan';
 
@@ -174,7 +175,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.settings_page.payments.title')} - {$t('admin.settings_page.page_title_suffix')}</title>
+	<title>{$t('admin.settings_page.payments.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/settings/site/+page.svelte
+++ b/frontend/src/routes/admin/settings/site/+page.svelte
@@ -4,6 +4,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { pb, type Profile } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { icon } from '$lib/icons';
@@ -419,7 +420,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.settings_page.title')} - {$t('admin.settings_page.page_title_suffix')}</title>
+	<title>{$t('admin.settings_page.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/settings/tags/+page.svelte
+++ b/frontend/src/routes/admin/settings/tags/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { toasts, confirm } from '$lib/stores';
 	import { TAG_COLORS, TAG_COLOR_LIST, type TagColor } from '$lib/colors';
 	import AdminTagBadge from '$components/admin/AdminTagBadge.svelte';
@@ -115,7 +116,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.tags_page.title')} {$t('admin.tags_page.page_title_suffix')}</title>
+	<title>{$t('admin.tags_page.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-3xl mx-auto">

--- a/frontend/src/routes/admin/settings/webhooks/+page.svelte
+++ b/frontend/src/routes/admin/settings/webhooks/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { pb } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { toasts, confirm } from '$lib/stores';
 
 	type Webhook = {
@@ -355,7 +356,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.webhooks.page_title')}</title>
+	<title>{$t('admin.webhooks.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-6xl mx-auto px-4 py-6">

--- a/frontend/src/routes/admin/skills/+page.svelte
+++ b/frontend/src/routes/admin/skills/+page.svelte
@@ -8,6 +8,7 @@
 	import { pb, type Skill } from '$lib/pocketbase';
 	import ReorderAnnouncer from '$lib/components/admin/ReorderAnnouncer.svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -552,7 +553,7 @@ async function loadCategoryOrder() {
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.skills.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.skills.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/subscribers/+page.svelte
+++ b/frontend/src/routes/admin/subscribers/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 
@@ -259,7 +260,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.subscribers.page_title')} | Facet</title>
+	<title>{$t('admin.subscribers.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto space-y-6">

--- a/frontend/src/routes/admin/subscribers/compose/+page.svelte
+++ b/frontend/src/routes/admin/subscribers/compose/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { beforeNavigate } from '$app/navigation';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 	import { marked } from 'marked';
@@ -318,7 +319,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.newsletter.compose_title')} | Facet</title>
+	<title>{$t('admin.newsletter.compose_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto space-y-6">

--- a/frontend/src/routes/admin/talks/+page.svelte
+++ b/frontend/src/routes/admin/talks/+page.svelte
@@ -5,6 +5,7 @@
 	import { afterNavigate } from '$app/navigation';
 	import { pb, type Talk } from '$lib/pocketbase';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
 	import { createAutosave } from '$lib/stores/autosave';
@@ -354,7 +355,7 @@ afterNavigate(() => {
 </script>
 
 <svelte:head>
-	<title>{$t('admin.content.talks.title')} {$t('admin.content.common.page_title_suffix')}</title>
+	<title>{$t('admin.content.talks.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/testimonials/+page.svelte
+++ b/frontend/src/routes/admin/testimonials/+page.svelte
@@ -4,6 +4,7 @@
 	import { toasts, confirm } from '$lib/stores';
 	import { scheduleTestimonialsRefresh } from '$lib/stores/testimonials';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 
 	interface Testimonial {
 		id: string;
@@ -217,7 +218,7 @@
 </script>
 
 <svelte:head>
-	<title>Testimonials | Admin</title>
+	<title>{$t('admin.content.testimonials.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/testimonials/requests/+page.svelte
+++ b/frontend/src/routes/admin/testimonials/requests/+page.svelte
@@ -4,6 +4,7 @@
 	import { pb } from '$lib/pocketbase';
 	import { toasts, confirm } from '$lib/stores';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 
 	interface TestimonialRequest {
 		id: string;
@@ -175,7 +176,7 @@
 </script>
 
 <svelte:head>
-	<title>Request Links | Testimonials | Admin</title>
+	<title>{$t('admin.testimonials.requests_page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/tokens/+page.svelte
+++ b/frontend/src/routes/admin/tokens/+page.svelte
@@ -8,6 +8,7 @@
 	import { icon } from '$lib/icons';
 	import PageHelp from '$components/admin/PageHelp.svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 
 	let loading = $state(true);
 	let tokens: ShareToken[] = $state([]);
@@ -303,7 +304,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.tokens.page_title')}</title>
+	<title>{$t('admin.tokens.page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-4xl mx-auto">

--- a/frontend/src/routes/admin/views/+page.svelte
+++ b/frontend/src/routes/admin/views/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import { pb, type View, type ShareToken } from '$lib/pocketbase';
 	import { collection } from '$lib/stores/demo';
 	import { toasts, confirm } from '$lib/stores';
@@ -332,7 +333,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('admin.views.title')} | Facet</title>
+	<title>{$t('admin.views.title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="max-w-5xl mx-auto">

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -20,6 +20,7 @@
 	import ViewSectionManager from '$components/admin/view-editor/ViewSectionManager.svelte';
 	import AdminTagBadge from '$components/admin/AdminTagBadge.svelte';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import type { OverrideEditorState, ResumeGenerationConfig, ExportRecord } from '$lib/view-editor/types';
 
 	// Default section definitions - used to initialize and provide labels
@@ -1014,7 +1015,7 @@
 </script>
 
 <svelte:head>
-	<title>Edit Facet | Facet</title>
+	<title>{$t('admin.views.edit_page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="view-editor-container">

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -16,6 +16,7 @@
 	import { ACCENT_COLORS, ACCENT_COLOR_LIST, type AccentColor } from '$lib/colors';
 	import { FONT_PACKS, FONT_PACK_LIST, type FontPack } from '$lib/fonts';
 	import { t } from 'svelte-i18n';
+	import { brandName } from '$lib/stores/plan';
 	import VisibilitySelector from '$components/admin/VisibilitySelector.svelte';
 
 	// Import DnD safely - only in browser
@@ -591,7 +592,7 @@
 </script>
 
 <svelte:head>
-	<title>Create Facet | Facet</title>
+	<title>{$t('admin.views.create_page_title')} | {$brandName}</title>
 </svelte:head>
 
 <div class="view-editor-container">


### PR DESCRIPTION
## Summary
Normalizes every admin `<title>` to the consistent form `{PageName} | {$brandName}` for a predictable SPA route-announcer experience (WCAG 2.4.2 On Focus / page-title consistency). Admin pages previously used 4 inconsistent formats: hardcoded `| Facet`, `| {$brandName}`, a translated ` page_title_suffix`, ` - {suffix}`, and several BARE titles with no brand at all.

## Changes
- All 38 non-conformant admin `+page.svelte` titles standardized to `{$t(pageNameKey)} | {$brandName}`, importing `brandName` from `$lib/stores/plan` (the same store the already-correct pages use). The 4 pages already in the target form (coupons, courses, help, pricing) were left untouched.
- Page-name strings stay in i18n (`$t()`); no new hardcoded English. Six previously hardcoded-English titles (Homepage, Review Import, Create/Edit Facet, Testimonials, Request Links) now use i18n keys. New keys added to all 5 locales (`admin.review.page_title`, `admin.views.create_page_title`, `admin.views.edit_page_title`, `admin.homepage.page_title`, `admin.testimonials.requests_page_title`); the Testimonials hub reuses the existing `admin.content.testimonials.title`.
- Public site titles untouched (only `routes/admin/**`).

## Certification
- `npm run check`: 0 errors, 0 warnings
- `npm run build`: succeeds
- `npm run i18n:validate`: 100% coverage, all locales OK