### PR TITLE
feat(admin): live site preview pane (port from Cloud)

### DIFF
--- a/frontend/src/components/admin/AdminHeader.svelte
+++ b/frontend/src/components/admin/AdminHeader.svelte
@@ -3,7 +3,12 @@
 	import { t } from 'svelte-i18n';
 	import { pb, currentUser, performLogout } from '$lib/pocketbase';
 	import { adminSidebarOpen } from '$lib/stores';
+	import { userPreferences } from '$lib/stores/userPreferences';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
+
+	function toggleLivePreview() {
+		userPreferences.setPref('livePreviewEnabled', !$userPreferences.livePreviewEnabled);
+	}
 
 	function toggleSidebar() {
 		adminSidebarOpen.update((v) => {
@@ -60,6 +65,32 @@
 				<span class="hidden sm:inline">{$t('admin.header.view_site')}</span>
 				<span class="sr-only">(opens in new tab)</span>
 			</a>
+
+			<!-- Live site preview toggle. Hidden on screens <lg because the
+			     right-column iframe is hidden at that breakpoint anyway —
+			     no value in toggling something invisible. -->
+			<button
+				type="button"
+				role="switch"
+				aria-checked={$userPreferences.livePreviewEnabled}
+				aria-label={$t('admin.header.live_preview_toggle')}
+				onclick={toggleLivePreview}
+				class="hidden lg:inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors {$userPreferences.livePreviewEnabled
+					? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-900/60'
+					: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
+				title={$t('admin.header.live_preview_toggle')}
+			>
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+				</svg>
+				<span class="hidden xl:inline">{$t('admin.header.live_preview_label')}</span>
+				<span aria-hidden="true" class="hidden xl:inline text-xs"
+					>{$userPreferences.livePreviewEnabled
+						? $t('admin.header.live_preview_on')
+						: $t('admin.header.live_preview_off')}</span
+				>
+			</button>
 
 			<ThemeToggle />
 

--- a/frontend/src/components/admin/LivePreview.svelte
+++ b/frontend/src/components/admin/LivePreview.svelte
@@ -1,0 +1,200 @@
+<!--
+  Live site preview iframe.
+
+  Renders the public profile homepage in a sandboxed iframe with a
+  debounced reload on PocketBase realtime updates to the profile record,
+  so the operator watches the public site update as they edit.
+
+  Behaviour:
+  - Realtime subscription is scoped to the specific profile record id
+    (not the wildcard `*` topic), keeping the subscription tight + cheap.
+  - Kill-switch via `VITE_DISABLE_LIVE_PREVIEW=1` at build time disables
+    the feature without touching source. Mounting is skipped entirely
+    when set.
+  - Iframe error events announce failure via the same polite live region
+    used for the ready announcement.
+  - If we can't resolve the profile record id (e.g. pre-seed), the
+    component still renders the iframe but skips the realtime
+    subscription — preview is static until manual reload, never crashes.
+
+  A11y design:
+  - iframe is tabindex=-1 (sandbox restricts interaction; sealing focus
+    out matches actual behavior and avoids a focus trap inside).
+  - Single sr-only note explains the preview is read-only.
+  - aria-busy on container during reload — no aria-live wrapper (would
+    spam SR users on every edit).
+  - One-time "ready" announcement on first load; one-time "unavailable"
+    on iframe error, both routed through a polite role="status" region.
+
+  Mounted only when the layout decides — see +layout.svelte. Default-OFF
+  means existing installs see zero behaviour change until the operator
+  opts in via the header toggle.
+-->
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { t } from 'svelte-i18n';
+	import { pb } from '$lib/pocketbase';
+	import { browser } from '$app/environment';
+
+	// Reload debounce: 400ms after PB realtime fires. Tuned so a fast typer
+	// saving every keystroke (autosave debounces internally) gets exactly
+	// one preview reload per coherent edit, not per keystroke.
+	const RELOAD_DEBOUNCE_MS = 400;
+
+	// Build-time kill switch. Set VITE_DISABLE_LIVE_PREVIEW=1 in .env to
+	// fully disable the feature without touching code. Default empty →
+	// enabled (subject to userPreferences toggle).
+	const KILL_SWITCH =
+		typeof import.meta.env !== 'undefined' &&
+		(import.meta.env.VITE_DISABLE_LIVE_PREVIEW === '1' ||
+			import.meta.env.VITE_DISABLE_LIVE_PREVIEW === 'true');
+
+	let iframeEl: HTMLIFrameElement | undefined = $state();
+	let busy = $state(false);
+	let firstLoadAnnounced = $state(false);
+	let errorAnnounced = $state(false);
+	let liveStatus = $state('');
+
+	// Bust the iframe cache on reload — appending a counter to the src
+	// forces a fresh fetch instead of relying on the browser's HTTP cache.
+	// The `preview=1` marker is ignored server-side but kept for parity.
+	let reloadCounter = $state(0);
+	let src = $derived(`/?preview=1&_=${reloadCounter}`);
+
+	let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+	let unsubscribeFn: (() => void) | null = null;
+
+	function scheduleReload() {
+		if (reloadTimer) clearTimeout(reloadTimer);
+		busy = true;
+		reloadTimer = setTimeout(() => {
+			reloadCounter += 1;
+			reloadTimer = null;
+		}, RELOAD_DEBOUNCE_MS);
+	}
+
+	function announce(message: string) {
+		liveStatus = message;
+		setTimeout(() => {
+			liveStatus = '';
+		}, 2000);
+	}
+
+	function handleIframeLoad() {
+		busy = false;
+		// Clear the error latch on a successful load so a later break→recover→break
+		// cycle re-announces the failure (WCAG 4.1.3) instead of going silent.
+		errorAnnounced = false;
+		if (!firstLoadAnnounced) {
+			// Throttled status: only the first successful load. Reloads
+			// after the user just typed don't need an announcement.
+			announce($t('admin.site_preview.ready_announce'));
+			firstLoadAnnounced = true;
+		}
+	}
+
+	function handleIframeError() {
+		busy = false;
+		if (!errorAnnounced) {
+			// One-shot error announcement so AT users hear when the preview
+			// breaks (e.g., CSP block, network failure, backend 503).
+			announce($t('admin.site_preview.error_announce'));
+			errorAnnounced = true;
+		}
+	}
+
+	onMount(async () => {
+		if (!browser || KILL_SWITCH) return;
+
+		// Narrow the realtime subscription to the single profile record.
+		// Subscribing to the specific record id (rather than the wildcard
+		// `*` topic) keeps the subscription tight + avoids fan-out from
+		// unrelated record-level writes.
+		//
+		// `requestKey: null` opts out of the PocketBase SDK's per-collection
+		// auto-cancellation. Other admin pages also fetch the profile
+		// collection at mount time, and the SDK cancels earlier in-flight
+		// calls to the same collection when a later one fires. Without
+		// `requestKey: null` our getList could lose the race and the
+		// subscribe path would never establish. One-shot retry on
+		// cancellation as belt-and-suspenders.
+		async function subscribeWithRetry(attempt = 0): Promise<void> {
+			try {
+				const records = await pb.collection('profile').getList(1, 1, { requestKey: null });
+				const profileId = records.items[0]?.id;
+				if (!profileId) {
+					// No profile record yet (rare — pre-seed). Render the
+					// iframe statically; operator can refresh manually.
+					return;
+				}
+				const unsub = await pb.collection('profile').subscribe(profileId, () => {
+					scheduleReload();
+				});
+				unsubscribeFn = unsub;
+			} catch (err) {
+				const msg = String(err);
+				const isAutoCancel = msg.includes('autocancelled') || msg.includes('aborted');
+				if (isAutoCancel && attempt < 2) {
+					// One backoff then retry. Auto-cancel happens when another
+					// page's same-collection fetch raced ahead of ours.
+					await new Promise((r) => setTimeout(r, 250 * (attempt + 1)));
+					return subscribeWithRetry(attempt + 1);
+				}
+				console.warn('[live-preview] realtime subscribe failed:', err);
+			}
+		}
+		await subscribeWithRetry();
+	});
+
+	onDestroy(() => {
+		if (reloadTimer) clearTimeout(reloadTimer);
+		if (unsubscribeFn) {
+			try {
+				unsubscribeFn();
+			} catch (err) {
+				console.warn('[live-preview] unsubscribe failed:', err);
+			}
+		}
+	});
+</script>
+
+{#if !KILL_SWITCH}
+	<aside class="live-preview-column min-w-0" aria-labelledby="site-preview-heading">
+		<h2 id="site-preview-heading" class="sr-only">{$t('admin.site_preview.heading')}</h2>
+		<span id="site-preview-note" class="sr-only">{$t('admin.site_preview.readonly_note')}</span>
+
+		<div
+			class="sticky top-20 h-[calc(100vh-6rem)] rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+			aria-busy={busy}
+		>
+			<iframe
+				bind:this={iframeEl}
+				title={$t('admin.site_preview.iframe_title')}
+				aria-describedby="site-preview-note"
+				{src}
+				loading="lazy"
+				sandbox="allow-same-origin allow-scripts"
+				referrerpolicy="same-origin"
+				tabindex="-1"
+				class="w-full h-full border-0 bg-white dark:bg-gray-800"
+			></iframe>
+		</div>
+
+		<!-- Polite, throttled status for screen readers. Fires once on first
+		     load and once on first error. -->
+		<div class="sr-only" role="status" aria-live="polite">{liveStatus}</div>
+	</aside>
+{/if}
+
+<style>
+	/* Opacity-only transition: width/transform shifts cause layout reflow
+	   that can trigger vestibular issues. */
+	.live-preview-column {
+		transition: opacity 150ms ease;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.live-preview-column {
+			transition: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/stores/userPreferences.ts
+++ b/frontend/src/lib/stores/userPreferences.ts
@@ -1,0 +1,74 @@
+/**
+ * User preferences store.
+ *
+ * Per-user toggles that should persist across sessions. Backed by
+ * localStorage under a single key (`facet-user-prefs`). Defaults are
+ * intentionally conservative — every new pref ships OFF until the user
+ * explicitly opts in, so existing installs see zero behavior change.
+ *
+ * Client-only: on the server `load()` returns DEFAULTS and `persist()` is
+ * a no-op.
+ */
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'facet-user-prefs';
+
+export interface UserPreferences {
+	/** When true, admin layout renders a right-column iframe of the public
+	 *  profile as a live preview. Default OFF. */
+	livePreviewEnabled: boolean;
+}
+
+const DEFAULTS: UserPreferences = {
+	livePreviewEnabled: false
+};
+
+function load(): UserPreferences {
+	if (!browser) return DEFAULTS;
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return DEFAULTS;
+		const parsed = JSON.parse(raw) as Partial<UserPreferences>;
+		return { ...DEFAULTS, ...parsed };
+	} catch {
+		return DEFAULTS;
+	}
+}
+
+function persist(value: UserPreferences): void {
+	if (!browser) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+	} catch {
+		/* localStorage quota or private-mode — ignore, in-memory only */
+	}
+}
+
+function createUserPreferencesStore() {
+	const { subscribe, set, update } = writable<UserPreferences>(load());
+
+	return {
+		subscribe,
+		set: (value: UserPreferences) => {
+			persist(value);
+			set(value);
+		},
+		/** Atomic update — passes current value, expects new value back. */
+		update: (updater: (current: UserPreferences) => UserPreferences) =>
+			update((current) => {
+				const next = updater(current);
+				persist(next);
+				return next;
+			}),
+		/** Convenience: set a single pref by key without mangling the rest. */
+		setPref: <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) =>
+			update((current) => {
+				const next = { ...current, [key]: value };
+				persist(next);
+				return next;
+			})
+	};
+}
+
+export const userPreferences = createUserPreferencesStore();

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1063,7 +1063,11 @@
       "demo": "Demo",
       "demo_on": "AN",
       "toggle_demo_mode": "Demo-Modus umschalten",
-      "opens_new_tab": "{label} (öffnet in neuem Tab)"
+      "opens_new_tab": "{label} (öffnet in neuem Tab)",
+      "live_preview_toggle": "Live-Vorschau umschalten",
+      "live_preview_label": "Vorschau",
+      "live_preview_on": "An",
+      "live_preview_off": "Aus"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "Einstellungen",
         "description": "Konto, Website, Integrationen und Entwicklertools."
       }
+    },
+    "site_preview": {
+      "heading": "Live-Vorschau",
+      "iframe_title": "Live-Vorschau Ihrer öffentlichen Seite",
+      "readonly_note": "Diese Vorschau ist schreibgeschützt und nicht per Tastatur bedienbar. Zum Ausblenden ausschalten.",
+      "ready_announce": "Live-Vorschau bereit",
+      "error_announce": "Live-Vorschau nicht verfügbar"
     }
   },
   "public": {

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -1063,7 +1063,11 @@
       "demo": "Demo",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggle demonstration",
-      "opens_new_tab": "{label} (opens in new window)"
+      "opens_new_tab": "{label} (opens in new window)",
+      "live_preview_toggle": "Toggle the living glimpse",
+      "live_preview_label": "Glimpse",
+      "live_preview_on": "Lit",
+      "live_preview_off": "Dimmed"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "Panod",
         "description": "Estel, nost, gonathra a tegil curu."
       }
+    },
+    "site_preview": {
+      "heading": "Living glimpse",
+      "iframe_title": "A living glimpse of your public realm",
+      "readonly_note": "This glimpse is for the eyes only, not the hand. Dim it to hide it away.",
+      "ready_announce": "Living glimpse made ready",
+      "error_announce": "The living glimpse is veiled"
     }
   },
   "public": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1210,7 +1210,11 @@
       "demo": "Demo",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggle demo mode",
-      "opens_new_tab": "{label} (opens in new tab)"
+      "opens_new_tab": "{label} (opens in new tab)",
+      "live_preview_toggle": "Toggle live preview",
+      "live_preview_label": "Preview",
+      "live_preview_on": "On",
+      "live_preview_off": "Off"
     },
     "password_modal": {
       "title": "Change Password",
@@ -2754,6 +2758,13 @@
         "title": "Settings",
         "description": "Account, site, integrations, and developer tools."
       }
+    },
+    "site_preview": {
+      "heading": "Live preview",
+      "iframe_title": "Live preview of your public site",
+      "readonly_note": "This preview is read-only and not keyboard accessible. Toggle off to hide it.",
+      "ready_announce": "Live preview ready",
+      "error_announce": "Live preview unavailable"
     }
   },
   "public": {

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -1063,7 +1063,11 @@
       "demo": "Training",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggle training mode",
-      "opens_new_tab": "{label} (opens in new viewport)"
+      "opens_new_tab": "{label} (opens in new viewport)",
+      "live_preview_toggle": "Toggle live battle preview",
+      "live_preview_label": "Preview",
+      "live_preview_on": "On",
+      "live_preview_off": "Off"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "choH",
         "description": "SeH, qach, rar, je chenmoHwI' jan."
       }
+    },
+    "site_preview": {
+      "heading": "Live battle preview",
+      "iframe_title": "Live preview of your public site",
+      "readonly_note": "This preview is read-only and not keyboard accessible. Toggle off to hide it. Qapla'!",
+      "ready_announce": "Live preview ready! Qapla'!",
+      "error_announce": "Live preview unavailable. Dishonorable!"
     }
   },
   "public": {

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -1063,7 +1063,11 @@
       "demo": "Demo",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggl demo moed",
-      "opens_new_tab": "{label} (openz in noo windoe)"
+      "opens_new_tab": "{label} (openz in noo windoe)",
+      "live_preview_toggle": "Toggle liv preview",
+      "live_preview_label": "Lookz",
+      "live_preview_on": "On",
+      "live_preview_off": "Off"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "Settingz",
         "description": "Akkount, sait, hookupz, an nerd toolz."
       }
+    },
+    "site_preview": {
+      "heading": "Liv preview",
+      "iframe_title": "Liv lookz at ur publik sait",
+      "readonly_note": "Dis preview iz lookz-only, no keyboardz. Toggle off 2 hide it.",
+      "ready_announce": "Liv preview redy!",
+      "error_announce": "Liv preview no can has. Sad kitteh."
     }
   },
   "public": {

--- a/frontend/src/routes/admin/+layout.svelte
+++ b/frontend/src/routes/admin/+layout.svelte
@@ -11,6 +11,8 @@
 	import { demoMode, initDemoMode, collection } from '$lib/stores/demo';
 	import AdminSidebar from '$components/admin/AdminSidebar.svelte';
 	import AdminHeader from '$components/admin/AdminHeader.svelte';
+	import LivePreview from '$components/admin/LivePreview.svelte';
+	import { userPreferences } from '$lib/stores/userPreferences';
 	import PasswordChangeModal from '$components/admin/PasswordChangeModal.svelte';
 	import TwoFactorModal from '$components/admin/TwoFactorModal.svelte';
 	import SetupWizard from '$components/admin/SetupWizard.svelte';
@@ -397,14 +399,20 @@
 
 			<AdminSidebar {isMobile} />
 
-			<!-- Main content: 
+			<!-- Main content:
 				- Mobile: full width (no margin)
 				- Desktop: margin-left based on sidebar state (preserves current behavior)
+				- When live preview is ON, allow main to shrink so the preview
+				  column gets reserved space at lg+. Below lg the preview is
+				  hidden via its own `lg:` gate so main stays full.
 			-->
 			<main
 				id="main-content"
 				class="flex-1 min-w-0 p-4 lg:p-6 mt-16 transition-all duration-200 overflow-x-clip w-full max-w-full
-					{isMobile ? '' : ($adminSidebarOpen ? 'lg:ml-64' : 'lg:ml-16')}"
+					{isMobile ? '' : ($adminSidebarOpen ? 'lg:ml-64' : 'lg:ml-16')}
+					{!isMobile && $userPreferences.livePreviewEnabled
+						? 'lg:max-w-[calc(50%-1rem)] xl:max-w-[calc(50%-1.5rem)]'
+						: ''}"
 			>
 				{#if showEncryptionWarning}
 					<div class="mb-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4" role="status">
@@ -431,6 +439,18 @@
 				{/if}
 				{@render children?.()}
 			</main>
+
+			<!-- Live site preview column.
+			     - Hidden via Tailwind `hidden lg:block` so mobile + tablet
+			       never render the iframe (no value on small screens; saves
+			       bandwidth + CPU on touch devices).
+			     - Mounted only when the toggle is ON. When OFF nothing renders
+			       (regression-safe). -->
+			{#if !isMobile && $userPreferences.livePreviewEnabled}
+				<div class="hidden lg:block flex-1 min-w-0 p-4 lg:p-6 mt-16">
+					<LivePreview />
+				</div>
+			{/if}
 		</div>
 
 			<SetupWizard />

--- a/frontend/tests/live-preview.spec.ts
+++ b/frontend/tests/live-preview.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Exercises the ported live-site preview: a header toggle (role=switch) that
+// opens a side column with a sandboxed iframe of the public homepage, with the
+// state persisted in localStorage. Desktop only (lg+).
+const BASE_URL =
+	process.env.PLAYWRIGHT_BASE_URL ?? process.env.VITE_POCKETBASE_URL ?? 'http://localhost:5173';
+const LOGIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const LOGIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'changeme123';
+
+async function login(page: Page) {
+	await page.goto(`${BASE_URL}/admin/login`);
+	await page.waitForSelector('input[type="email"]', { timeout: 10_000 });
+	await page.fill('input[type="email"]', LOGIN_EMAIL);
+	await page.fill('input[type="password"]', LOGIN_PASSWORD);
+	await page.click('button[type="submit"]');
+	await page.waitForURL((url) => /\/admin(\/|$)/.test(url.pathname) && !url.pathname.includes('/login'), {
+		timeout: 15_000
+	});
+}
+
+const toggle = (page: Page) => page.getByRole('switch', { name: 'Toggle live preview' });
+const previewFrame = (page: Page) => page.locator('iframe[title="Live preview of your public site"]');
+
+test.describe('Live site preview', () => {
+	test.beforeEach(async ({ page }) => {
+		await login(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		// Leave the preference off for the next test/file.
+		const t = toggle(page);
+		if ((await t.count()) > 0 && (await t.getAttribute('aria-checked')) === 'true') {
+			await t.click();
+		}
+	});
+
+	test('toggle is an accessible switch, off by default', async ({ page }) => {
+		const t = toggle(page);
+		await expect(t).toBeVisible();
+		await expect(t).toHaveAttribute('aria-checked', 'false');
+		// No preview iframe until enabled.
+		await expect(previewFrame(page)).toHaveCount(0);
+	});
+
+	test('enabling shows the sandboxed live-site iframe', async ({ page }) => {
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'true');
+		const frame = previewFrame(page);
+		await expect(frame).toBeVisible();
+		await expect(frame).toHaveAttribute('src', /\/\?preview=1/);
+		// Sealed from tab order (read-only pane).
+		await expect(frame).toHaveAttribute('tabindex', '-1');
+	});
+
+	test('preference persists across a reload (localStorage)', async ({ page }) => {
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'true');
+		await page.reload();
+		await page.waitForURL(/\/admin/);
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'true');
+		await expect(previewFrame(page)).toBeVisible();
+	});
+
+	test('disabling hides the preview column', async ({ page }) => {
+		await toggle(page).click();
+		await expect(previewFrame(page)).toBeVisible();
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'false');
+		await expect(previewFrame(page)).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
Ports Cloud's live-site preview. A header toggle (`role=switch`) opens a side column with a **sandboxed iframe of the public homepage that auto-reloads as you edit** (PocketBase realtime on the profile record, debounced; graceful static fallback if realtime is unavailable). The editor shrinks to ~50% at `lg+`; the existing 'View Site' link stays. Toggle state persists in localStorage. Build kill switch `VITE_DISABLE_LIVE_PREVIEW`.

## Files
- **New:** `components/admin/LivePreview.svelte`, `lib/stores/userPreferences.ts`
- **Edit:** `AdminHeader.svelte` (switch toggle), `routes/admin/+layout.svelte` (preview column + main shrink), `locales/*.json` (i18n ×5, namespaced `admin.header.live_preview_*` + `admin.site_preview.*` to avoid the existing view-editor `live_preview` keys)

## Accessibility
accessibility-lead reviewed all three files — **shippable**. Applied both required fixes: iframe `aria-describedby` → read-only note (1.3.1), and error-latch reset on successful load so a break→recover→break cycle re-announces (4.1.3). Switch semantics, throttled live-region announcements, `tabindex=-1` sealed read-only iframe, and reduced-motion all confirmed correct.

## Certification
svelte-check 0/0 · i18n 100% (all 5 locales) · build OK · `tests/live-preview.spec.ts` **4/4** (accessible switch off-by-default, iframe shows on enable with `preview=1`+`tabindex=-1`, persists across reload, hides on disable) · visually confirmed (side-by-side editor + live Soft Premium site).