### PR TITLE
feat: operator-settable text color for public profile (AAA by construction)

### DIFF
--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -751,6 +751,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 					"contact_links":   profile.Get("contact_links"),
 					"visibility":      profile.GetString("visibility"),
 					"accent_color":    profile.GetString("accent_color"),
+					"text_color":      profile.GetString("text_color"),
 					"font_pack":       profile.GetString("font_pack"),
 					"hero_layout":     profile.GetString("hero_layout"),
 					"hero_spacing":    profile.GetString("hero_spacing"),
@@ -961,6 +962,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 						"accent_color":     p.GetString("accent_color"),
 						"custom_hex_color": p.GetString("custom_hex_color"),
 						"font_pack":        p.GetString("font_pack"),
+						"text_color":       p.GetString("text_color"),
 					}
 				}
 
@@ -989,6 +991,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 					"contact_links":   profile.Get("contact_links"),
 					"visibility":      profile.GetString("visibility"),
 					"accent_color":    profile.GetString("accent_color"),
+					"text_color":      profile.GetString("text_color"),
 					"font_pack":       profile.GetString("font_pack"),
 					"hero_layout":     profile.GetString("hero_layout"),
 					"hero_spacing":    profile.GetString("hero_spacing"),

--- a/backend/migrations/1779200000_add_text_color.go
+++ b/backend/migrations/1779200000_add_text_color.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Adds a nullable text_color TextField to the profile collection.
+//
+// text_color holds the operator's chosen body/heading text hue as #RRGGBB (empty
+// = default neutral ink). The frontend derives a per-mode, hue-preserved, AAA
+// (7:1) clamped ink from this hue (deriveTextInk in colors.ts) and injects it as
+// --text-ink / --text-ink-dark, so the operator's hue is honored while contrast
+// can never fall below AAA. Empty ⇒ nothing injected ⇒ render unchanged, so
+// existing instances are byte-identical until an operator opts in.
+func init() {
+	m.Register(func(app core.App) error {
+		profileCollection, err := app.FindCollectionByNameOrId("profile")
+		if err != nil {
+			// Collection doesn't exist, nothing to do.
+			return nil
+		}
+
+		if profileCollection.Fields.GetByName("text_color") == nil {
+			profileCollection.Fields.Add(&core.TextField{
+				Name:    "text_color",
+				Max:     7, // #RRGGBB
+				Pattern: `^#[0-9a-fA-F]{6}$`,
+			})
+
+			if err := app.Save(profileCollection); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, func(app core.App) error {
+		profileCollection, err := app.FindCollectionByNameOrId("profile")
+		if err != nil {
+			return nil
+		}
+
+		if f := profileCollection.Fields.GetByName("text_color"); f != nil {
+			profileCollection.Fields.RemoveById(f.GetId())
+			return app.Save(profileCollection)
+		}
+
+		return nil
+	})
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -111,6 +111,65 @@
 	color: var(--ink);
 }
 
+/* ==========================================================================
+   Operator text (font) color — enhanced contrast (WCAG 2.2 SC 1.4.6, Level AAA)
+   by construction.
+
+   Scope of the AAA claim: this guarantees SC 1.4.6 (Contrast Enhanced, 7:1) for
+   the tinted heading + body text only. It does NOT assert full-page Level AAA
+   (e.g. 1.4.8 Visual Presentation, 2.4.13 Focus Appearance are out of scope and
+   untouched here).
+
+   The operator picks a hue; hooks.server.ts derives a per-mode, hue-preserved,
+   7:1-clamped ink (deriveTextInk in colors.ts) and injects it as --text-ink
+   (light) and --text-ink-dark (dark). These rules tint HEADINGS + BODY text on
+   the PUBLIC profile only, and leave surfaces / borders / icons / muted chrome
+   neutral for hierarchy.
+
+   WHY this mechanism (vs retinting the --gray-N ramp): gray-700/800/900 also
+   back some dark-mode surfaces, borders and icon fills, so warming the ramp
+   would bleed the hue into non-text chrome. Instead we override only the TEXT
+   utilities used for headings + body, scoped to public content.
+
+   Specificity: a plain `body { color }` loses to Tailwind's `.text-gray-900`.
+   These selectors compound a public-scope class with the utility class (and the
+   block is UNLAYERED, so it also beats @layer utilities), so they reliably win
+   on real text elements.
+
+   Gating + no-op default: the ENTIRE block is scoped under `:root[data-text-ink]`,
+   an attribute hooks.server.ts adds to <html> ONLY when the operator set a color.
+   When no color is set, the attribute is absent and NONE of these rules exist in
+   the cascade — so each declaration's bare `color: var(--text-ink)` is never
+   reached and the default render is byte-identical to today (no fallback-value
+   drift on headings like .section-title). The attribute and the --text-ink vars
+   are always injected together.
+
+   Scope: applies to the public document body but NEVER inside `.admin-shell`
+   (admin chrome stays on its own neutral palette).
+   ========================================================================== */
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) :is(h1, h2, h3, h4, h5, h6),
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) .text-gray-900,
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) .text-gray-800,
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) .text-gray-700 {
+	color: var(--text-ink);
+}
+
+/* Dark mode: headings use `dark:text-white`, body uses `dark:text-gray-300/200`.
+   Override those to the lightened dark ink. Only present when the attribute is
+   set, so an un-set color is a no-op. */
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) :is(h1, h2, h3, h4, h5, h6),
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) .dark\:text-white,
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) .dark\:text-gray-200,
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) .dark\:text-gray-300 {
+	color: var(--text-ink-dark);
+}
+
+/* MUTED text (gray-500/600 light, gray-400/500 dark) is intentionally LEFT
+   NEUTRAL — see PR notes / contrast review. Keeping muted neutral preserves the
+   visual hierarchy (primary text takes the hue, secondary text recedes) and
+   avoids muted+hue combinations drifting toward the 7:1 floor. The absence of a
+   rule here is deliberate. */
+
 @layer base {
 	/* ==========================================================================
 	   Accent Color CSS Custom Properties
@@ -189,7 +248,7 @@
 		--chip: #ece4de;
 		--ink: #2a2522;
 		--muted: #5a524d;
-		--border: #988e85; /* load-bearing (>=3:1) */
+		--border: #8f857c; /* load-bearing: 3.20:1 vs --surface-2 #faf4f0, 3.50:1 vs #ffffff */
 		--border-hairline: #ddd1ca; /* decorative only */
 		--border-interactive: #988e85;
 		/* Accent surfaces (creator accent, contrast-clamped by B2). */

--- a/frontend/src/components/admin/TextColorPicker.svelte
+++ b/frontend/src/components/admin/TextColorPicker.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+	/**
+	 * TextColorPicker — operator-settable body/heading text color for the public
+	 * profile, AAA-readable BY CONSTRUCTION.
+	 *
+	 * The operator picks a hue; deriveTextInk() clamps it per-mode (darken for
+	 * light, lighten for dark) so it always clears 7:1 against the lightest
+	 * surface text sits on. The picker shows the CLAMPED result live — what you
+	 * pick is what renders, and it is always readable.
+	 *
+	 * Accessibility:
+	 * - Curated suggestions follow the WAI-ARIA APG radio pattern (roving
+	 *   tabindex, arrow keys move focus + selection, Home/End jump).
+	 * - Hex input validates on blur (less noisy for screen readers); a persistent
+	 *   aria-live region announces commit + error.
+	 * - The live preview swatches carry text alternatives (not color-only).
+	 */
+	import { tick } from 'svelte';
+	import { t } from 'svelte-i18n';
+	import { isValidHexColor, deriveTextInk } from '$lib/colors';
+
+	let {
+		value = $bindable(''),
+		onchange
+	}: {
+		value?: string;
+		onchange?: (hex: string) => void;
+	} = $props();
+
+	// Curated, harmonious ink hues. Operators can still type any hex — these are
+	// just sensible starting points (warm + cool, all distinct from the accent).
+	const SUGGESTIONS: Array<{ hex: string; labelKey: string }> = [
+		{ hex: '#1f2937', labelKey: 'admin.text_color_picker.suggestion_slate' },
+		{ hex: '#3f3f46', labelKey: 'admin.text_color_picker.suggestion_graphite' },
+		{ hex: '#7c2d12', labelKey: 'admin.text_color_picker.suggestion_umber' },
+		{ hex: '#1e3a8a', labelKey: 'admin.text_color_picker.suggestion_navy' },
+		{ hex: '#14532d', labelKey: 'admin.text_color_picker.suggestion_forest' },
+		{ hex: '#581c87', labelKey: 'admin.text_color_picker.suggestion_plum' }
+	];
+
+	let swatchRefs: HTMLButtonElement[] = $state([]);
+	let hexInput = $state(value || '');
+	let hexError = $state('');
+	let announce = $state('');
+
+	const normalized = $derived(value && isValidHexColor(value) ? value : '');
+	// Live clamped inks — exactly what hooks.server.ts injects and the page renders.
+	const ink = $derived(normalized ? deriveTextInk(normalized) : null);
+
+	const selectedIndex = $derived(SUGGESTIONS.findIndex((s) => s.hex.toLowerCase() === normalized.toLowerCase()));
+	// Roving tabstop owner: the selected suggestion, else the first.
+	const focusedIndex = $derived(selectedIndex >= 0 ? selectedIndex : 0);
+
+	function normalizeHex(raw: string): string {
+		const trimmed = raw.trim();
+		if (!trimmed) return '';
+		return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+	}
+
+	function pick(hex: string) {
+		const norm = normalizeHex(hex);
+		value = norm;
+		hexInput = norm;
+		hexError = '';
+		announce = $t('admin.text_color_picker.announced', { values: { hex: norm } });
+		onchange?.(norm);
+	}
+
+	function commitHex() {
+		const norm = normalizeHex(hexInput);
+		if (!norm) {
+			value = '';
+			hexError = '';
+			announce = $t('admin.text_color_picker.announced_reset');
+			onchange?.('');
+			return;
+		}
+		if (!isValidHexColor(norm)) {
+			hexError = $t('admin.text_color_picker.invalid');
+			return;
+		}
+		hexError = '';
+		value = norm;
+		hexInput = norm;
+		announce = $t('admin.text_color_picker.announced', { values: { hex: norm } });
+		onchange?.(norm);
+	}
+
+	function handleHexInput(e: Event) {
+		hexInput = (e.currentTarget as HTMLInputElement).value;
+		if (hexError) hexError = '';
+	}
+
+	function reset() {
+		value = '';
+		hexInput = '';
+		hexError = '';
+		announce = $t('admin.text_color_picker.announced_reset');
+		onchange?.('');
+	}
+
+	async function handleSwatchKeyDown(e: KeyboardEvent) {
+		const last = SUGGESTIONS.length - 1;
+		let next = focusedIndex;
+		switch (e.key) {
+			case 'ArrowRight':
+			case 'ArrowDown':
+				next = focusedIndex >= last ? 0 : focusedIndex + 1;
+				break;
+			case 'ArrowLeft':
+			case 'ArrowUp':
+				next = focusedIndex <= 0 ? last : focusedIndex - 1;
+				break;
+			case 'Home':
+				next = 0;
+				break;
+			case 'End':
+				next = last;
+				break;
+			default:
+				return;
+		}
+		e.preventDefault();
+		pick(SUGGESTIONS[next].hex);
+		await tick();
+		swatchRefs[next]?.focus();
+	}
+</script>
+
+<fieldset class="space-y-4">
+	<legend class="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+		{$t('admin.text_color_picker.label')}
+	</legend>
+	<p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+		{$t('admin.text_color_picker.description')}
+	</p>
+
+	<!-- Curated suggestions — WAI-ARIA APG radio pattern with roving tabindex -->
+	<div
+		role="radiogroup"
+		aria-label={$t('admin.text_color_picker.suggestions_label')}
+		tabindex={-1}
+		class="flex flex-wrap gap-3"
+		onkeydown={handleSwatchKeyDown}
+	>
+		{#each SUGGESTIONS as s, i (s.hex)}
+			{@const isChecked = normalized.toLowerCase() === s.hex.toLowerCase()}
+			<button
+				type="button"
+				role="radio"
+				aria-checked={isChecked}
+				aria-label={$t(s.labelKey)}
+				tabindex={i === focusedIndex ? 0 : -1}
+				bind:this={swatchRefs[i]}
+				onclick={() => pick(s.hex)}
+				class="relative aspect-square w-12 h-12 rounded-xl border-2 transition-all duration-200 ring-offset-2 ring-offset-white dark:ring-offset-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 dark:focus-visible:ring-white {isChecked
+					? 'border-gray-900 dark:border-white scale-110'
+					: 'border-transparent hover:scale-105'}"
+				style="background-color: {s.hex}"
+			>
+				{#if isChecked}
+					<div class="absolute inset-0 flex items-center justify-center">
+						<svg class="w-5 h-5 text-white drop-shadow" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+						</svg>
+					</div>
+				{/if}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Custom hex input -->
+	<div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+		<label for="text-color-hex-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+			{$t('admin.text_color_picker.custom_label')}
+		</label>
+		<div class="flex items-center gap-2">
+			<span
+				class="inline-block w-11 h-11 rounded-lg border border-gray-300 dark:border-gray-600 shrink-0"
+				style="background-color: {normalized || '#ffffff'}"
+				aria-hidden="true"
+			></span>
+			<input
+				id="text-color-hex-input"
+				type="text"
+				bind:value={hexInput}
+				oninput={handleHexInput}
+				onblur={commitHex}
+				onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitHex(); } }}
+				placeholder={$t('admin.text_color_picker.custom_placeholder')}
+				maxlength="7"
+				spellcheck="false"
+				autocomplete="off"
+				autocapitalize="off"
+				autocorrect="off"
+				aria-invalid={hexError !== ''}
+				aria-describedby="text-color-hex-help text-color-hex-error"
+				class="input flex-1 font-mono"
+			/>
+			{#if normalized}
+				<button
+					type="button"
+					onclick={reset}
+					class="px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors min-h-11"
+				>
+					{$t('admin.text_color_picker.reset')}
+				</button>
+			{/if}
+		</div>
+		<p id="text-color-hex-help" class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+			{$t('admin.text_color_picker.custom_help')}
+		</p>
+		<p
+			id="text-color-hex-error"
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			class="text-sm text-red-600 dark:text-red-400 mt-1 min-h-[1.25rem]"
+		>
+			{hexError}
+		</p>
+	</div>
+
+	<!-- Live region for confirmation announcements (visually hidden) -->
+	<span class="sr-only" aria-live="polite" aria-atomic="true">{announce}</span>
+
+	<!-- Live CLAMPED preview — shows the actual rendered ink for both modes, so
+	     "what you pick is what you get, and it is always readable". -->
+	{#if ink}
+		<div class="rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 mt-4">
+			<span class="block px-4 pt-3 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide font-medium">
+				{$t('admin.text_color_picker.preview_label')}
+			</span>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-px bg-gray-200 dark:bg-gray-700 mt-3">
+				<!-- Light mode preview (clamped vs white surface) -->
+				<div class="p-4" style="background-color: #ffffff;">
+					<span class="block text-[10px] uppercase tracking-wide font-semibold mb-2" style="color: #6b7280;">
+						{$t('admin.text_color_picker.preview_light')} · {ink.light}
+					</span>
+					<span class="block text-lg font-bold" style="color: {ink.light};">
+						{$t('admin.text_color_picker.preview_heading')}
+					</span>
+					<span class="block text-sm" style="color: {ink.light};">
+						{$t('admin.text_color_picker.preview_body')}
+					</span>
+				</div>
+				<!-- Dark mode preview (clamped vs dark surface) -->
+				<div class="p-4" style="background-color: #221e1a;">
+					<span class="block text-[10px] uppercase tracking-wide font-semibold mb-2" style="color: #ada199;">
+						{$t('admin.text_color_picker.preview_dark')} · {ink.dark}
+					</span>
+					<span class="block text-lg font-bold" style="color: {ink.dark};">
+						{$t('admin.text_color_picker.preview_heading')}
+					</span>
+					<span class="block text-sm" style="color: {ink.dark};">
+						{$t('admin.text_color_picker.preview_body')}
+					</span>
+				</div>
+			</div>
+			<p class="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
+				{$t('admin.text_color_picker.aaa_note')}
+			</p>
+		</div>
+	{/if}
+</fieldset>

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import type { Handle } from '@sveltejs/kit';
 import PocketBase from 'pocketbase';
 import { PB_COOKIE_NAME } from '$lib/pocketbase';
-import { generateAccentCSSVars, SOFT_PREMIUM_DEFAULT_ACCENT } from '$lib/colors';
+import { generateAccentCSSVars, generateTextInkCSSVars, SOFT_PREMIUM_DEFAULT_ACCENT } from '$lib/colors';
 import { generateFontCSSVars, getGoogleFontsUrl, DEFAULT_FONT_PACK } from '$lib/fonts';
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -22,6 +22,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 	let operatorFontPack = '';
 	let operatorAccent = '';
 	let operatorCustomHex = '';
+	let operatorTextColor = '';
 	try {
 		const homepageRes = await fetch(`${pbUrl}/api/homepage`, {
 			headers: { 'X-Internal': 'true' }
@@ -31,8 +32,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 			operatorAccent = homepage.profile?.accent_color || '';
 			operatorCustomHex = homepage.profile?.custom_hex_color || '';
 			operatorFontPack = homepage.profile?.font_pack || '';
+			operatorTextColor = homepage.profile?.text_color || '';
 		}
 	} catch { /* silent - fallback to client-side application */ }
+
+	// Text (font) color: derive a per-mode AAA-clamped ink from the operator's
+	// chosen hue and inject --text-ink (light) + --text-ink-dark (dark). Empty ⇒
+	// '' ⇒ nothing injected ⇒ default render unchanged. The clamp lives in
+	// colors.ts (deriveTextInk) and is exercised by the AAA proof test.
+	const textInkCSSVars = generateTextInkCSSVars(operatorTextColor);
 
 	// Soft Premium is the only design — always on. The warm token layer keys off
 	// the data-design attribute, hardcoded where the <html> tag is composed below
@@ -79,6 +87,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 						.replace(/;?\s*$/, ';')
 				);
 			}
+			if (textInkCSSVars) {
+				varParts.push(
+					textInkCSSVars
+						.replace(/^:root\s*\{/, '')
+						.replace(/\}\s*$/, '')
+						.trim()
+						.replace(/\s+/g, ' ')
+						.replace(/;?\s*$/, ';')
+				);
+			}
 
 			let result = html;
 
@@ -86,6 +104,12 @@ export const handle: Handle = async ({ event, resolve }) => {
 			// attribute and the inline style vars both land. Soft Premium is always
 			// on, so data-design is always emitted.
 			const htmlAttrs: string[] = ['data-design="soft-premium"'];
+			// data-text-ink gates the scoped text-color rules in app.css. Present
+			// ONLY when the operator set a color, so the default render carries no
+			// text-ink rules at all (byte-identical to today).
+			if (textInkCSSVars) {
+				htmlAttrs.push('data-text-ink');
+			}
 			if (varParts.length > 0) {
 				htmlAttrs.push(`style="${varParts.join(' ')}"`);
 			}

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -498,6 +498,129 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 }
 
 /**
+ * AAA text-ink targets and reference surfaces.
+ *
+ * Body/heading text on the public profile can land on any of several surfaces in
+ * each mode. We clamp the operator's hue against the WORST-CASE surface — the one
+ * that yields the LOWEST contrast for that ink — so clearing 7:1 there guarantees
+ * AAA on every other surface text can land on, by construction.
+ *
+ * The worst case differs by mode because of which side of the surface the ink is:
+ *
+ *  - Light mode (ink is DARKER than the surface): contrast = (L_surf+0.05)/(L_ink+0.05),
+ *    which INCREASES with surface luminance. So the DARKEST light surface is the
+ *    worst case. Text lands on `--surface` (#ffffff), but also directly on the warm
+ *    `--bg` (#fbf8f4) and soft-premium `--bg` (#fef9f6), which are DARKER than white
+ *    and therefore LOWER-contrast for dark ink. The darkest of these is #fbf8f4
+ *    (L≈0.9418), so we clamp against it; clearing 7:1 on #fbf8f4 also clears the
+ *    lighter #fef9f6 and #ffffff automatically.
+ *  - Dark mode (ink is LIGHTER than the surface): contrast = (L_ink+0.05)/(L_surf+0.05),
+ *    which DECREASES with surface luminance. So the LIGHTEST dark surface is the
+ *    worst case. Text lands on `--surface` (#221e1a, L≈0.0134) and the darker `--bg`
+ *    (#1a1613, L≈0.0084); #221e1a is the lighter (higher-L) → worst case. Clearing
+ *    7:1 on #221e1a also clears it on the darker #1a1613.
+ *
+ * NOTE: if a future design token introduces a light-mode text surface DARKER than
+ * #fbf8f4, or a dark-mode surface LIGHTER than #221e1a, these constants must be
+ * updated — the guarantee is only as strong as "clamp against the worst-case
+ * surface." See tests/text-color-aaa.spec.ts for the regression proof.
+ */
+export const TEXT_INK_MIN_CONTRAST = 7;
+// Worst-case (lowest-contrast) surface per mode — see block comment above.
+// Light: darkest surface tinted text lands on (warm --bg), NOT white.
+const TEXT_INK_LIGHT_SURFACE = '#fbf8f4';
+// Dark: lightest dark surface tinted text lands on (dark --surface).
+const TEXT_INK_DARK_SURFACE = '#221e1a';
+
+/** Contrast ratio between two relative luminances (WCAG 2.x), order-independent. */
+function contrastRatio(l1: number, l2: number): number {
+	const hi = Math.max(l1, l2);
+	const lo = Math.min(l1, l2);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Derive a per-mode, hue-preserved, AAA-clamped text ink from an operator's hue.
+ *
+ * Returns `{ light, dark }` hex strings, both guaranteed to clear 7:1 against the
+ * WORST-CASE (lowest-contrast) surface text sits on in their respective modes (the
+ * warm `--bg` #fbf8f4 in light mode, the dark `--surface` #221e1a in dark mode).
+ *
+ * Mechanism (mirrors `clamp600`'s binary search): we only ever move lightness in
+ * the AAA-safe direction while keeping hue:
+ *  - Light ink: mix the hue toward BLACK (all channels scale toward 0 equally →
+ *    hue preserved) until contrast vs the warm --bg ≥ 7:1.
+ *  - Dark ink: mix the hue toward WHITE (all channels scale toward 255 equally →
+ *    hue preserved) until contrast vs the dark surface ≥ 7:1.
+ *
+ * Black (light) and white (dark) always satisfy 7:1, so each search terminates.
+ * Invalid input falls back to a neutral readable ink so the default never breaks.
+ */
+export function deriveTextInk(hex: string): { light: string; dark: string } {
+	if (!isValidHexColor(hex)) {
+		// Neutral, AAA-safe defaults (near-black on light, near-white on dark).
+		return { light: '#1a1613', dark: '#f4eee4' };
+	}
+	const r = parseInt(hex.slice(1, 3), 16);
+	const g = parseInt(hex.slice(3, 5), 16);
+	const b = parseInt(hex.slice(5, 7), 16);
+
+	const mix = (base: number, target: number, amount: number): number =>
+		Math.round(base + (target - base) * amount);
+	const toHex = (red: number, green: number, blue: number): string =>
+		'#' + [red, green, blue].map((c) => c.toString(16).padStart(2, '0')).join('');
+
+	const surfaceLum = (surface: string): number => {
+		const sr = parseInt(surface.slice(1, 3), 16);
+		const sg = parseInt(surface.slice(3, 5), 16);
+		const sb = parseInt(surface.slice(5, 7), 16);
+		return channelLuminance(sr, sg, sb);
+	};
+
+	// Binary-search the smallest mix `amount` (toward `target`) whose resulting ink
+	// clears 7:1 against `surface`. amount=0 is the raw hue; amount=1 is the target
+	// (black or white), which always passes — so the bracket [0,1] always contains
+	// a solution and the search converges.
+	const clamp = (target: number, surface: string): string => {
+		const surfL = surfaceLum(surface);
+		const inkLum = (amount: number): number =>
+			channelLuminance(mix(r, target, amount), mix(g, target, amount), mix(b, target, amount));
+		// Already AAA at the raw hue? Honor it exactly.
+		if (contrastRatio(inkLum(0), surfL) >= TEXT_INK_MIN_CONTRAST) {
+			return toHex(r, g, b);
+		}
+		let lo = 0;
+		let hi = 1;
+		for (let i = 0; i < 24; i++) {
+			const mAmt = (lo + hi) / 2;
+			if (contrastRatio(inkLum(mAmt), surfL) >= TEXT_INK_MIN_CONTRAST) hi = mAmt;
+			else lo = mAmt;
+		}
+		return toHex(mix(r, target, hi), mix(g, target, hi), mix(b, target, hi));
+	};
+
+	return {
+		light: clamp(0, TEXT_INK_LIGHT_SURFACE), // darken toward black
+		dark: clamp(255, TEXT_INK_DARK_SURFACE) // lighten toward white
+	};
+}
+
+/**
+ * Build the SSR `<style>`/inline CSS-var declarations for the operator's text
+ * color. Returns `--text-ink` (light value) and `--text-ink-dark` (dark value)
+ * as a `:root { ... }` block, or '' when no color is set (so the default render
+ * is byte-identical to today — nothing is injected, the scoped rule no-ops).
+ */
+export function generateTextInkCSSVars(textColor?: string | null): string {
+	if (!textColor || !isValidHexColor(textColor)) return '';
+	const { light, dark } = deriveTextInk(textColor);
+	return `:root {
+		--text-ink: ${light};
+		--text-ink-dark: ${dark};
+	}`;
+}
+
+/**
  * Generate CSS custom properties for accent color (works server-side, no DOM needed).
  * Returns a CSS string that can be injected into <style> tags for SSR.
  */

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "Akzentfarbe auf {hex} gesetzt",
       "announced_curated": "Akzentfarbe auf {name} gesetzt"
     },
+    "text_color_picker": {
+      "label": "Textfarbe",
+      "description": "Färbe Überschriften und Fließtext auf deiner öffentlichen Seite. Wir passen den Farbton automatisch an, damit er in hellem und dunklem Modus stets gut lesbar bleibt (WCAG AAA).",
+      "suggestions_label": "Vorgeschlagene Textfarben",
+      "suggestion_slate": "Schiefer",
+      "suggestion_graphite": "Graphit",
+      "suggestion_umber": "Umbra",
+      "suggestion_navy": "Marineblau",
+      "suggestion_forest": "Waldgrün",
+      "suggestion_plum": "Pflaume",
+      "custom_label": "Oder wähle eine eigene Hex-Farbe",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Sechs hexadezimale Zeichen (0-9, A-F), mit optionalem führenden #. Leer lassen für die Standardfarbe.",
+      "invalid": "Gib eine gültige Hex-Farbe ein (z. B. #1f2937)",
+      "reset": "Auf Standard zurücksetzen",
+      "preview_label": "Live-Vorschau (automatisch angepasst)",
+      "preview_light": "Heller Modus",
+      "preview_dark": "Dunkler Modus",
+      "preview_heading": "Überschrift",
+      "preview_body": "Hier steht ein Absatz Fließtext.",
+      "aaa_note": "Der angezeigte Farbton ist genau das, was auf deiner Seite erscheint. Er wird automatisch so begrenzt, dass er in jedem Modus einen Kontrast von 7:1 (WCAG AAA) zum Hintergrund erreicht.",
+      "announced": "Textfarbe auf {hex} gesetzt",
+      "announced_reset": "Textfarbe auf Standard zurückgesetzt",
+      "updated": "Textfarbe aktualisiert",
+      "error": "Textfarbe konnte nicht aktualisiert werden"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Facette bearbeiten",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "Accent color set to {hex}",
       "announced_curated": "Accent color set to {name}"
     },
+    "text_color_picker": {
+      "label": "Gwath i phith",
+      "description": "Maetho i tîw beleg a phith na i barth lîn. Cenim i gwath an i phith bain a thand (WCAG AAA) vi galad a vi dúath.",
+      "suggestions_label": "Gwaith i phith iestannen",
+      "suggestion_slate": "Gond Luin",
+      "suggestion_graphite": "Morn-glân",
+      "suggestion_umber": "Baran",
+      "suggestion_navy": "Luin-dûr",
+      "suggestion_forest": "Taur-laeg",
+      "suggestion_plum": "Gwaloth",
+      "custom_label": "Egor ceno gwath hej veleg",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Eneg tengw hex (0-9, A-F), na # ned-ohtar. Awartha an i gwath iaur.",
+      "invalid": "Anno gwath hex mae (sui #1f2937)",
+      "reset": "Danna an i gwath iaur",
+      "preview_label": "Tirith cuin (cennen)",
+      "preview_light": "Galad",
+      "preview_dark": "Dúath",
+      "preview_heading": "Têw beleg",
+      "preview_body": "Si nostach i phith o i barth.",
+      "aaa_note": "I gwath i cenich nan i gwath i thiâ nan i barth. Tortha cuin an i thand 7:1 (WCAG AAA) na i mbar vi pân lû.",
+      "announced": "Gwath i phith nan {hex}",
+      "announced_reset": "Gwath i phith danna an i gwath iaur",
+      "updated": "Gwath i phith cennen",
+      "error": "Ú-bell anno i gwath i phith"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Shape Facet",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1724,6 +1724,32 @@
       "announced_custom": "Accent color set to {hex}",
       "announced_curated": "Accent color set to {name}"
     },
+    "text_color_picker": {
+      "label": "Text color",
+      "description": "Tint headings and body text on your public page. We auto-adjust the shade so it always stays highly readable (WCAG AAA) in both light and dark mode.",
+      "suggestions_label": "Suggested text colors",
+      "suggestion_slate": "Slate",
+      "suggestion_graphite": "Graphite",
+      "suggestion_umber": "Umber",
+      "suggestion_navy": "Navy",
+      "suggestion_forest": "Forest",
+      "suggestion_plum": "Plum",
+      "custom_label": "Or pick a custom hex color",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Six hexadecimal characters (0-9, A-F), with optional leading #. Leave empty for the default ink.",
+      "invalid": "Enter a valid hex color (e.g. #1f2937)",
+      "reset": "Reset to default",
+      "preview_label": "Live preview (auto-adjusted)",
+      "preview_light": "Light mode",
+      "preview_dark": "Dark mode",
+      "preview_heading": "Heading text",
+      "preview_body": "Body paragraph text reads here.",
+      "aaa_note": "The shade shown is what renders on your page. It is automatically clamped to clear 7:1 contrast (WCAG AAA) against the background in each mode.",
+      "announced": "Text color set to {hex}",
+      "announced_reset": "Text color reset to default",
+      "updated": "Text color updated",
+      "error": "Failed to update text color"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Edit Facet",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "Accent color set to {hex}",
       "announced_curated": "Accent color set to {name}"
     },
+    "text_color_picker": {
+      "label": "ngutlh rItlh",
+      "description": "publicHom Daq nargh ngutlh 'ej porgh ngutlh yIrItlhmoH. rItlh wIchoHmoH 'e' wIlaDlaHchugh reH (WCAG AAA) wovbe' 'ej wovqu'.",
+      "suggestions_label": "ngutlh rItlh chuvmey",
+      "suggestion_slate": "nagh SuD",
+      "suggestion_graphite": "qIj",
+      "suggestion_umber": "Doq qIj",
+      "suggestion_navy": "SuD'a'",
+      "suggestion_forest": "ngem SuD",
+      "suggestion_plum": "naH Doq",
+      "custom_label": "pagh hex rItlh DawIv",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "jav hex mIllogh (0-9, A-F), # tlhItlh DaH. rItlh motlh chovnatlhlu' chugh chImmoH.",
+      "invalid": "lugh hex rItlh yIghItlh (#1f2937 rur)",
+      "reset": "rItlh motlh Daq yIchegh",
+      "preview_label": "ral leghlu' (choHlu')",
+      "preview_light": "wovbe'",
+      "preview_dark": "wovqu'",
+      "preview_heading": "ngutlh nIvbogh",
+      "preview_body": "naDev porgh ngutlh laDlu'.",
+      "aaa_note": "rItlh leghlu'bogh 'oH publicHomDaq nargh'e'. reH 7:1 (WCAG AAA) Hutlhmey DuvDaq choHchu'lu' Hoch Daq.",
+      "announced": "{hex} ngutlh rItlh",
+      "announced_reset": "rItlh motlh Daq ngutlh rItlh chegh",
+      "updated": "ngutlh rItlh choHlu'",
+      "error": "ngutlh rItlh choHlaHbe'"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Modify Facet",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "ACCENT COLOR SET 2 {hex}",
       "announced_curated": "ACCENT COLOR SET 2 {name}"
     },
+    "text_color_picker": {
+      "label": "Werdz Culah",
+      "description": "Maek ur big werdz an lil werdz on ur public payj haz culah. We fix teh shaed so it can reedz gud (WCAG AAA) in brite mode an dark mode.",
+      "suggestions_label": "Sugjestd werdz culahs",
+      "suggestion_slate": "Slaet",
+      "suggestion_graphite": "Pensil",
+      "suggestion_umber": "Brown",
+      "suggestion_navy": "Bloo",
+      "suggestion_forest": "Treez",
+      "suggestion_plum": "Plum",
+      "custom_label": "Or pik ur own hex culah",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Six hex letterz (0-9, A-F), wif optshunal # in frunt. Leev emptee for defalt ink.",
+      "invalid": "Givs a reel hex culah plz (liek #1f2937)",
+      "reset": "Bak to defalt",
+      "preview_label": "Liv peek (auto-fixd)",
+      "preview_light": "Brite mode",
+      "preview_dark": "Dark mode",
+      "preview_heading": "Big Werdz",
+      "preview_body": "Lil werdz go heer for reedin.",
+      "aaa_note": "Teh shaed u see iz wut showz on ur payj. We awtomatiklee skootch it til it haz 7:1 contrast (WCAG AAA) wif teh bakgrund in each mode.",
+      "announced": "Werdz culah iz now {hex}",
+      "announced_reset": "Werdz culah bak to defalt",
+      "updated": "Werdz culah chanjd",
+      "error": "Cudnt chanj werdz culah"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Edit Facet",

--- a/frontend/src/routes/admin/homepage/+page.svelte
+++ b/frontend/src/routes/admin/homepage/+page.svelte
@@ -15,6 +15,7 @@ import { brandName } from '$lib/stores/plan';
 	import MarkdownEditor from '$components/admin/MarkdownEditor.svelte';
 	import HomepageSectionManager from '$components/admin/HomepageSectionManager.svelte';
 	import AccentPicker from '$components/admin/AccentPicker.svelte';
+	import TextColorPicker from '$components/admin/TextColorPicker.svelte';
 	import AccordionSection from '$components/admin/forms/AccordionSection.svelte';
 	import { DEFAULT_ACCENT_COLOR, type AccentColor } from '$lib/colors';
 	import { FONT_PACKS, FONT_PACK_LIST, DEFAULT_FONT_PACK, type FontPack } from '$lib/fonts';
@@ -154,6 +155,7 @@ import { brandName } from '$lib/stores/plan';
 	let heroBgError = $state('');
 	let accentColor: AccentColor = $state(DEFAULT_ACCENT_COLOR);
 	let customHexColor: string = $state('');
+	let textColor: string = $state('');
 	let fontPack: FontPack = $state(DEFAULT_FONT_PACK);
 
 	const heroLayoutOptions = [
@@ -459,6 +461,7 @@ import { brandName } from '$lib/stores/plan';
 				heroBgColor = ((profile as unknown as { hero_bg_color?: string }).hero_bg_color) || '';
 				accentColor = ((profile as unknown as { accent_color?: string }).accent_color as AccentColor) || DEFAULT_ACCENT_COLOR;
 				customHexColor = (profile as unknown as { custom_hex_color?: string }).custom_hex_color || '';
+				textColor = (profile as unknown as { text_color?: string }).text_color || '';
 				fontPack = ((profile as unknown as { font_pack?: string }).font_pack as FontPack) || DEFAULT_FONT_PACK;
 
 				if (profile.avatar) {
@@ -512,6 +515,22 @@ import { brandName } from '$lib/stores/plan';
 		} catch (err) {
 			console.error('Failed to save custom hex color:', err);
 			toasts.add('error', $t('admin.settings_page.appearance.accent_color_error'));
+		}
+	}
+
+	// Text (font) color autosave. Empty string clears it back to the default ink.
+	// The derived AAA-clamped ink is computed SSR-side (deriveTextInk), so saving
+	// the raw hue is all that's needed; the public page re-derives on next load.
+	async function saveTextColor(hex: string) {
+		if (!profile) return;
+		try {
+			await collection('profile').update(profile.id as string, { text_color: hex });
+			textColor = hex;
+			toasts.add('success', $t('admin.text_color_picker.updated'));
+			window.dispatchEvent(new CustomEvent('text-color-changed', { detail: hex }));
+		} catch (err) {
+			console.error('Failed to save text color:', err);
+			toasts.add('error', $t('admin.text_color_picker.error'));
 		}
 	}
 
@@ -1157,6 +1176,12 @@ import { brandName } from '$lib/stores/plan';
 							onchange={(color) => saveAccentColor(color)}
 							onhexchange={(hex) => saveCustomHexColor(hex)}
 						/>
+						<div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+							<TextColorPicker
+								value={textColor}
+								onchange={(hex) => saveTextColor(hex)}
+							/>
+						</div>
 						<div class="pt-4 border-t border-gray-200 dark:border-gray-700">
 							<span class="block text-sm font-semibold text-gray-900 dark:text-white mb-1">{$t('admin.homepage.font_pack_title')}</span>
 							<p class="text-sm text-gray-600 dark:text-gray-400 mb-3">{$t('admin.homepage.font_pack_description')}</p>

--- a/frontend/tests/text-color-aaa.spec.ts
+++ b/frontend/tests/text-color-aaa.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { apiBaseURL } from './config';
+
+/**
+ * AAA proof for the operator-settable text (font) color.
+ *
+ * The whole promise of the feature is: whatever hue the operator picks — even a
+ * deliberately terrible one (pale yellow, mid gray) — the ACTUAL rendered text
+ * on the public page clears WCAG AAA (7:1) against its background, in BOTH light
+ * and dark mode, BY CONSTRUCTION.
+ *
+ * This test drives the real bundled CSS + the real SSR injection (no mocks):
+ *  1. PATCH profile.text_color to a bad pick.
+ *  2. Load the public page.
+ *  3. Read the COMPUTED color of a heading AND a body paragraph and compute the
+ *     contrast ratio in-test against their COMPUTED background.
+ *  4. Repeat in dark mode.
+ *  5. Assert the default (no text_color) is unchanged, and that a known surface
+ *     element is NOT tinted (stays the neutral stone value).
+ *
+ * The PB superuser PATCHes the field; the public render re-derives the AAA clamp.
+ */
+
+const PB_SUPERUSER = process.env.PB_SUPERUSER_EMAIL || 'admin@localhost.dev';
+const PB_SUPERUSER_PW = process.env.PB_SUPERUSER_PASSWORD || 'admin123';
+
+// Two deliberately bad picks: pale yellow (worst case for dark-on-light) and a
+// mid gray (near the worst case for BOTH modes). Both must end up AAA.
+const BAD_PICKS = ['#ffe066', '#808080'];
+
+function srgbLuminance(r: number, g: number, b: number): number {
+	const f = (c: number) => {
+		const cc = c / 255;
+		return cc <= 0.03928 ? cc / 12.92 : Math.pow((cc + 0.055) / 1.055, 2.4);
+	};
+	return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+function parseRgb(s: string): [number, number, number] {
+	const m = s.match(/\d+(\.\d+)?/g);
+	if (!m || m.length < 3) throw new Error(`Cannot parse color: ${s}`);
+	return [Number(m[0]), Number(m[1]), Number(m[2])];
+}
+
+function contrast(c1: string, c2: string): number {
+	const l1 = srgbLuminance(...parseRgb(c1));
+	const l2 = srgbLuminance(...parseRgb(c2));
+	const hi = Math.max(l1, l2);
+	const lo = Math.min(l1, l2);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+async function superuserToken(request: APIRequestContext): Promise<string> {
+	const res = await request.post(
+		`${apiBaseURL}/api/collections/_superusers/auth-with-password`,
+		{ data: { identity: PB_SUPERUSER, password: PB_SUPERUSER_PW } }
+	);
+	expect(res.ok(), 'PB superuser auth must succeed').toBeTruthy();
+	return (await res.json()).token as string;
+}
+
+async function profileId(request: APIRequestContext, token: string): Promise<string> {
+	const res = await request.get(`${apiBaseURL}/api/collections/profile/records?perPage=1`, {
+		headers: { Authorization: token }
+	});
+	expect(res.ok()).toBeTruthy();
+	const items = (await res.json()).items as Array<{ id: string }>;
+	expect(items.length, 'a profile record must exist').toBeGreaterThan(0);
+	return items[0].id;
+}
+
+async function setTextColor(
+	request: APIRequestContext,
+	token: string,
+	id: string,
+	hex: string
+): Promise<void> {
+	const res = await request.patch(`${apiBaseURL}/api/collections/profile/records/${id}`, {
+		headers: { Authorization: token },
+		data: { text_color: hex }
+	});
+	expect(res.ok(), `PATCH text_color=${hex || '(empty)'} must succeed`).toBeTruthy();
+}
+
+/**
+ * Measure computed color + background for a heading and a body paragraph on the
+ * currently loaded public page, in the given theme. Appends a real product-class
+ * body paragraph into <main> so the assertion does not depend on seeded content,
+ * while still exercising the exact scoped CSS rule the product ships.
+ */
+async function measure(page: import('@playwright/test').Page, dark: boolean) {
+	return page.evaluate((isDark) => {
+		document.documentElement.classList.toggle('dark', isDark);
+
+		const bgOf = (el: Element | null): string => {
+			let e: Element | null = el;
+			while (e) {
+				const c = getComputedStyle(e).backgroundColor;
+				if (c && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent') return c;
+				e = e.parentElement;
+			}
+			return getComputedStyle(document.documentElement).backgroundColor;
+		};
+
+		// Heading: a real section/article heading (text-gray-900 / dark:text-white).
+		const heading = document.querySelector('article h3, h2.section-title, main h1');
+
+		// Body: append a product-class paragraph into <main> so we always have a
+		// body target on a real surface, styled by the real scoped CSS rules.
+		const main = document.querySelector('main') || document.body;
+		let para = document.getElementById('aaa-test-body') as HTMLParagraphElement | null;
+		if (!para) {
+			para = document.createElement('p');
+			para.id = 'aaa-test-body';
+			para.className = 'prose-custom text-gray-700 dark:text-gray-300';
+			para.textContent = 'Body paragraph text used for the AAA contrast assertion.';
+			const card = document.createElement('div');
+			card.className = 'card p-4';
+			card.appendChild(para);
+			main.appendChild(card);
+		}
+
+		// On-bg body: append a SECOND product-class paragraph directly to <main>
+		// (no .card wrapper) so it inherits the warm page --bg, which is the
+		// worst-case (lowest-contrast) surface for dark-on-light text. bgOf walks
+		// up past <main> (no background) to documentElement, which carries --bg.
+		let paraOnBg = document.getElementById('aaa-test-body-onbg') as HTMLParagraphElement | null;
+		if (!paraOnBg) {
+			paraOnBg = document.createElement('p');
+			paraOnBg.id = 'aaa-test-body-onbg';
+			paraOnBg.className = 'prose-custom text-gray-700 dark:text-gray-300';
+			paraOnBg.textContent = 'Body paragraph text on the warm page background for the AAA contrast assertion.';
+			main.appendChild(paraOnBg);
+		}
+
+		const surface = document.querySelector('.card, article');
+
+		return {
+			headingColor: heading ? getComputedStyle(heading).color : null,
+			headingBg: bgOf(heading),
+			bodyColor: getComputedStyle(para).color,
+			bodyBg: bgOf(para),
+			bodyOnBgColor: getComputedStyle(paraOnBg).color,
+			bodyOnBgBg: bgOf(paraOnBg),
+			surfaceBg: surface ? getComputedStyle(surface).backgroundColor : null,
+			textInk: getComputedStyle(document.documentElement).getPropertyValue('--text-ink').trim(),
+			hasAttr: document.documentElement.hasAttribute('data-text-ink')
+		};
+	}, dark);
+}
+
+test.describe('operator text color is AAA by construction', () => {
+	let token: string;
+	let id: string;
+
+	test.beforeAll(async ({ request }) => {
+		token = await superuserToken(request);
+		id = await profileId(request, token);
+	});
+
+	test.afterAll(async ({ request }) => {
+		// Always reset so the live instance / other specs see the default.
+		await setTextColor(request, token, id, '');
+	});
+
+	test('default (no text_color) leaves text + surfaces untinted', async ({ request, page }) => {
+		await setTextColor(request, token, id, '');
+		await page.goto('/', { waitUntil: 'networkidle' });
+
+		const light = await measure(page, false);
+		expect(light.hasAttr, 'no data-text-ink attribute when unset').toBeFalsy();
+		expect(light.textInk, '--text-ink unset by default').toBe('');
+		// Surface stays the neutral stone white (#ffffff) — not tinted.
+		expect(light.surfaceBg).toBe('rgb(255, 255, 255)');
+	});
+
+	for (const pick of BAD_PICKS) {
+		test(`bad pick ${pick}: heading + body clear 7:1 in light AND dark`, async ({
+			request,
+			page
+		}) => {
+			await setTextColor(request, token, id, pick);
+			await page.goto('/', { waitUntil: 'networkidle' });
+
+			// ---- Light mode ----
+			const light = await measure(page, false);
+			expect(light.hasAttr, 'data-text-ink present when color set').toBeTruthy();
+			expect(light.textInk, '--text-ink injected').toMatch(/^#[0-9a-fA-F]{6}$/);
+			expect(light.headingColor, 'heading present').not.toBeNull();
+
+			const lightHeading = contrast(light.headingColor!, light.headingBg);
+			const lightBody = contrast(light.bodyColor, light.bodyBg);
+			expect(
+				lightHeading,
+				`light heading ${light.headingColor} on ${light.headingBg} = ${lightHeading.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+			expect(
+				lightBody,
+				`light body ${light.bodyColor} on ${light.bodyBg} = ${lightBody.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+
+			// Worst-case surface: body text directly on the warm page --bg (#fbf8f4),
+			// not a white card. The clamp targets exactly this surface, so hold it to
+			// the strict 7.0 floor.
+			const lightBodyOnBg = contrast(light.bodyOnBgColor, light.bodyOnBgBg);
+			expect(
+				lightBodyOnBg,
+				`light body on page bg ${light.bodyOnBgColor} on ${light.bodyOnBgBg} = ${lightBodyOnBg.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(7.0);
+
+			// Surface must NOT be tinted — still neutral stone white.
+			expect(light.surfaceBg, 'surface stays neutral in light mode').toBe('rgb(255, 255, 255)');
+
+			// ---- Dark mode ----
+			const dark = await measure(page, true);
+			const darkHeading = contrast(dark.headingColor!, dark.headingBg);
+			const darkBody = contrast(dark.bodyColor, dark.bodyBg);
+			expect(
+				darkHeading,
+				`dark heading ${dark.headingColor} on ${dark.headingBg} = ${darkHeading.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+			expect(
+				darkBody,
+				`dark body ${dark.bodyColor} on ${dark.bodyBg} = ${darkBody.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+
+			// Worst-case surface in dark mode: body text directly on the page --bg
+			// (#1a1613), not a card. Hold it to the strict 7.0 floor.
+			const darkBodyOnBg = contrast(dark.bodyOnBgColor, dark.bodyOnBgBg);
+			expect(
+				darkBodyOnBg,
+				`dark body on page bg ${dark.bodyOnBgColor} on ${dark.bodyOnBgBg} = ${darkBodyOnBg.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(7.0);
+		});
+	}
+});


### PR DESCRIPTION
## Summary

Net-new feature: an operator-settable **body/heading text (font) color** for the public profile that is **WCAG 2.2 SC 1.4.6 (enhanced contrast, 7:1) readable by construction**. The operator picks a hue; we auto-derive a per-mode, hue-preserved, 7:1-clamped ink so the contrast can never fall below AAA. What the operator picks is what renders, and it is always readable.

Neither self-hosted Facet nor Cloud had this before.

## The `deriveTextInk` algorithm

`deriveTextInk(hex) -> { light, dark }` (in `frontend/src/lib/colors.ts`), reusing the existing `channelLuminance` + binary-search clamp pattern from `clamp600`/`generatePaletteFromHex`:

- **Light ink:** darken the hue (mix toward black — scales all channels toward 0 equally, so hue is preserved) via binary search until contrast vs the **worst-case** light surface clears 7:1. The worst case is the warm page `--bg` **#fbf8f4** (NOT white): for dark ink, contrast *increases* with surface luminance, so the darkest surface text lands on is the hardest. Clearing 7:1 on #fbf8f4 also clears it on the soft-premium `--bg` #fef9f6 and on white `--surface`.
- **Dark ink:** lighten the hue (mix toward white) until contrast vs the worst-case dark surface **#221e1a** (the lightest dark surface text lands on) clears 7:1, which also clears the darker `--bg` #1a1613.
- Black (light) / white (dark) always satisfy 7:1, so the search provably terminates. Invalid input returns a neutral AAA-safe fallback.

## Application mechanism (chosen: scoped, gated, text-only) and WHY

I evaluated retinting the `--gray-N` ramp vs a dedicated token + scoped rule, and chose the latter:

- **Why not retint the gray ramp:** `gray-700/800/900` also back some dark-mode surfaces, borders, and icon fills, so warming the ramp would bleed the hue into non-text chrome.
- **What I did instead:** SSR injects `--text-ink` / `--text-ink-dark` plus a `data-text-ink` attribute on `<html>` (`hooks.server.ts`, mirroring how accent + font vars are injected — so it is FOUC-free, correct on the first frame). An **unlayered**, **public-scoped** CSS block gated under `:root[data-text-ink]` tints only heading + body utilities (`text-gray-700/800/900`, the dark variants, and `h1`-`h6`), explicitly excluding `.admin-shell`.
- **Default is a true no-op:** with no color set the attribute is absent, so the entire block is out of the cascade and the default render is byte-identical to today.
- **Muted text (gray-500/600) stays neutral** for hierarchy — confirmed by the contrast review (primary text takes the hue, secondary text recedes; avoids muted+hue drifting toward the 7:1 floor).

## Data + plumbing

- New nullable `text_color` TextField (`#RRGGBB`) on the `profile` collection (migration `1779200000_add_text_color.go`, copying the `custom_hex_color` shape).
- Serialized through `/api/homepage` (and the view-data path) in `backend/hooks/view.go`.
- Profile/global is the MVP; per-view override deliberately out of scope (low value, non-trivial).

## Admin UI

A `TextColorPicker.svelte` control in the Brand section of `/admin/homepage`: hex input + swatch + curated suggestions (WAI-ARIA APG radiogroup, roving tabindex) + a **live clamped preview** showing the actual rendered ink for light and dark. Persists to `profile.text_color`.

## i18n

`text_color_picker` strings added to all 5 locales (en/de/elvish/klingon/lolcat), 2-space JSON. `npm run i18n:validate` 100%.

## Accessibility (AAA sign-off)

Reviewed by `accessibility-lead` + `contrast-master` + `wcag-aaa`. They caught a **critical** bug in the first draft (light ink was clamped against `#ffffff`, leaving text at ~6.6:1 on the warm `--bg`) — **fixed** by clamping against the true worst-case surface `#fbf8f4`. Post-fix, every derived ink clears 7:1 on all worst-case surfaces in both modes, independently verified. Mechanism does not touch focus, links, muted, or semantic colors. Signed off.

## Certification

- `go build ./...` + `go test ./...` green.
- `npm run check`: 0 errors, 0 warnings. `npm run build`: OK. `npm run i18n:validate`: 100%.
- **AAA proof test** (`frontend/tests/text-color-aaa.spec.ts`, `--workers=1`): 3/3 pass. Drives the real bundled CSS + SSR; PATCHes bad picks (`#ffe066`, `#808080`); asserts rendered heading + body clear 7:1 against their background in light AND dark, including text on the worst-case page `--bg`; asserts default is untinted and surfaces stay neutral.
- Accent AAA regression test: 2/2 pass.

### Measured contrast (worst-case surfaces, post-fix)

| Pick | Light ink | on #fbf8f4 | Dark ink | on #221e1a |
|------|-----------|------------|----------|------------|
| `#ffe066` | `#605527` | 7.02:1 | `#ffe066` | 12.70:1 |
| `#808080` | `#555555` | 7.04:1 | `#a9a9a9` | 7.04:1 |

All ≥ 7:1.
