### PR TITLE
fix: repair Soft Premium redesign regressions on main

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -241,6 +241,13 @@
 	}
 
 	body {
+		/* Light-mode body background follows the warm Soft Premium surface token
+		   (--bg, #fbf8f4) instead of a hardcoded pure white, so overscroll / glow
+		   and ultra-wide gutters show the warm canvas rather than a jarring #fff.
+		   Dark mode keeps its var-backed `dark:bg-gray-900` utility (warm under
+		   Soft Premium) from app.html, and the @media print rule below overrides
+		   this to #fff for clean printing. */
+		background-color: var(--bg, #fff);
 		/* overflow-x: clip — modern equivalent of `hidden` that does NOT create
 		   a scroll container, so `position: sticky` inside still anchors to the
 		   viewport. With `hidden`, descendants like the sticky save header on

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -18,7 +18,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100" style="margin: 0; padding: 0; width: 100%; max-width: 100%;">
+	<body data-sveltekit-preload-data="hover" class="dark:bg-gray-900 text-gray-900 dark:text-gray-100" style="margin: 0; padding: 0; width: 100%; max-width: 100%;">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/frontend/src/components/public/ProjectsSection.svelte
+++ b/frontend/src/components/public/ProjectsSection.svelte
@@ -11,13 +11,14 @@
 
 	let { items, layout = 'grid-3', viewSlug = '' }: Props = $props();
 
-	// Soft Premium opt-in detection. SSR always renders the classic branch (the
-	// server injects data-design on <html> *after* component render, so it is not
-	// observable here), keeping classic output byte-identical. After mount we read
-	// the attribute and, only under soft-premium, swap in the refined serif initial
-	// plate. The post-mount swap touches the cover-less fallback only.
+	// Soft Premium is always on, so data-design="soft-premium" is present on the
+	// document root at SSR time (injected by hooks.server.ts). The cover-less
+	// fallback plate therefore renders the warm sp-plate directly in the markup;
+	// every plate selector is gated by [data-design='soft-premium'] in the style
+	// block, so the refined serif initial plate paints on first paint with no
+	// post-mount swap and no flash.
 	// Code-point-safe first character (emoji/multibyte titles are not split mid
-	// surrogate-pair, unlike charAt(0)). Used only for the soft-premium serif plate.
+	// surrogate-pair, unlike charAt(0)). Used for the soft-premium serif plate.
 	const initial = (title: string) => [...(title ?? '')][0] ?? '';
 
 	// Validate operator-supplied URLs against a scheme allowlist before rendering

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -464,13 +464,14 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 	// because all channels scale toward 0 equally) until white text on it clears
 	// 7:1. Starts at the nominal 0.15 darkening and only ever goes darker, so the
 	// accent hue is preserved and the change is strictly more accessible. Black
-	// always passes, so the search terminates.
-	function clamp600(): string {
+	// always passes, so the search terminates. Returns the resolved mix-toward-black
+	// AMOUNT (not the hex) so the darker shades can be floored above it (see below).
+	function clamp600Amount(): number {
 		const baseAmount = 0.15;
 		const lum = (amount: number) =>
 			channelLuminance(mix(r, 0, amount), mix(g, 0, amount), mix(b, 0, amount));
 		if (whiteOnColorContrast(lum(baseAmount)) >= ACCENT_MIN_CONTRAST) {
-			return toHex(mix(r, 0, baseAmount), mix(g, 0, baseAmount), mix(b, 0, baseAmount));
+			return baseAmount;
 		}
 		let lo = baseAmount;
 		let hi = 1;
@@ -479,8 +480,22 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 			if (whiteOnColorContrast(lum(m)) >= ACCENT_MIN_CONTRAST) hi = m;
 			else lo = m;
 		}
-		return toHex(mix(r, 0, hi), mix(g, 0, hi), mix(b, 0, hi));
+		return hi;
 	}
+
+	// For a PALE custom accent (e.g. #ffe066), the AAA clamp above can drive 600's
+	// darkening amount well past the nominal 0.30 used for 700. Left unguarded, that
+	// makes 600 DARKER than 700, a non-monotonic (inverted) ramp. Floor each darker
+	// shade strictly above the clamped 600 amount so the scale stays monotonic from
+	// 600 through 950 regardless of how deep the clamp had to go. The nominal mixes
+	// (0.30/0.45/0.60/0.80) are preserved for normal accents where 600's amount sits
+	// at or below 0.30.
+	const a600 = clamp600Amount();
+	const a700 = Math.max(0.30, a600 + 0.07);
+	const a800 = Math.max(0.45, a700 + 0.10);
+	const a900 = Math.max(0.60, a800 + 0.12);
+	const a950 = Math.max(0.80, a900 + 0.10);
+	const mixBlack = (amount: number) => toHex(mix(r, 0, amount), mix(g, 0, amount), mix(b, 0, amount));
 
 	return {
 		50:  toHex(mix(r, 255, 0.95), mix(g, 255, 0.95), mix(b, 255, 0.95)),
@@ -489,11 +504,11 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 		300: toHex(mix(r, 255, 0.55), mix(g, 255, 0.55), mix(b, 255, 0.55)),
 		400: toHex(mix(r, 255, 0.30), mix(g, 255, 0.30), mix(b, 255, 0.30)),
 		500: hex,
-		600: clamp600(),
-		700: toHex(mix(r, 0, 0.30), mix(g, 0, 0.30), mix(b, 0, 0.30)),
-		800: toHex(mix(r, 0, 0.45), mix(g, 0, 0.45), mix(b, 0, 0.45)),
-		900: toHex(mix(r, 0, 0.60), mix(g, 0, 0.60), mix(b, 0, 0.60)),
-		950: toHex(mix(r, 0, 0.80), mix(g, 0, 0.80), mix(b, 0, 0.80)),
+		600: mixBlack(a600),
+		700: mixBlack(a700),
+		800: mixBlack(a800),
+		900: mixBlack(a900),
+		950: mixBlack(a950),
 	};
 }
 

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -67,7 +67,7 @@ export interface Profile {
 	visibility: 'public' | 'unlisted' | 'private';
 	accent_color?: 'sky' | 'indigo' | 'emerald' | 'rose' | 'amber' | 'slate';
 	custom_hex_color?: string;
-	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric';
+	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | 'soft-premium';
 	hero_layout?: 'standard' | 'centered' | 'split' | 'minimal' | 'stacked';
 	hero_spacing?: 'compact' | 'default' | 'spacious';
 	hero_bg_color?: string;
@@ -429,7 +429,7 @@ export interface View {
 	is_active: boolean;
 	is_default?: boolean;
 	accent_color?: 'sky' | 'indigo' | 'emerald' | 'rose' | 'amber' | 'slate' | null;
-	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | null;
+	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | 'soft-premium' | null;
 	hero_layout?: 'standard' | 'centered' | 'split' | 'minimal' | 'stacked' | null;
 	hero_spacing?: 'compact' | 'default' | 'spacious' | null;
 	hero_bg_color?: string | null;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 	import Toast from '$components/shared/Toast.svelte';
 	import ConfirmDialog from '$components/shared/ConfirmDialog.svelte';
 	import { ACCENT_COLORS, DEFAULT_ACCENT_COLOR, type AccentColor, generatePaletteFromHex, hexToRgbChannels, buildPaletteRootBlock } from '$lib/colors';
-	import { getFontPack, DEFAULT_FONT_PACK, type FontPack } from '$lib/fonts';
+	import { getFontPack, type FontPack } from '$lib/fonts';
 	import { initI18n, setLocale, waitLocale } from '$lib/i18n';
 	import { isLoading as i18nLoading, t } from 'svelte-i18n';
 	import { initPlan, initPlanFromSSR, type PlanConfig } from '$lib/stores/plan';
@@ -193,19 +193,21 @@ function applyFlatAccent(color: string) {
   --font-code: '${pack.code}', ${pack.codeFallback};
 }`;
 
-		// Load Google Fonts for non-default packs
-		if (packName !== DEFAULT_FONT_PACK) {
-			if (!fontLinkEl) {
-				fontLinkEl = document.createElement('link');
-				fontLinkEl.id = 'dynamic-google-fonts';
-				fontLinkEl.rel = 'stylesheet';
-				document.head.appendChild(fontLinkEl);
-			}
-			fontLinkEl.href = pack.googleFontsUrl;
-		} else if (fontLinkEl) {
-			fontLinkEl.remove();
-			fontLinkEl = null;
+		// Ensure the resolved pack's Google Fonts are loaded, including the DEFAULT
+		// pack (soft-premium = Hanken Grotesk + Newsreader). app.html only statically
+		// loads the editorial fonts, and SSR (hooks.server.ts) injects the resolved
+		// pack's link on first paint; but this client applier re-runs on every SPA
+		// navigation. If the default pack special-cased *removing* the link, the
+		// default pack's fonts would drop on client nav and the page would fall back
+		// to Plus Jakarta. So we always (re)create/point the link at the resolved
+		// pack's URL, for the default pack too.
+		if (!fontLinkEl) {
+			fontLinkEl = document.createElement('link');
+			fontLinkEl.id = 'dynamic-google-fonts';
+			fontLinkEl.rel = 'stylesheet';
+			document.head.appendChild(fontLinkEl);
 		}
+		fontLinkEl.href = pack.googleFontsUrl;
 	}
 
 	async function loadAccentColor() {

--- a/frontend/tests/accent-aaa-clamp.spec.ts
+++ b/frontend/tests/accent-aaa-clamp.spec.ts
@@ -48,6 +48,48 @@ test('generatePaletteFromHex clamps white-on-600 to AAA (7:1), preserving hue', 
 	}
 });
 
+// Relative luminance (WCAG) of a #rrggbb hex, used to assert a monotonic ramp.
+function relLuminance(hex: string) {
+	const h = hex.trim().replace('#', '');
+	const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+	const f = (c: number) => {
+		const cc = c / 255;
+		return cc <= 0.03928 ? cc / 12.92 : Math.pow((cc + 0.055) / 1.055, 2.4);
+	};
+	return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+test('palette ramp is monotonic from 600 to 950 even for pale accents whose 600 clamps deep', async ({ page }) => {
+	await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+	const palettes = await page.evaluate(async (modUrl) => {
+		const mod = (await import(/* @vite-ignore */ modUrl)) as {
+			generatePaletteFromHex: (hex: string) => Record<string, string>;
+		};
+		const hexes = [
+			'#ffe066', // pale yellow: clamp600 drives 600 well past the nominal 700 mix
+			'#22d3ee', // pale cyan
+			'#ffe600', // worst-case pale yellow
+			'#a3e635', // lime
+			'#c2410c', // Soft Premium default terracotta (must not regress)
+			'#1e3a8a' // deep blue (600 stays at nominal)
+		];
+		return hexes.map((h) => ({ h, scale: mod.generatePaletteFromHex(h) }));
+	}, COLORS_MOD);
+
+	for (const { h, scale } of palettes) {
+		const steps = ['500', '600', '700', '800', '900', '950'] as const;
+		const lums = steps.map((s) => relLuminance(scale[s]));
+		// Each darker step must be strictly darker (lower luminance) than the
+		// previous one (no inversion). Epsilon covers 8-bit rounding.
+		for (let i = 1; i < steps.length; i++) {
+			expect(
+				lums[i],
+				`${h}: ${steps[i]}=${scale[steps[i]]} (L=${lums[i].toFixed(4)}) must be darker than ${steps[i - 1]}=${scale[steps[i - 1]]} (L=${lums[i - 1].toFixed(4)})`
+			).toBeLessThan(lums[i - 1] + 1e-9);
+		}
+	}
+});
+
 test('clamp only deepens — a hue already dark enough is left at its nominal 600', async ({ page }) => {
 	await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
 	const { darkSix, paleSix } = await page.evaluate(async (modUrl) => {

--- a/frontend/tests/soft-premium-fonts.spec.ts
+++ b/frontend/tests/soft-premium-fonts.spec.ts
@@ -75,4 +75,77 @@ test.describe('Soft Premium fonts (font selector governs)', () => {
 		const font = await bodyFont(page);
 		expect(font).toContain('hanken');
 	});
+
+	// Regression guard: applying the DEFAULT pack (soft-premium) on the client must
+	// KEEP the Google Fonts link. The live admin font picker drives applyFontPack via
+	// the 'font-pack-changed' window event; the regression special-cased the default
+	// pack and *removed* the dynamic link, so a creator who previews soft-premium (or
+	// switches back to it) lost Hanken/Newsreader and the body fell back to Plus
+	// Jakarta. We exercise the exact event the picker uses, then confirm a Hanken
+	// dynamic link is present and the resolved --font-body is Hanken. This is the
+	// discriminating assertion: the buggy code produced no soft-premium dynamic link.
+	const applyDefaultPackOnClient = (page: Page) =>
+		page.evaluate(
+			() =>
+				new Promise<void>((resolve) => {
+					window.dispatchEvent(new CustomEvent('font-pack-changed', { detail: 'soft-premium' }));
+					// let the layout's handler + Svelte effect flush
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+				})
+		);
+
+	const dynamicLinkState = (page: Page) =>
+		page.evaluate(() => {
+			const link = document.querySelector('link#dynamic-google-fonts') as HTMLLinkElement | null;
+			return {
+				dynamicHasHanken: !!link && /Hanken/i.test(link.href),
+				fontBody: getComputedStyle(document.body).fontFamily.toLowerCase(),
+				sameDoc: (window as unknown as Record<string, boolean>).__spaMarker === true
+			};
+		});
+
+	test('applying the default pack on the client keeps the Hanken link, and it survives SPA nav', async ({ page, request }) => {
+		const token = await adminToken(request);
+		await setFontPack(request, token, '');
+
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'networkidle' });
+		// Tag the live document so we can prove the next navigation is client-side.
+		await page.evaluate(() => ((window as unknown as Record<string, boolean>).__spaMarker = true));
+
+		// Drive the real admin live-preview event for the DEFAULT pack.
+		await applyDefaultPackOnClient(page);
+
+		const applied = await dynamicLinkState(page);
+		expect(
+			applied.dynamicHasHanken,
+			'applying soft-premium on the client must create/keep #dynamic-google-fonts pointing at Hanken (regression removed it)'
+		).toBeTruthy();
+		expect(applied.fontBody).toContain('hanken');
+
+		// Now navigate client-side; the SvelteKit font $effect re-runs applyFontPack
+		// and must not drop the default pack's link.
+		const inAppHref = await page.evaluate(() => {
+			const a = Array.from(document.querySelectorAll('a[href]')).find((el) => {
+				const href = (el as HTMLAnchorElement).getAttribute('href') || '';
+				return href.startsWith('/') && !href.startsWith('//') && !href.startsWith('/#');
+			}) as HTMLAnchorElement | undefined;
+			return a ? a.getAttribute('href') : null;
+		});
+
+		if (inAppHref) {
+			await Promise.all([
+				page.waitForURL((url) => url.pathname === inAppHref, { timeout: 10_000 }),
+				page.click(`a[href="${inAppHref}"]`)
+			]);
+			// Re-apply (as the picker would on the new page) and assert persistence.
+			await applyDefaultPackOnClient(page);
+			const afterNav = await dynamicLinkState(page);
+			expect(afterNav.sameDoc, 'navigation should be client-side (SPA)').toBeTruthy();
+			expect(
+				afterNav.dynamicHasHanken,
+				'dynamic Hanken link must remain after SPA nav with the default pack'
+			).toBeTruthy();
+			expect(afterNav.fontBody).toContain('hanken');
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Repairs a set of confirmed regressions introduced by the merged **Soft Premium** redesign on `main`, now that soft-premium is always on and is the `DEFAULT_FONT_PACK`. Each item was verified against the actual code before fixing. Scope is strictly the five listed fixes (frontend only).

## Fixes

1. **[CRITICAL] Default fonts drop after SPA navigation** — `frontend/src/routes/+layout.svelte`. `applyFontPack()` removed the Google-Fonts `<link>` whenever the resolved pack was the default. Since the default is now `soft-premium` (Hanken Grotesk + Newsreader), client/admin navigation (the font `$effect` and the live `font-pack-changed` preview event both re-run `applyFontPack`) dropped those faces and fell back to Plus Jakarta. Now we always (re)create and point the dynamic `#dynamic-google-fonts` link at the resolved pack's URL, including the default pack. SSR (`hooks.server.ts`) still injects the link on first paint (verified).

2. **[CRITICAL] `font_pack` TS union omitted `'soft-premium'`** — `frontend/src/lib/pocketbase.ts`. Added `'soft-premium'` to both the `Profile` and `View` `font_pack` unions (it is in `fonts.ts` `FontPack` and is the default). `hero_layout` unions already match across the codebase on `main`; `'rail'` intentionally **not** added (belongs to the separate rail PR).

3. **[IMPORTANT] Projects cover-plate FOUC** — `frontend/src/components/public/ProjectsSection.svelte`. The markup already renders the warm `sp-plate` directly and its CSS is gated by `:global([data-design='soft-premium'])`, which is present at SSR — so the plate already paints on first paint with no flash. The only defect was a **stale comment** describing a post-mount classic→sp swap that no longer exists; corrected it. `TalksSection.svelte` has only the `sp-title` accent (no cover plate), so nothing to change there. Swept all section/route components for the same stale pattern — only ProjectsSection had it.

4. **[IMPORTANT] Non-monotonic accent ramp** — `frontend/src/lib/colors.ts`. For a pale custom accent the AAA `clamp600()` could darken shade 600 past the fixed-amount 700 (e.g. `#ffe066` produced 600=`#655828` L=0.099 but 700=`#b39d47` L=0.342 — inverted). `clamp600` now returns its mix-toward-black amount and 700/800/900/950 are floored strictly above it, keeping the ramp monotonic. The terracotta default (`#c2410c`) and the existing AAA / nominal-600 assertions (`#1e3a8a` → `#1a3175`) are preserved.

5. **[IMPORTANT] `<body>` hardcoded `bg-white`** — `frontend/src/app.html` + `frontend/src/app.css`. Removed `bg-white` from `<body>` and backed the light-mode body background with `background-color: var(--bg, #fff)` so overscroll / ultra-wide gutters show the warm `#fbf8f4` canvas instead of pure white. Dark mode keeps its var-backed `dark:bg-gray-900` (warm under soft-premium, wins by specificity); the `@media print` rule still forces `#fff`.

## Tests added
- `tests/soft-premium-fonts.spec.ts`: SPA-nav font-persistence guard driving the real `font-pack-changed` event for the default pack — **fails on the pre-fix code, passes on the fix**.
- `tests/accent-aaa-clamp.spec.ts`: palette monotonicity assertion (600→950) for pale hues `#ffe066`, `#22d3ee`, `#ffe600` plus the terracotta default and deep blue.

## Accessibility
Delegated items 3 and 5 to `accessibility-lead`. Verdict: **PASS / SHIP**, no fixes required. Light-mode body text contrast 16.75:1 (well above AA 4.5:1); dark and print unaffected; the cover plate is decorative and correctly `aria-hidden`, with the real project title rendered as a separate linked `<h3>`.

## Certification (local, against an isolated backend :8092 + frontend :5274)
- `go build ./...` — OK
- `go test ./...` — ok (hooks, services), no failures
- `npm run check` — 0 errors, 0 warnings
- `npm run i18n:validate` — 100% all locales, Status: OK
- `npm run build` — OK
- Playwright (relevant suites, `--workers=1`) — 10 passed (accent-clamp incl. new monotonicity, soft-premium-fonts incl. new SPA guard, accent-default, tokens)

Note: `npm run lint` is non-functional repo-wide on `main` (no `eslint.config.js`; prettier warns on all 1193 files due to unresolved config) and is not in the required gate set; not touched.
