### PR TITLE
test(e2e): serialize single-tenant suite to fix design-state contamination

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
 	expect: {
 		timeout: 5_000
 	},
+	// These E2E specs drive ONE single-tenant instance with shared global state
+	// (the site_settings.design mode, nav mode, etc.). Parallel workers mutating
+	// that single record interleave and contaminate each other — e.g. one spec
+	// sets soft-premium while another asserts classic. Run serially so each test
+	// owns the instance state for its duration.
+	fullyParallel: false,
+	workers: 1,
 	retries: process.env.CI ? 2 : 0,
 	use: {
 		baseURL: uiBaseURL,

--- a/frontend/tests/design-switch.spec.ts
+++ b/frontend/tests/design-switch.spec.ts
@@ -34,11 +34,19 @@ test.describe('Visual Design switch (/admin product)', () => {
 	});
 
 	test.afterEach(async ({ page }) => {
-		// Always restore Classic so the instance is left in its default state.
+		// Always restore Classic AND wait for the server to persist it, so the
+		// next spec file (sharing this instance) starts from a clean classic
+		// state instead of racing an unsaved change.
 		const classic = page.locator('[role="radio"]', { hasText: 'Classic' }).first();
 		if ((await classic.getAttribute('aria-checked')) === 'false') {
+			const saved = page.waitForResponse(
+				(r) =>
+					r.url().includes('/api/site-settings') &&
+					r.request().method() === 'PUT' &&
+					r.ok()
+			);
 			await classic.click();
-			await page.waitForTimeout(500);
+			await saved;
 		}
 	});
 

--- a/frontend/tests/soft-premium-accent-default.spec.ts
+++ b/frontend/tests/soft-premium-accent-default.spec.ts
@@ -23,7 +23,17 @@ async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
 	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
 	const radio = page.locator('[role="radio"]', { hasText: label }).first();
 	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		// Wait for the server PUT to persist before returning — a following
+		// page.goto() reads design from the server (SSR) and would otherwise
+		// race the not-yet-saved change, contaminating cross-file batch runs.
+		const saved = page.waitForResponse(
+			(r) =>
+				r.url().includes('/api/site-settings') &&
+				r.request().method() === 'PUT' &&
+				r.ok()
+		);
 		await radio.click();
+		await saved;
 		await expect(radio).toHaveAttribute('aria-checked', 'true');
 	}
 }

--- a/frontend/tests/soft-premium-fonts.spec.ts
+++ b/frontend/tests/soft-premium-fonts.spec.ts
@@ -20,7 +20,17 @@ async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
 	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
 	const radio = page.locator('[role="radio"]', { hasText: label }).first();
 	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		// Wait for the server PUT to persist before returning — a following
+		// page.goto() reads design from the server (SSR) and would otherwise
+		// race the not-yet-saved change, contaminating cross-file batch runs.
+		const saved = page.waitForResponse(
+			(r) =>
+				r.url().includes('/api/site-settings') &&
+				r.request().method() === 'PUT' &&
+				r.ok()
+		);
 		await radio.click();
+		await saved;
 		await expect(radio).toHaveAttribute('aria-checked', 'true');
 	}
 }

--- a/frontend/tests/soft-premium-tokens.spec.ts
+++ b/frontend/tests/soft-premium-tokens.spec.ts
@@ -39,7 +39,17 @@ async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
 	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
 	const radio = page.locator('[role="radio"]', { hasText: label }).first();
 	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		// Wait for the server PUT to persist before returning — a following
+		// page.goto() reads design from the server (SSR) and would otherwise
+		// race the not-yet-saved change, contaminating cross-file batch runs.
+		const saved = page.waitForResponse(
+			(r) =>
+				r.url().includes('/api/site-settings') &&
+				r.request().method() === 'PUT' &&
+				r.ok()
+		);
 		await radio.click();
+		await saved;
 		await expect(radio).toHaveAttribute('aria-checked', 'true');
 	}
 }

--- a/frontend/tests/soft-premium-utils.spec.ts
+++ b/frontend/tests/soft-premium-utils.spec.ts
@@ -21,7 +21,17 @@ async function setDesign(page: Page, label: 'Classic' | 'Soft Premium') {
 	await page.waitForSelector('[aria-labelledby="design-style-heading"]', { timeout: 10_000 });
 	const radio = page.locator('[role="radio"]', { hasText: label }).first();
 	if ((await radio.getAttribute('aria-checked')) === 'false') {
+		// Wait for the server PUT to persist before returning — a following
+		// page.goto() reads design from the server (SSR) and would otherwise
+		// race the not-yet-saved change, contaminating cross-file batch runs.
+		const saved = page.waitForResponse(
+			(r) =>
+				r.url().includes('/api/site-settings') &&
+				r.request().method() === 'PUT' &&
+				r.ok()
+		);
 		await radio.click();
+		await saved;
 		await expect(radio).toHaveAttribute('aria-checked', 'true');
 	}
 }


### PR DESCRIPTION
## Problem
After the Soft Premium backport (#467) merged, the soft-premium / design-switch / accent-clamp / typography Playwright specs **fail intermittently when run as a batch but pass in isolation**.

## Root cause
These specs drive **one single-tenant instance** and mutate a **shared global setting** (`site_settings.design`). Playwright's default parallel workers interleave — one spec sets `soft-premium` while another asserts `classic` — corrupting each other's state. Confirmed: `--workers=1` makes the batch pass 16/16; default workers fails.

## Fix
- `playwright.config.ts`: `workers: 1` + `fullyParallel: false` (this suite is inherently stateful/serial).
- `setDesign()` / afterEach: await the server PUT (`waitForResponse`) instead of optimistic click + `waitForTimeout(500)`, so a following SSR page load can't race the unsaved change.

## Verified
Full soft-premium + design-switch + accent-clamp + typography batch: **16/16 via config** (no flag).

## Out of scope (separate triage — pre-existing, not design-related)
A full-suite run surfaced 7 unrelated failures: `backport-qa.spec.ts` AccentPicker/sidebar/reorder tests appear to assert against pre-redesign UI locations (e.g. expecting exactly 1 checked radio on `/admin/settings/site`, which now also hosts the theme-mode + design radiogroups), and `media-management.spec.ts` needs seeded media. These predate / are independent of this fix and warrant their own pass.