### PR TITLE
fix(a11y): key curriculum rows + announce moves (prevents wrong-record edits)

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -835,6 +835,8 @@
 			"lesson_preview": "Vorschaulektion (vor dem Kauf verfuegbar)",
 			"reorder_modules": "Module neu ordnen",
 			"reorder_lessons": "Lektionen neu ordnen",
+			"module_moved_announce": "Modul {title} an Position {position} von {total} verschoben",
+			"lesson_moved_announce": "Lektion {title} an Position {position} von {total} verschoben",
 			"select": "Auswaehlen",
 			"section_publishing": "Veroeffentlichung",
 			"section_details": "Kursdetails",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -835,6 +835,8 @@
 			"lesson_preview": "Cenie lektiona (cen ere manca)",
 			"reorder_modules": "Satya Rannar",
 			"reorder_lessons": "Satya Lektionar",
+			"module_moved_announce": "Ranna {title} mennen na nan {position} o {total}",
+			"lesson_moved_announce": "Lektion {title} mennen na nan {position} o {total}",
 			"select": "Cire",
 			"section_publishing": "Vistala",
 			"section_details": "Tirelya Entar",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -983,6 +983,8 @@
 			"lesson_preview": "Preview lesson (available before purchase)",
 			"reorder_modules": "Reorder Modules",
 			"reorder_lessons": "Reorder Lessons",
+			"module_moved_announce": "Moved module {title} to position {position} of {total}",
+			"lesson_moved_announce": "Moved lesson {title} to position {position} of {total}",
 			"select": "Select",
 			"section_publishing": "Publishing",
 			"section_details": "Course Details",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -835,6 +835,8 @@
 			"lesson_preview": "legh paQDI'norgh (je' pagh poQ)",
 			"reorder_modules": "bobcho' tlhej mIw",
 			"reorder_lessons": "paQDI'norgh tlhej mIw",
+			"module_moved_announce": "bobcho' {title} Daq {position} vo' {total} vIHpu'",
+			"lesson_moved_announce": "paQDI'norgh {title} Daq {position} vo' {total} vIHpu'",
 			"select": "wIv",
 			"section_publishing": "ngeH",
 			"section_details": "ghojmeH Segh",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -835,6 +835,8 @@
 			"lesson_preview": "Peek lesson (can see b4 buyin)",
 			"reorder_modules": "Move Chapterz Around",
 			"reorder_lessons": "Move Lessonz Around",
+			"module_moved_announce": "Movd chapter {title} 2 spot {position} ov {total}",
+			"lesson_moved_announce": "Movd lesson {title} 2 spot {position} ov {total}",
 			"select": "Pik",
 			"section_publishing": "Publishin",
 			"section_details": "Lernin Deetailz",

--- a/frontend/src/routes/admin/courses/+page.svelte
+++ b/frontend/src/routes/admin/courses/+page.svelte
@@ -17,9 +17,13 @@
 	import Toggle from '$components/admin/Toggle.svelte';
 	import VisibilitySelector from '$components/admin/VisibilitySelector.svelte';
 	import AccessTierSelect from '$components/admin/AccessTierSelect.svelte';
+	import ReorderAnnouncer from '$lib/components/admin/ReorderAnnouncer.svelte';
 	import { pb } from '$lib/pocketbase';
 
 	const hasCourses = hasFeature('courses');
+
+	// Shared screen-reader announcer for keyboard curriculum reorder (modules + lessons).
+	let reorderAnnouncer = $state<ReorderAnnouncer | undefined>(undefined);
 
 	type Course = {
 		id: string;
@@ -778,6 +782,12 @@
 				pb.collection('modules').update(targetModule.id, { sort_order: module.sort_order })
 			]);
 			await loadCurriculum(editingCourse.id);
+			// Announce the new position (1-based) for screen-reader users.
+			reorderAnnouncer?.announce(
+				$t('admin.courses.module_moved_announce', {
+					values: { title: module.title, position: targetIndex + 1, total: courseModules.length }
+				})
+			);
 		} catch (err) {
 			console.error('Failed to reorder modules:', err);
 			toasts.add('error', $t('admin.courses.error_reorder_modules'));
@@ -1082,6 +1092,12 @@
 				pb.collection('lessons').update(targetLesson.id, { sort_order: lesson.sort_order })
 			]);
 			await loadCurriculum(editingCourse.id);
+			// Announce the new position (1-based) for screen-reader users.
+			reorderAnnouncer?.announce(
+				$t('admin.courses.lesson_moved_announce', {
+					values: { title: lesson.title, position: targetIndex + 1, total: moduleLessons.length }
+				})
+			);
 		} catch (err) {
 			console.error('Failed to reorder lessons:', err);
 			toasts.add('error', $t('admin.courses.error_reorder_lessons'));
@@ -1304,6 +1320,8 @@
 			<!-- Curriculum tab -->
 			{#if activeTab === 'curriculum'}
 			<div class="card rounded-t-none border-t border-gray-200 dark:border-gray-700 p-6 space-y-4">
+				<!-- Polite live region for keyboard module/lesson reorder announcements -->
+				<ReorderAnnouncer bind:this={reorderAnnouncer} />
 				<div class="flex items-center justify-between">
 					<h2 class="text-lg font-semibold text-gray-900 dark:text-white">{$t('admin.courses.tab_curriculum')}</h2>
 					{#if editingCourse}
@@ -1402,7 +1420,7 @@
 						</div>
 					{:else}
 						<div class="space-y-4">
-							{#each courseModules as module, moduleIndex}
+							{#each courseModules as module, moduleIndex (module.id)}
 								<div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
 									<!-- Module Header -->
 									<div class="flex items-center gap-3 px-4 py-3 bg-gray-50 dark:bg-gray-800/50">
@@ -1457,7 +1475,7 @@
 											{/if}
 
 											<!-- Lesson List -->
-											{#each courseLessons[module.id] || [] as lesson, lessonIndex}
+											{#each courseLessons[module.id] || [] as lesson, lessonIndex (lesson.id)}
 												<div class="border border-gray-100 dark:border-gray-700 rounded-lg">
 													<!-- Lesson Header -->
 													<div class="flex items-center gap-3 px-3 py-2">


### PR DESCRIPTION
## Problem (A2 - data-safety accessibility bug)

In \`admin/courses/+page.svelte\` the curriculum module list and lesson list were rendered with **unkeyed** \`{#each}\` blocks. After a keyboard "Move up/down" reorder, Svelte rebinds rows positionally, so focus could land on a button now controlling a **different** record. A keyboard user could delete or edit the wrong module/lesson. The page also had **zero** move announcements, so screen-reader users got no feedback that a reorder happened.

## Fix

- Add stable keys: \`{#each courseModules as module, moduleIndex (module.id)}\` and \`{#each courseLessons[module.id] || [] as lesson, lessonIndex (lesson.id)}\`. Focus now stays with the moved record's button.
- Reuse the existing \`ReorderAnnouncer\` component (same pattern as \`HomepageSectionManager.svelte\`) and announce the new position inside the existing \`moveModule\` / \`moveLesson\` handlers via a polite \`aria-live\` region.
- Added two i18n keys (\`module_moved_announce\`, \`lesson_moved_announce\`) to all 5 locales (en/de/elvish/klingon/lolcat).

Persistence logic is unchanged - this is purely keying + announcing.

## Certification (frontend/)

- \`npm run check\`: 0 errors, 0 warnings
- \`npm run build\`: succeeds
- \`npm run i18n:validate\`: 100% across all locales