### PR TITLE
feat: redesign parity bundle — live preview, rail layout, AAA text color + regression fixes

### DIFF
--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -751,6 +751,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 					"contact_links":   profile.Get("contact_links"),
 					"visibility":      profile.GetString("visibility"),
 					"accent_color":    profile.GetString("accent_color"),
+					"text_color":      profile.GetString("text_color"),
 					"font_pack":       profile.GetString("font_pack"),
 					"hero_layout":     profile.GetString("hero_layout"),
 					"hero_spacing":    profile.GetString("hero_spacing"),
@@ -961,6 +962,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 						"accent_color":     p.GetString("accent_color"),
 						"custom_hex_color": p.GetString("custom_hex_color"),
 						"font_pack":        p.GetString("font_pack"),
+						"text_color":       p.GetString("text_color"),
 					}
 				}
 
@@ -989,6 +991,7 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 					"contact_links":   profile.Get("contact_links"),
 					"visibility":      profile.GetString("visibility"),
 					"accent_color":    profile.GetString("accent_color"),
+					"text_color":      profile.GetString("text_color"),
 					"font_pack":       profile.GetString("font_pack"),
 					"hero_layout":     profile.GetString("hero_layout"),
 					"hero_spacing":    profile.GetString("hero_spacing"),

--- a/backend/migrations/1779100000_widen_hero_layout_rail.go
+++ b/backend/migrations/1779100000_widen_hero_layout_rail.go
@@ -1,0 +1,68 @@
+package migrations
+
+import (
+	"slices"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Widen the hero_layout SelectField to include 'rail' as the 6th allowed
+// value on both the profile and views collections. Without this, the
+// frontend's new rail layout can't be persisted (PocketBase rejects unknown
+// SelectField values with 400 before the row reaches the DB).
+//
+// Migration is additive — it does NOT change defaults. Existing tenants keep
+// whatever hero_layout they already have, and self-hosted continues to default
+// new profiles to 'standard'.
+
+func init() {
+	m.Register(func(app core.App) error {
+		for _, collName := range []string{"profile", "views"} {
+			coll, err := app.FindCollectionByNameOrId(collName)
+			if err != nil {
+				return nil
+			}
+			field := coll.Fields.GetByName("hero_layout")
+			if field == nil {
+				continue
+			}
+			sel, ok := field.(*core.SelectField)
+			if !ok {
+				continue
+			}
+			if slices.Contains(sel.Values, "rail") {
+				continue
+			}
+			sel.Values = append(sel.Values, "rail")
+			if err := app.Save(coll); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, func(app core.App) error {
+		for _, collName := range []string{"profile", "views"} {
+			coll, err := app.FindCollectionByNameOrId(collName)
+			if err != nil {
+				continue
+			}
+			field := coll.Fields.GetByName("hero_layout")
+			if field == nil {
+				continue
+			}
+			sel, ok := field.(*core.SelectField)
+			if !ok {
+				continue
+			}
+			next := sel.Values[:0]
+			for _, v := range sel.Values {
+				if v != "rail" {
+					next = append(next, v)
+				}
+			}
+			sel.Values = next
+			app.Save(coll)
+		}
+		return nil
+	})
+}

--- a/backend/migrations/1779200000_add_text_color.go
+++ b/backend/migrations/1779200000_add_text_color.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Adds a nullable text_color TextField to the profile collection.
+//
+// text_color holds the operator's chosen body/heading text hue as #RRGGBB (empty
+// = default neutral ink). The frontend derives a per-mode, hue-preserved, AAA
+// (7:1) clamped ink from this hue (deriveTextInk in colors.ts) and injects it as
+// --text-ink / --text-ink-dark, so the operator's hue is honored while contrast
+// can never fall below AAA. Empty ⇒ nothing injected ⇒ render unchanged, so
+// existing instances are byte-identical until an operator opts in.
+func init() {
+	m.Register(func(app core.App) error {
+		profileCollection, err := app.FindCollectionByNameOrId("profile")
+		if err != nil {
+			// Collection doesn't exist, nothing to do.
+			return nil
+		}
+
+		if profileCollection.Fields.GetByName("text_color") == nil {
+			profileCollection.Fields.Add(&core.TextField{
+				Name:    "text_color",
+				Max:     7, // #RRGGBB
+				Pattern: `^#[0-9a-fA-F]{6}$`,
+			})
+
+			if err := app.Save(profileCollection); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, func(app core.App) error {
+		profileCollection, err := app.FindCollectionByNameOrId("profile")
+		if err != nil {
+			return nil
+		}
+
+		if f := profileCollection.Fields.GetByName("text_color"); f != nil {
+			profileCollection.Fields.RemoveById(f.GetId())
+			return app.Save(profileCollection)
+		}
+
+		return nil
+	})
+}

--- a/backend/migrations/1779300000_add_soft_premium_font_pack.go
+++ b/backend/migrations/1779300000_add_soft_premium_font_pack.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"slices"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Widen the font_pack SelectField to include 'soft-premium' as an allowed value
+// on both the profile and views collections. The original add_font_pack migration
+// shipped without 'soft-premium', so PocketBase silently strips the value on write
+// (SelectField rejects/drops unknown values before the row reaches the DB) and the
+// Soft Premium font pack never persists.
+//
+// Migration is additive and idempotent — it does NOT change defaults. Existing
+// tenants keep whatever font_pack they already have; this only appends the missing
+// allowed value so the frontend's soft-premium selection round-trips correctly.
+
+func init() {
+	m.Register(func(app core.App) error {
+		for _, collName := range []string{"profile", "views"} {
+			coll, err := app.FindCollectionByNameOrId(collName)
+			if err != nil {
+				continue
+			}
+			field := coll.Fields.GetByName("font_pack")
+			if field == nil {
+				continue
+			}
+			sel, ok := field.(*core.SelectField)
+			if !ok {
+				continue
+			}
+			if slices.Contains(sel.Values, "soft-premium") {
+				continue
+			}
+			sel.Values = append(sel.Values, "soft-premium")
+			if err := app.Save(coll); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, func(app core.App) error {
+		for _, collName := range []string{"profile", "views"} {
+			coll, err := app.FindCollectionByNameOrId(collName)
+			if err != nil {
+				continue
+			}
+			field := coll.Fields.GetByName("font_pack")
+			if field == nil {
+				continue
+			}
+			sel, ok := field.(*core.SelectField)
+			if !ok {
+				continue
+			}
+			next := sel.Values[:0]
+			for _, v := range sel.Values {
+				if v != "soft-premium" {
+					next = append(next, v)
+				}
+			}
+			sel.Values = next
+			app.Save(coll)
+		}
+		return nil
+	})
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -111,6 +111,65 @@
 	color: var(--ink);
 }
 
+/* ==========================================================================
+   Operator text (font) color — enhanced contrast (WCAG 2.2 SC 1.4.6, Level AAA)
+   by construction.
+
+   Scope of the AAA claim: this guarantees SC 1.4.6 (Contrast Enhanced, 7:1) for
+   the tinted heading + body text only. It does NOT assert full-page Level AAA
+   (e.g. 1.4.8 Visual Presentation, 2.4.13 Focus Appearance are out of scope and
+   untouched here).
+
+   The operator picks a hue; hooks.server.ts derives a per-mode, hue-preserved,
+   7:1-clamped ink (deriveTextInk in colors.ts) and injects it as --text-ink
+   (light) and --text-ink-dark (dark). These rules tint HEADINGS + BODY text on
+   the PUBLIC profile only, and leave surfaces / borders / icons / muted chrome
+   neutral for hierarchy.
+
+   WHY this mechanism (vs retinting the --gray-N ramp): gray-700/800/900 also
+   back some dark-mode surfaces, borders and icon fills, so warming the ramp
+   would bleed the hue into non-text chrome. Instead we override only the TEXT
+   utilities used for headings + body, scoped to public content.
+
+   Specificity: a plain `body { color }` loses to Tailwind's `.text-gray-900`.
+   These selectors compound a public-scope class with the utility class (and the
+   block is UNLAYERED, so it also beats @layer utilities), so they reliably win
+   on real text elements.
+
+   Gating + no-op default: the ENTIRE block is scoped under `:root[data-text-ink]`,
+   an attribute hooks.server.ts adds to <html> ONLY when the operator set a color.
+   When no color is set, the attribute is absent and NONE of these rules exist in
+   the cascade — so each declaration's bare `color: var(--text-ink)` is never
+   reached and the default render is byte-identical to today (no fallback-value
+   drift on headings like .section-title). The attribute and the --text-ink vars
+   are always injected together.
+
+   Scope: applies to the public document body but NEVER inside `.admin-shell`
+   (admin chrome stays on its own neutral palette).
+   ========================================================================== */
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) :is(h1, h2, h3, h4, h5, h6),
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) .text-gray-900,
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) .text-gray-800,
+:root[data-text-ink] body:not(.admin-shell *):not(.admin-shell) .text-gray-700 {
+	color: var(--text-ink);
+}
+
+/* Dark mode: headings use `dark:text-white`, body uses `dark:text-gray-300/200`.
+   Override those to the lightened dark ink. Only present when the attribute is
+   set, so an un-set color is a no-op. */
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) :is(h1, h2, h3, h4, h5, h6),
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) .dark\:text-white,
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) .dark\:text-gray-200,
+:root[data-text-ink].dark body:not(.admin-shell *):not(.admin-shell) .dark\:text-gray-300 {
+	color: var(--text-ink-dark);
+}
+
+/* MUTED text (gray-500/600 light, gray-400/500 dark) is intentionally LEFT
+   NEUTRAL — see PR notes / contrast review. Keeping muted neutral preserves the
+   visual hierarchy (primary text takes the hue, secondary text recedes) and
+   avoids muted+hue combinations drifting toward the 7:1 floor. The absence of a
+   rule here is deliberate. */
+
 @layer base {
 	/* ==========================================================================
 	   Accent Color CSS Custom Properties
@@ -189,7 +248,7 @@
 		--chip: #ece4de;
 		--ink: #2a2522;
 		--muted: #5a524d;
-		--border: #988e85; /* load-bearing (>=3:1) */
+		--border: #8f857c; /* load-bearing: 3.20:1 vs --surface-2 #faf4f0, 3.50:1 vs #ffffff */
 		--border-hairline: #ddd1ca; /* decorative only */
 		--border-interactive: #988e85;
 		/* Accent surfaces (creator accent, contrast-clamped by B2). */

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -189,7 +189,7 @@
 		--chip: #ece4de;
 		--ink: #2a2522;
 		--muted: #5a524d;
-		--border: #988e85; /* load-bearing (>=3:1) */
+		--border: #8f857c; /* load-bearing: 3.20:1 vs --surface-2 #faf4f0, 3.50:1 vs #ffffff */
 		--border-hairline: #ddd1ca; /* decorative only */
 		--border-interactive: #988e85;
 		/* Accent surfaces (creator accent, contrast-clamped by B2). */

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -241,6 +241,13 @@
 	}
 
 	body {
+		/* Light-mode body background follows the warm Soft Premium surface token
+		   (--bg, #fbf8f4) instead of a hardcoded pure white, so overscroll / glow
+		   and ultra-wide gutters show the warm canvas rather than a jarring #fff.
+		   Dark mode keeps its var-backed `dark:bg-gray-900` utility (warm under
+		   Soft Premium) from app.html, and the @media print rule below overrides
+		   this to #fff for clean printing. */
+		background-color: var(--bg, #fff);
 		/* overflow-x: clip — modern equivalent of `hidden` that does NOT create
 		   a scroll container, so `position: sticky` inside still anchors to the
 		   viewport. With `hidden`, descendants like the sticky save header on

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -18,7 +18,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100" style="margin: 0; padding: 0; width: 100%; max-width: 100%;">
+	<body data-sveltekit-preload-data="hover" class="dark:bg-gray-900 text-gray-900 dark:text-gray-100" style="margin: 0; padding: 0; width: 100%; max-width: 100%;">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/frontend/src/components/admin/AdminHeader.svelte
+++ b/frontend/src/components/admin/AdminHeader.svelte
@@ -3,7 +3,12 @@
 	import { t } from 'svelte-i18n';
 	import { pb, currentUser, performLogout } from '$lib/pocketbase';
 	import { adminSidebarOpen } from '$lib/stores';
+	import { userPreferences } from '$lib/stores/userPreferences';
 	import ThemeToggle from '$components/shared/ThemeToggle.svelte';
+
+	function toggleLivePreview() {
+		userPreferences.setPref('livePreviewEnabled', !$userPreferences.livePreviewEnabled);
+	}
 
 	function toggleSidebar() {
 		adminSidebarOpen.update((v) => {
@@ -60,6 +65,32 @@
 				<span class="hidden sm:inline">{$t('admin.header.view_site')}</span>
 				<span class="sr-only">(opens in new tab)</span>
 			</a>
+
+			<!-- Live site preview toggle. Hidden on screens <lg because the
+			     right-column iframe is hidden at that breakpoint anyway —
+			     no value in toggling something invisible. -->
+			<button
+				type="button"
+				role="switch"
+				aria-checked={$userPreferences.livePreviewEnabled}
+				aria-label={$t('admin.header.live_preview_toggle')}
+				onclick={toggleLivePreview}
+				class="hidden lg:inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors {$userPreferences.livePreviewEnabled
+					? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-900/60'
+					: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
+				title={$t('admin.header.live_preview_toggle')}
+			>
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+				</svg>
+				<span class="hidden xl:inline">{$t('admin.header.live_preview_label')}</span>
+				<span aria-hidden="true" class="hidden xl:inline text-xs"
+					>{$userPreferences.livePreviewEnabled
+						? $t('admin.header.live_preview_on')
+						: $t('admin.header.live_preview_off')}</span
+				>
+			</button>
 
 			<ThemeToggle />
 

--- a/frontend/src/components/admin/LivePreview.svelte
+++ b/frontend/src/components/admin/LivePreview.svelte
@@ -1,0 +1,200 @@
+<!--
+  Live site preview iframe.
+
+  Renders the public profile homepage in a sandboxed iframe with a
+  debounced reload on PocketBase realtime updates to the profile record,
+  so the operator watches the public site update as they edit.
+
+  Behaviour:
+  - Realtime subscription is scoped to the specific profile record id
+    (not the wildcard `*` topic), keeping the subscription tight + cheap.
+  - Kill-switch via `VITE_DISABLE_LIVE_PREVIEW=1` at build time disables
+    the feature without touching source. Mounting is skipped entirely
+    when set.
+  - Iframe error events announce failure via the same polite live region
+    used for the ready announcement.
+  - If we can't resolve the profile record id (e.g. pre-seed), the
+    component still renders the iframe but skips the realtime
+    subscription — preview is static until manual reload, never crashes.
+
+  A11y design:
+  - iframe is tabindex=-1 (sandbox restricts interaction; sealing focus
+    out matches actual behavior and avoids a focus trap inside).
+  - Single sr-only note explains the preview is read-only.
+  - aria-busy on container during reload — no aria-live wrapper (would
+    spam SR users on every edit).
+  - One-time "ready" announcement on first load; one-time "unavailable"
+    on iframe error, both routed through a polite role="status" region.
+
+  Mounted only when the layout decides — see +layout.svelte. Default-OFF
+  means existing installs see zero behaviour change until the operator
+  opts in via the header toggle.
+-->
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { t } from 'svelte-i18n';
+	import { pb } from '$lib/pocketbase';
+	import { browser } from '$app/environment';
+
+	// Reload debounce: 400ms after PB realtime fires. Tuned so a fast typer
+	// saving every keystroke (autosave debounces internally) gets exactly
+	// one preview reload per coherent edit, not per keystroke.
+	const RELOAD_DEBOUNCE_MS = 400;
+
+	// Build-time kill switch. Set VITE_DISABLE_LIVE_PREVIEW=1 in .env to
+	// fully disable the feature without touching code. Default empty →
+	// enabled (subject to userPreferences toggle).
+	const KILL_SWITCH =
+		typeof import.meta.env !== 'undefined' &&
+		(import.meta.env.VITE_DISABLE_LIVE_PREVIEW === '1' ||
+			import.meta.env.VITE_DISABLE_LIVE_PREVIEW === 'true');
+
+	let iframeEl: HTMLIFrameElement | undefined = $state();
+	let busy = $state(false);
+	let firstLoadAnnounced = $state(false);
+	let errorAnnounced = $state(false);
+	let liveStatus = $state('');
+
+	// Bust the iframe cache on reload — appending a counter to the src
+	// forces a fresh fetch instead of relying on the browser's HTTP cache.
+	// The `preview=1` marker is ignored server-side but kept for parity.
+	let reloadCounter = $state(0);
+	let src = $derived(`/?preview=1&_=${reloadCounter}`);
+
+	let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+	let unsubscribeFn: (() => void) | null = null;
+
+	function scheduleReload() {
+		if (reloadTimer) clearTimeout(reloadTimer);
+		busy = true;
+		reloadTimer = setTimeout(() => {
+			reloadCounter += 1;
+			reloadTimer = null;
+		}, RELOAD_DEBOUNCE_MS);
+	}
+
+	function announce(message: string) {
+		liveStatus = message;
+		setTimeout(() => {
+			liveStatus = '';
+		}, 2000);
+	}
+
+	function handleIframeLoad() {
+		busy = false;
+		// Clear the error latch on a successful load so a later break→recover→break
+		// cycle re-announces the failure (WCAG 4.1.3) instead of going silent.
+		errorAnnounced = false;
+		if (!firstLoadAnnounced) {
+			// Throttled status: only the first successful load. Reloads
+			// after the user just typed don't need an announcement.
+			announce($t('admin.site_preview.ready_announce'));
+			firstLoadAnnounced = true;
+		}
+	}
+
+	function handleIframeError() {
+		busy = false;
+		if (!errorAnnounced) {
+			// One-shot error announcement so AT users hear when the preview
+			// breaks (e.g., CSP block, network failure, backend 503).
+			announce($t('admin.site_preview.error_announce'));
+			errorAnnounced = true;
+		}
+	}
+
+	onMount(async () => {
+		if (!browser || KILL_SWITCH) return;
+
+		// Narrow the realtime subscription to the single profile record.
+		// Subscribing to the specific record id (rather than the wildcard
+		// `*` topic) keeps the subscription tight + avoids fan-out from
+		// unrelated record-level writes.
+		//
+		// `requestKey: null` opts out of the PocketBase SDK's per-collection
+		// auto-cancellation. Other admin pages also fetch the profile
+		// collection at mount time, and the SDK cancels earlier in-flight
+		// calls to the same collection when a later one fires. Without
+		// `requestKey: null` our getList could lose the race and the
+		// subscribe path would never establish. One-shot retry on
+		// cancellation as belt-and-suspenders.
+		async function subscribeWithRetry(attempt = 0): Promise<void> {
+			try {
+				const records = await pb.collection('profile').getList(1, 1, { requestKey: null });
+				const profileId = records.items[0]?.id;
+				if (!profileId) {
+					// No profile record yet (rare — pre-seed). Render the
+					// iframe statically; operator can refresh manually.
+					return;
+				}
+				const unsub = await pb.collection('profile').subscribe(profileId, () => {
+					scheduleReload();
+				});
+				unsubscribeFn = unsub;
+			} catch (err) {
+				const msg = String(err);
+				const isAutoCancel = msg.includes('autocancelled') || msg.includes('aborted');
+				if (isAutoCancel && attempt < 2) {
+					// One backoff then retry. Auto-cancel happens when another
+					// page's same-collection fetch raced ahead of ours.
+					await new Promise((r) => setTimeout(r, 250 * (attempt + 1)));
+					return subscribeWithRetry(attempt + 1);
+				}
+				console.warn('[live-preview] realtime subscribe failed:', err);
+			}
+		}
+		await subscribeWithRetry();
+	});
+
+	onDestroy(() => {
+		if (reloadTimer) clearTimeout(reloadTimer);
+		if (unsubscribeFn) {
+			try {
+				unsubscribeFn();
+			} catch (err) {
+				console.warn('[live-preview] unsubscribe failed:', err);
+			}
+		}
+	});
+</script>
+
+{#if !KILL_SWITCH}
+	<aside class="live-preview-column min-w-0" aria-labelledby="site-preview-heading">
+		<h2 id="site-preview-heading" class="sr-only">{$t('admin.site_preview.heading')}</h2>
+		<span id="site-preview-note" class="sr-only">{$t('admin.site_preview.readonly_note')}</span>
+
+		<div
+			class="sticky top-20 h-[calc(100vh-6rem)] rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+			aria-busy={busy}
+		>
+			<iframe
+				bind:this={iframeEl}
+				title={$t('admin.site_preview.iframe_title')}
+				aria-describedby="site-preview-note"
+				{src}
+				loading="lazy"
+				sandbox="allow-same-origin allow-scripts"
+				referrerpolicy="same-origin"
+				tabindex="-1"
+				class="w-full h-full border-0 bg-white dark:bg-gray-800"
+			></iframe>
+		</div>
+
+		<!-- Polite, throttled status for screen readers. Fires once on first
+		     load and once on first error. -->
+		<div class="sr-only" role="status" aria-live="polite">{liveStatus}</div>
+	</aside>
+{/if}
+
+<style>
+	/* Opacity-only transition: width/transform shifts cause layout reflow
+	   that can trigger vestibular issues. */
+	.live-preview-column {
+		transition: opacity 150ms ease;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.live-preview-column {
+			transition: none;
+		}
+	}
+</style>

--- a/frontend/src/components/admin/TextColorPicker.svelte
+++ b/frontend/src/components/admin/TextColorPicker.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+	/**
+	 * TextColorPicker — operator-settable body/heading text color for the public
+	 * profile, AAA-readable BY CONSTRUCTION.
+	 *
+	 * The operator picks a hue; deriveTextInk() clamps it per-mode (darken for
+	 * light, lighten for dark) so it always clears 7:1 against the lightest
+	 * surface text sits on. The picker shows the CLAMPED result live — what you
+	 * pick is what renders, and it is always readable.
+	 *
+	 * Accessibility:
+	 * - Curated suggestions follow the WAI-ARIA APG radio pattern (roving
+	 *   tabindex, arrow keys move focus + selection, Home/End jump).
+	 * - Hex input validates on blur (less noisy for screen readers); a persistent
+	 *   aria-live region announces commit + error.
+	 * - The live preview swatches carry text alternatives (not color-only).
+	 */
+	import { tick } from 'svelte';
+	import { t } from 'svelte-i18n';
+	import { isValidHexColor, deriveTextInk } from '$lib/colors';
+
+	let {
+		value = $bindable(''),
+		onchange
+	}: {
+		value?: string;
+		onchange?: (hex: string) => void;
+	} = $props();
+
+	// Curated, harmonious ink hues. Operators can still type any hex — these are
+	// just sensible starting points (warm + cool, all distinct from the accent).
+	const SUGGESTIONS: Array<{ hex: string; labelKey: string }> = [
+		{ hex: '#1f2937', labelKey: 'admin.text_color_picker.suggestion_slate' },
+		{ hex: '#3f3f46', labelKey: 'admin.text_color_picker.suggestion_graphite' },
+		{ hex: '#7c2d12', labelKey: 'admin.text_color_picker.suggestion_umber' },
+		{ hex: '#1e3a8a', labelKey: 'admin.text_color_picker.suggestion_navy' },
+		{ hex: '#14532d', labelKey: 'admin.text_color_picker.suggestion_forest' },
+		{ hex: '#581c87', labelKey: 'admin.text_color_picker.suggestion_plum' }
+	];
+
+	let swatchRefs: HTMLButtonElement[] = $state([]);
+	let hexInput = $state(value || '');
+	let hexError = $state('');
+	let announce = $state('');
+
+	const normalized = $derived(value && isValidHexColor(value) ? value : '');
+	// Live clamped inks — exactly what hooks.server.ts injects and the page renders.
+	const ink = $derived(normalized ? deriveTextInk(normalized) : null);
+
+	const selectedIndex = $derived(SUGGESTIONS.findIndex((s) => s.hex.toLowerCase() === normalized.toLowerCase()));
+	// Roving tabstop owner: the selected suggestion, else the first.
+	const focusedIndex = $derived(selectedIndex >= 0 ? selectedIndex : 0);
+
+	function normalizeHex(raw: string): string {
+		const trimmed = raw.trim();
+		if (!trimmed) return '';
+		return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+	}
+
+	function pick(hex: string) {
+		const norm = normalizeHex(hex);
+		value = norm;
+		hexInput = norm;
+		hexError = '';
+		announce = $t('admin.text_color_picker.announced', { values: { hex: norm } });
+		onchange?.(norm);
+	}
+
+	function commitHex() {
+		const norm = normalizeHex(hexInput);
+		if (!norm) {
+			value = '';
+			hexError = '';
+			announce = $t('admin.text_color_picker.announced_reset');
+			onchange?.('');
+			return;
+		}
+		if (!isValidHexColor(norm)) {
+			hexError = $t('admin.text_color_picker.invalid');
+			return;
+		}
+		hexError = '';
+		value = norm;
+		hexInput = norm;
+		announce = $t('admin.text_color_picker.announced', { values: { hex: norm } });
+		onchange?.(norm);
+	}
+
+	function handleHexInput(e: Event) {
+		hexInput = (e.currentTarget as HTMLInputElement).value;
+		if (hexError) hexError = '';
+	}
+
+	function reset() {
+		value = '';
+		hexInput = '';
+		hexError = '';
+		announce = $t('admin.text_color_picker.announced_reset');
+		onchange?.('');
+	}
+
+	async function handleSwatchKeyDown(e: KeyboardEvent) {
+		const last = SUGGESTIONS.length - 1;
+		let next = focusedIndex;
+		switch (e.key) {
+			case 'ArrowRight':
+			case 'ArrowDown':
+				next = focusedIndex >= last ? 0 : focusedIndex + 1;
+				break;
+			case 'ArrowLeft':
+			case 'ArrowUp':
+				next = focusedIndex <= 0 ? last : focusedIndex - 1;
+				break;
+			case 'Home':
+				next = 0;
+				break;
+			case 'End':
+				next = last;
+				break;
+			default:
+				return;
+		}
+		e.preventDefault();
+		pick(SUGGESTIONS[next].hex);
+		await tick();
+		swatchRefs[next]?.focus();
+	}
+</script>
+
+<fieldset class="space-y-4">
+	<legend class="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+		{$t('admin.text_color_picker.label')}
+	</legend>
+	<p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+		{$t('admin.text_color_picker.description')}
+	</p>
+
+	<!-- Curated suggestions — WAI-ARIA APG radio pattern with roving tabindex -->
+	<div
+		role="radiogroup"
+		aria-label={$t('admin.text_color_picker.suggestions_label')}
+		tabindex={-1}
+		class="flex flex-wrap gap-3"
+		onkeydown={handleSwatchKeyDown}
+	>
+		{#each SUGGESTIONS as s, i (s.hex)}
+			{@const isChecked = normalized.toLowerCase() === s.hex.toLowerCase()}
+			<button
+				type="button"
+				role="radio"
+				aria-checked={isChecked}
+				aria-label={$t(s.labelKey)}
+				tabindex={i === focusedIndex ? 0 : -1}
+				bind:this={swatchRefs[i]}
+				onclick={() => pick(s.hex)}
+				class="relative aspect-square w-12 h-12 rounded-xl border-2 transition-all duration-200 ring-offset-2 ring-offset-white dark:ring-offset-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 dark:focus-visible:ring-white {isChecked
+					? 'border-gray-900 dark:border-white scale-110'
+					: 'border-transparent hover:scale-105'}"
+				style="background-color: {s.hex}"
+			>
+				{#if isChecked}
+					<div class="absolute inset-0 flex items-center justify-center">
+						<svg class="w-5 h-5 text-white drop-shadow" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+						</svg>
+					</div>
+				{/if}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Custom hex input -->
+	<div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+		<label for="text-color-hex-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+			{$t('admin.text_color_picker.custom_label')}
+		</label>
+		<div class="flex items-center gap-2">
+			<span
+				class="inline-block w-11 h-11 rounded-lg border border-gray-300 dark:border-gray-600 shrink-0"
+				style="background-color: {normalized || '#ffffff'}"
+				aria-hidden="true"
+			></span>
+			<input
+				id="text-color-hex-input"
+				type="text"
+				bind:value={hexInput}
+				oninput={handleHexInput}
+				onblur={commitHex}
+				onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitHex(); } }}
+				placeholder={$t('admin.text_color_picker.custom_placeholder')}
+				maxlength="7"
+				spellcheck="false"
+				autocomplete="off"
+				autocapitalize="off"
+				autocorrect="off"
+				aria-invalid={hexError !== ''}
+				aria-describedby="text-color-hex-help text-color-hex-error"
+				class="input flex-1 font-mono"
+			/>
+			{#if normalized}
+				<button
+					type="button"
+					onclick={reset}
+					class="px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors min-h-11"
+				>
+					{$t('admin.text_color_picker.reset')}
+				</button>
+			{/if}
+		</div>
+		<p id="text-color-hex-help" class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+			{$t('admin.text_color_picker.custom_help')}
+		</p>
+		<p
+			id="text-color-hex-error"
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			class="text-sm text-red-600 dark:text-red-400 mt-1 min-h-[1.25rem]"
+		>
+			{hexError}
+		</p>
+	</div>
+
+	<!-- Live region for confirmation announcements (visually hidden) -->
+	<span class="sr-only" aria-live="polite" aria-atomic="true">{announce}</span>
+
+	<!-- Live CLAMPED preview — shows the actual rendered ink for both modes, so
+	     "what you pick is what you get, and it is always readable". -->
+	{#if ink}
+		<div class="rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 mt-4">
+			<span class="block px-4 pt-3 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide font-medium">
+				{$t('admin.text_color_picker.preview_label')}
+			</span>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-px bg-gray-200 dark:bg-gray-700 mt-3">
+				<!-- Light mode preview (clamped vs white surface) -->
+				<div class="p-4" style="background-color: #ffffff;">
+					<span class="block text-[10px] uppercase tracking-wide font-semibold mb-2" style="color: #6b7280;">
+						{$t('admin.text_color_picker.preview_light')} · {ink.light}
+					</span>
+					<span class="block text-lg font-bold" style="color: {ink.light};">
+						{$t('admin.text_color_picker.preview_heading')}
+					</span>
+					<span class="block text-sm" style="color: {ink.light};">
+						{$t('admin.text_color_picker.preview_body')}
+					</span>
+				</div>
+				<!-- Dark mode preview (clamped vs dark surface) -->
+				<div class="p-4" style="background-color: #221e1a;">
+					<span class="block text-[10px] uppercase tracking-wide font-semibold mb-2" style="color: #ada199;">
+						{$t('admin.text_color_picker.preview_dark')} · {ink.dark}
+					</span>
+					<span class="block text-lg font-bold" style="color: {ink.dark};">
+						{$t('admin.text_color_picker.preview_heading')}
+					</span>
+					<span class="block text-sm" style="color: {ink.dark};">
+						{$t('admin.text_color_picker.preview_body')}
+					</span>
+				</div>
+			</div>
+			<p class="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
+				{$t('admin.text_color_picker.aaa_note')}
+			</p>
+		</div>
+	{/if}
+</fieldset>

--- a/frontend/src/components/admin/ViewPreview.svelte
+++ b/frontend/src/components/admin/ViewPreview.svelte
@@ -58,6 +58,7 @@
 		// Props from parent editor
 		profile?: Profile | null;
 		accentColor?: AccentColor | null; // View-specific accent color
+		heroLayout?: string | null; // View hero layout (null = inherit from profile)
 		heroHeadline?: string;
 		heroSummary?: string;
 		ctaText?: string;
@@ -105,6 +106,7 @@
 	let {
 		profile = null,
 		accentColor = null,
+		heroLayout = null,
 		heroHeadline = '',
 		heroSummary = '',
 		ctaText = '',
@@ -214,6 +216,14 @@
 				summary: heroSummary || profile.summary
 			}
 		: null);
+
+	// Effective hero layout (view override > profile default > standard) and the
+	// rail flag that drives the 2-col grid in the mini-preview.
+	let effectiveHeroLayout = $derived(
+		(heroLayout || (profile as Profile | null)?.hero_layout || 'standard') as
+			'standard' | 'centered' | 'split' | 'minimal' | 'stacked' | 'rail'
+	);
+	let useRailLayout = $derived(effectiveHeroLayout === 'rail');
 	// Reactive computation of all section data - ensures updates when props change
 	let computedSections = $derived(computeAllSections(sections, sectionItems));
 	// Reactive count of visible sections for empty state check (includes custom content)
@@ -262,10 +272,14 @@
 </script>
 
 <div class="preview-container" class:preview-mobile={previewMode === 'mobile'} style={accentStyles}>
+	<!-- Rail layout: 2-col grid wraps the hero (col 1) + CTA/content (col 2)
+	     so the rail sidebar previews correctly. Other layouts fall back to
+	     display:contents (no structural change). -->
+	<div class={useRailLayout ? 'preview-rail-grid' : 'contents'}>
 	<!-- Mini Hero -->
 	{#if effectiveProfile}
 		<div class="preview-hero">
-			<ProfileHero profile={effectiveProfile} />
+			<ProfileHero profile={effectiveProfile} layout={effectiveHeroLayout} />
 		</div>
 	{:else}
 		<div class="preview-hero-placeholder">
@@ -278,6 +292,7 @@
 		</div>
 	{/if}
 
+	<div class={useRailLayout ? 'min-w-0' : 'contents'}>
 	<!-- CTA Banner Preview -->
 	{#if ctaText && ctaUrl}
 		<div class="bg-primary-600 text-white py-2 px-4">
@@ -381,9 +396,17 @@
 			</div>
 		{/if}
 	</div>
+	</div><!-- /content column (rail col 2) -->
+	</div><!-- /rail grid wrapper -->
 </div>
 
 <style>
+	.preview-rail-grid {
+		display: grid;
+		grid-template-columns: minmax(120px, 200px) minmax(0, 1fr);
+		align-items: start;
+	}
+
 	.preview-container {
 		background: var(--color-bg-primary, white);
 		border-radius: 0.5rem;

--- a/frontend/src/components/public/ProfileHero.svelte
+++ b/frontend/src/components/public/ProfileHero.svelte
@@ -4,7 +4,7 @@
 	import { parseMarkdown } from '$lib/utils';
 	import { hexLuminance, DARK_TEXT_THRESHOLD, isValidHexColor } from '$lib/colors';
 
-	type HeroLayout = 'standard' | 'centered' | 'split' | 'minimal' | 'stacked';
+	type HeroLayout = 'standard' | 'centered' | 'split' | 'minimal' | 'stacked' | 'rail';
 	type HeroSpacing = 'compact' | 'default' | 'spacious' | '';
 
 	interface Props {
@@ -238,6 +238,78 @@
 		{/if}
 	</div>
 </header>
+
+{:else if layout === 'rail'}
+<!-- Rail: sticky warm sidebar ~320px + main content column (wired by the
+     page route via a 2-col grid). Mobile collapses to a top strip. -->
+<aside
+	class="rail-hero relative {effectiveBgColor !== '' ? '' : 'bg-[var(--surface-2)]'} text-[var(--ink)] border-b md:border-b-0 md:border-r border-[var(--border)] md:sticky md:top-0 md:h-screen md:overflow-y-auto"
+	style={headerBgStyle}
+	aria-label={$t('public.hero.rail_sidebar_label')}
+	itemscope
+	itemtype="https://schema.org/Person"
+>
+	<div class="px-6 sm:px-7 py-8 md:py-10">
+		{#if avatarUrl}
+			<img
+				src={avatarUrl}
+				alt={profile?.name ? $t('public.hero.profile_photo_alt', { values: { name: profile.name } }) : $t('public.hero.profile_photo_generic')}
+				class="w-[72px] h-[72px] rounded-full object-cover mb-5 shadow-[var(--sh-2)]"
+			/>
+		{:else if showAvatar && profile?.name}
+			<div class="w-[72px] h-[72px] rounded-full bg-[var(--accent)] text-white flex items-center justify-center text-2xl font-bold mb-5" role="img" aria-label={$t('public.hero.profile_initial_alt', { values: { name: profile.name } })}>
+				{profile.name.charAt(0)}
+			</div>
+		{/if}
+
+		{#if profile?.name}
+			<h1 class="hero-name text-[26px] font-extrabold tracking-tight mb-2 text-[var(--ink)]" style="line-height: 1.1; letter-spacing: -0.02em;" itemprop="name">
+				{profile.name}
+			</h1>
+		{/if}
+
+		{#if profile?.headline}
+			<p class="text-sm text-[var(--muted)] mb-4 leading-snug" itemprop="jobTitle">
+				{profile.headline}
+			</p>
+		{/if}
+
+		{#if profile?.location}
+			<p class="flex items-center gap-1.5 text-xs text-[var(--muted)] mb-5" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+				<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+				</svg>
+				<span class="sr-only">{$t('public.hero.location_label')}</span>
+				<span itemprop="addressLocality">{profile.location}</span>
+			</p>
+		{/if}
+
+		{#if profile?.summary}
+			<div class="prose prose-sm max-w-none mb-6 text-[var(--muted)]" itemprop="description">
+				{@html parseMarkdown(profile.summary)}
+			</div>
+		{/if}
+
+		{#if contactLinks.length > 0}
+			<nav class="flex flex-col gap-2" aria-label={$t('public.hero.contact_links_label')}>
+				{#each contactLinks as link}
+					<a
+						href={link.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-2 px-3 py-2 rounded-[9px] text-sm bg-[var(--surface)] border border-[var(--border)] text-[var(--ink)] hover:bg-[var(--chip)] transition-colors"
+						aria-label={$t('public.hero.opens_new_tab', { values: { label: link.label || link.type } })}
+						itemprop={link.type === 'email' ? 'email' : 'sameAs'}
+					>
+						{@render contactIcon(link.type)}
+						<span>{link.label || link.type}</span>
+					</a>
+				{/each}
+			</nav>
+		{/if}
+	</div>
+</aside>
 
 {:else if layout === 'stacked'}
 <!-- Stacked: Headline at top, full-width image below -->

--- a/frontend/src/components/public/ProfileHero.svelte
+++ b/frontend/src/components/public/ProfileHero.svelte
@@ -241,11 +241,12 @@
 
 {:else if layout === 'rail'}
 <!-- Rail: sticky warm sidebar ~320px + main content column (wired by the
-     page route via a 2-col grid). Mobile collapses to a top strip. -->
-<aside
+     page route via a 2-col grid). Mobile collapses to a top strip.
+     Uses <header> (banner landmark) like the other five layouts — it carries
+     the page's primary <h1>/identity, so <aside>/complementary would be wrong. -->
+<header
 	class="rail-hero relative {effectiveBgColor !== '' ? '' : 'bg-[var(--surface-2)]'} text-[var(--ink)] border-b md:border-b-0 md:border-r border-[var(--border)] md:sticky md:top-0 md:h-screen md:overflow-y-auto"
 	style={headerBgStyle}
-	aria-label={$t('public.hero.rail_sidebar_label')}
 	itemscope
 	itemtype="https://schema.org/Person"
 >
@@ -309,7 +310,7 @@
 			</nav>
 		{/if}
 	</div>
-</aside>
+</header>
 
 {:else if layout === 'stacked'}
 <!-- Stacked: Headline at top, full-width image below -->

--- a/frontend/src/components/public/ProfileNav.svelte
+++ b/frontend/src/components/public/ProfileNav.svelte
@@ -154,7 +154,7 @@
 </script>
 
 {#if navItems.length > 0}
-	<nav class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-30 print:hidden">
+	<nav aria-label={$t('public.nav.sections_label')} class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-30 print:hidden">
 		<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
 			<div class="flex items-center gap-1 py-2 overflow-x-auto scrollbar-hide -mx-4 px-4 sm:mx-0 sm:px-0">
 				{#each navItems as item (item.id)}

--- a/frontend/src/components/public/ProjectsSection.svelte
+++ b/frontend/src/components/public/ProjectsSection.svelte
@@ -11,13 +11,14 @@
 
 	let { items, layout = 'grid-3', viewSlug = '' }: Props = $props();
 
-	// Soft Premium opt-in detection. SSR always renders the classic branch (the
-	// server injects data-design on <html> *after* component render, so it is not
-	// observable here), keeping classic output byte-identical. After mount we read
-	// the attribute and, only under soft-premium, swap in the refined serif initial
-	// plate. The post-mount swap touches the cover-less fallback only.
+	// Soft Premium is always on, so data-design="soft-premium" is present on the
+	// document root at SSR time (injected by hooks.server.ts). The cover-less
+	// fallback plate therefore renders the warm sp-plate directly in the markup;
+	// every plate selector is gated by [data-design='soft-premium'] in the style
+	// block, so the refined serif initial plate paints on first paint with no
+	// post-mount swap and no flash.
 	// Code-point-safe first character (emoji/multibyte titles are not split mid
-	// surrogate-pair, unlike charAt(0)). Used only for the soft-premium serif plate.
+	// surrogate-pair, unlike charAt(0)). Used for the soft-premium serif plate.
 	const initial = (title: string) => [...(title ?? '')][0] ?? '';
 
 	// Validate operator-supplied URLs against a scheme allowlist before rendering

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import type { Handle } from '@sveltejs/kit';
 import PocketBase from 'pocketbase';
 import { PB_COOKIE_NAME } from '$lib/pocketbase';
-import { generateAccentCSSVars, SOFT_PREMIUM_DEFAULT_ACCENT } from '$lib/colors';
+import { generateAccentCSSVars, generateTextInkCSSVars, SOFT_PREMIUM_DEFAULT_ACCENT } from '$lib/colors';
 import { generateFontCSSVars, getGoogleFontsUrl, DEFAULT_FONT_PACK } from '$lib/fonts';
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -22,6 +22,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 	let operatorFontPack = '';
 	let operatorAccent = '';
 	let operatorCustomHex = '';
+	let operatorTextColor = '';
 	try {
 		const homepageRes = await fetch(`${pbUrl}/api/homepage`, {
 			headers: { 'X-Internal': 'true' }
@@ -31,8 +32,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 			operatorAccent = homepage.profile?.accent_color || '';
 			operatorCustomHex = homepage.profile?.custom_hex_color || '';
 			operatorFontPack = homepage.profile?.font_pack || '';
+			operatorTextColor = homepage.profile?.text_color || '';
 		}
 	} catch { /* silent - fallback to client-side application */ }
+
+	// Text (font) color: derive a per-mode AAA-clamped ink from the operator's
+	// chosen hue and inject --text-ink (light) + --text-ink-dark (dark). Empty ⇒
+	// '' ⇒ nothing injected ⇒ default render unchanged. The clamp lives in
+	// colors.ts (deriveTextInk) and is exercised by the AAA proof test.
+	const textInkCSSVars = generateTextInkCSSVars(operatorTextColor);
 
 	// Soft Premium is the only design — always on. The warm token layer keys off
 	// the data-design attribute, hardcoded where the <html> tag is composed below
@@ -79,6 +87,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 						.replace(/;?\s*$/, ';')
 				);
 			}
+			if (textInkCSSVars) {
+				varParts.push(
+					textInkCSSVars
+						.replace(/^:root\s*\{/, '')
+						.replace(/\}\s*$/, '')
+						.trim()
+						.replace(/\s+/g, ' ')
+						.replace(/;?\s*$/, ';')
+				);
+			}
 
 			let result = html;
 
@@ -86,6 +104,12 @@ export const handle: Handle = async ({ event, resolve }) => {
 			// attribute and the inline style vars both land. Soft Premium is always
 			// on, so data-design is always emitted.
 			const htmlAttrs: string[] = ['data-design="soft-premium"'];
+			// data-text-ink gates the scoped text-color rules in app.css. Present
+			// ONLY when the operator set a color, so the default render carries no
+			// text-ink rules at all (byte-identical to today).
+			if (textInkCSSVars) {
+				htmlAttrs.push('data-text-ink');
+			}
 			if (varParts.length > 0) {
 				htmlAttrs.push(`style="${varParts.join(' ')}"`);
 			}

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -498,6 +498,129 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 }
 
 /**
+ * AAA text-ink targets and reference surfaces.
+ *
+ * Body/heading text on the public profile can land on any of several surfaces in
+ * each mode. We clamp the operator's hue against the WORST-CASE surface — the one
+ * that yields the LOWEST contrast for that ink — so clearing 7:1 there guarantees
+ * AAA on every other surface text can land on, by construction.
+ *
+ * The worst case differs by mode because of which side of the surface the ink is:
+ *
+ *  - Light mode (ink is DARKER than the surface): contrast = (L_surf+0.05)/(L_ink+0.05),
+ *    which INCREASES with surface luminance. So the DARKEST light surface is the
+ *    worst case. Text lands on `--surface` (#ffffff), but also directly on the warm
+ *    `--bg` (#fbf8f4) and soft-premium `--bg` (#fef9f6), which are DARKER than white
+ *    and therefore LOWER-contrast for dark ink. The darkest of these is #fbf8f4
+ *    (L≈0.9418), so we clamp against it; clearing 7:1 on #fbf8f4 also clears the
+ *    lighter #fef9f6 and #ffffff automatically.
+ *  - Dark mode (ink is LIGHTER than the surface): contrast = (L_ink+0.05)/(L_surf+0.05),
+ *    which DECREASES with surface luminance. So the LIGHTEST dark surface is the
+ *    worst case. Text lands on `--surface` (#221e1a, L≈0.0134) and the darker `--bg`
+ *    (#1a1613, L≈0.0084); #221e1a is the lighter (higher-L) → worst case. Clearing
+ *    7:1 on #221e1a also clears it on the darker #1a1613.
+ *
+ * NOTE: if a future design token introduces a light-mode text surface DARKER than
+ * #fbf8f4, or a dark-mode surface LIGHTER than #221e1a, these constants must be
+ * updated — the guarantee is only as strong as "clamp against the worst-case
+ * surface." See tests/text-color-aaa.spec.ts for the regression proof.
+ */
+export const TEXT_INK_MIN_CONTRAST = 7;
+// Worst-case (lowest-contrast) surface per mode — see block comment above.
+// Light: darkest surface tinted text lands on (warm --bg), NOT white.
+const TEXT_INK_LIGHT_SURFACE = '#fbf8f4';
+// Dark: lightest dark surface tinted text lands on (dark --surface).
+const TEXT_INK_DARK_SURFACE = '#221e1a';
+
+/** Contrast ratio between two relative luminances (WCAG 2.x), order-independent. */
+function contrastRatio(l1: number, l2: number): number {
+	const hi = Math.max(l1, l2);
+	const lo = Math.min(l1, l2);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Derive a per-mode, hue-preserved, AAA-clamped text ink from an operator's hue.
+ *
+ * Returns `{ light, dark }` hex strings, both guaranteed to clear 7:1 against the
+ * WORST-CASE (lowest-contrast) surface text sits on in their respective modes (the
+ * warm `--bg` #fbf8f4 in light mode, the dark `--surface` #221e1a in dark mode).
+ *
+ * Mechanism (mirrors `clamp600`'s binary search): we only ever move lightness in
+ * the AAA-safe direction while keeping hue:
+ *  - Light ink: mix the hue toward BLACK (all channels scale toward 0 equally →
+ *    hue preserved) until contrast vs the warm --bg ≥ 7:1.
+ *  - Dark ink: mix the hue toward WHITE (all channels scale toward 255 equally →
+ *    hue preserved) until contrast vs the dark surface ≥ 7:1.
+ *
+ * Black (light) and white (dark) always satisfy 7:1, so each search terminates.
+ * Invalid input falls back to a neutral readable ink so the default never breaks.
+ */
+export function deriveTextInk(hex: string): { light: string; dark: string } {
+	if (!isValidHexColor(hex)) {
+		// Neutral, AAA-safe defaults (near-black on light, near-white on dark).
+		return { light: '#1a1613', dark: '#f4eee4' };
+	}
+	const r = parseInt(hex.slice(1, 3), 16);
+	const g = parseInt(hex.slice(3, 5), 16);
+	const b = parseInt(hex.slice(5, 7), 16);
+
+	const mix = (base: number, target: number, amount: number): number =>
+		Math.round(base + (target - base) * amount);
+	const toHex = (red: number, green: number, blue: number): string =>
+		'#' + [red, green, blue].map((c) => c.toString(16).padStart(2, '0')).join('');
+
+	const surfaceLum = (surface: string): number => {
+		const sr = parseInt(surface.slice(1, 3), 16);
+		const sg = parseInt(surface.slice(3, 5), 16);
+		const sb = parseInt(surface.slice(5, 7), 16);
+		return channelLuminance(sr, sg, sb);
+	};
+
+	// Binary-search the smallest mix `amount` (toward `target`) whose resulting ink
+	// clears 7:1 against `surface`. amount=0 is the raw hue; amount=1 is the target
+	// (black or white), which always passes — so the bracket [0,1] always contains
+	// a solution and the search converges.
+	const clamp = (target: number, surface: string): string => {
+		const surfL = surfaceLum(surface);
+		const inkLum = (amount: number): number =>
+			channelLuminance(mix(r, target, amount), mix(g, target, amount), mix(b, target, amount));
+		// Already AAA at the raw hue? Honor it exactly.
+		if (contrastRatio(inkLum(0), surfL) >= TEXT_INK_MIN_CONTRAST) {
+			return toHex(r, g, b);
+		}
+		let lo = 0;
+		let hi = 1;
+		for (let i = 0; i < 24; i++) {
+			const mAmt = (lo + hi) / 2;
+			if (contrastRatio(inkLum(mAmt), surfL) >= TEXT_INK_MIN_CONTRAST) hi = mAmt;
+			else lo = mAmt;
+		}
+		return toHex(mix(r, target, hi), mix(g, target, hi), mix(b, target, hi));
+	};
+
+	return {
+		light: clamp(0, TEXT_INK_LIGHT_SURFACE), // darken toward black
+		dark: clamp(255, TEXT_INK_DARK_SURFACE) // lighten toward white
+	};
+}
+
+/**
+ * Build the SSR `<style>`/inline CSS-var declarations for the operator's text
+ * color. Returns `--text-ink` (light value) and `--text-ink-dark` (dark value)
+ * as a `:root { ... }` block, or '' when no color is set (so the default render
+ * is byte-identical to today — nothing is injected, the scoped rule no-ops).
+ */
+export function generateTextInkCSSVars(textColor?: string | null): string {
+	if (!textColor || !isValidHexColor(textColor)) return '';
+	const { light, dark } = deriveTextInk(textColor);
+	return `:root {
+		--text-ink: ${light};
+		--text-ink-dark: ${dark};
+	}`;
+}
+
+/**
  * Generate CSS custom properties for accent color (works server-side, no DOM needed).
  * Returns a CSS string that can be injected into <style> tags for SSR.
  */

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -464,13 +464,14 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 	// because all channels scale toward 0 equally) until white text on it clears
 	// 7:1. Starts at the nominal 0.15 darkening and only ever goes darker, so the
 	// accent hue is preserved and the change is strictly more accessible. Black
-	// always passes, so the search terminates.
-	function clamp600(): string {
+	// always passes, so the search terminates. Returns the resolved mix-toward-black
+	// AMOUNT (not the hex) so the darker shades can be floored above it (see below).
+	function clamp600Amount(): number {
 		const baseAmount = 0.15;
 		const lum = (amount: number) =>
 			channelLuminance(mix(r, 0, amount), mix(g, 0, amount), mix(b, 0, amount));
 		if (whiteOnColorContrast(lum(baseAmount)) >= ACCENT_MIN_CONTRAST) {
-			return toHex(mix(r, 0, baseAmount), mix(g, 0, baseAmount), mix(b, 0, baseAmount));
+			return baseAmount;
 		}
 		let lo = baseAmount;
 		let hi = 1;
@@ -479,8 +480,22 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 			if (whiteOnColorContrast(lum(m)) >= ACCENT_MIN_CONTRAST) hi = m;
 			else lo = m;
 		}
-		return toHex(mix(r, 0, hi), mix(g, 0, hi), mix(b, 0, hi));
+		return hi;
 	}
+
+	// For a PALE custom accent (e.g. #ffe066), the AAA clamp above can drive 600's
+	// darkening amount well past the nominal 0.30 used for 700. Left unguarded, that
+	// makes 600 DARKER than 700, a non-monotonic (inverted) ramp. Floor each darker
+	// shade strictly above the clamped 600 amount so the scale stays monotonic from
+	// 600 through 950 regardless of how deep the clamp had to go. The nominal mixes
+	// (0.30/0.45/0.60/0.80) are preserved for normal accents where 600's amount sits
+	// at or below 0.30.
+	const a600 = clamp600Amount();
+	const a700 = Math.max(0.30, a600 + 0.07);
+	const a800 = Math.max(0.45, a700 + 0.10);
+	const a900 = Math.max(0.60, a800 + 0.12);
+	const a950 = Math.max(0.80, a900 + 0.10);
+	const mixBlack = (amount: number) => toHex(mix(r, 0, amount), mix(g, 0, amount), mix(b, 0, amount));
 
 	return {
 		50:  toHex(mix(r, 255, 0.95), mix(g, 255, 0.95), mix(b, 255, 0.95)),
@@ -489,11 +504,11 @@ export function generatePaletteFromHex(hex: string): ColorScale {
 		300: toHex(mix(r, 255, 0.55), mix(g, 255, 0.55), mix(b, 255, 0.55)),
 		400: toHex(mix(r, 255, 0.30), mix(g, 255, 0.30), mix(b, 255, 0.30)),
 		500: hex,
-		600: clamp600(),
-		700: toHex(mix(r, 0, 0.30), mix(g, 0, 0.30), mix(b, 0, 0.30)),
-		800: toHex(mix(r, 0, 0.45), mix(g, 0, 0.45), mix(b, 0, 0.45)),
-		900: toHex(mix(r, 0, 0.60), mix(g, 0, 0.60), mix(b, 0, 0.60)),
-		950: toHex(mix(r, 0, 0.80), mix(g, 0, 0.80), mix(b, 0, 0.80)),
+		600: mixBlack(a600),
+		700: mixBlack(a700),
+		800: mixBlack(a800),
+		900: mixBlack(a900),
+		950: mixBlack(a950),
 	};
 }
 

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -67,7 +67,7 @@ export interface Profile {
 	visibility: 'public' | 'unlisted' | 'private';
 	accent_color?: 'sky' | 'indigo' | 'emerald' | 'rose' | 'amber' | 'slate';
 	custom_hex_color?: string;
-	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric';
+	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | 'soft-premium';
 	hero_layout?: 'standard' | 'centered' | 'split' | 'minimal' | 'stacked';
 	hero_spacing?: 'compact' | 'default' | 'spacious';
 	hero_bg_color?: string;
@@ -429,7 +429,7 @@ export interface View {
 	is_active: boolean;
 	is_default?: boolean;
 	accent_color?: 'sky' | 'indigo' | 'emerald' | 'rose' | 'amber' | 'slate' | null;
-	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | null;
+	font_pack?: 'editorial' | 'modern' | 'classic' | 'technical' | 'editorial-bold' | 'humanist' | 'geometric' | 'soft-premium' | null;
 	hero_layout?: 'standard' | 'centered' | 'split' | 'minimal' | 'stacked' | null;
 	hero_spacing?: 'compact' | 'default' | 'spacious' | null;
 	hero_bg_color?: string | null;

--- a/frontend/src/lib/stores/userPreferences.ts
+++ b/frontend/src/lib/stores/userPreferences.ts
@@ -1,0 +1,74 @@
+/**
+ * User preferences store.
+ *
+ * Per-user toggles that should persist across sessions. Backed by
+ * localStorage under a single key (`facet-user-prefs`). Defaults are
+ * intentionally conservative — every new pref ships OFF until the user
+ * explicitly opts in, so existing installs see zero behavior change.
+ *
+ * Client-only: on the server `load()` returns DEFAULTS and `persist()` is
+ * a no-op.
+ */
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'facet-user-prefs';
+
+export interface UserPreferences {
+	/** When true, admin layout renders a right-column iframe of the public
+	 *  profile as a live preview. Default OFF. */
+	livePreviewEnabled: boolean;
+}
+
+const DEFAULTS: UserPreferences = {
+	livePreviewEnabled: false
+};
+
+function load(): UserPreferences {
+	if (!browser) return DEFAULTS;
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return DEFAULTS;
+		const parsed = JSON.parse(raw) as Partial<UserPreferences>;
+		return { ...DEFAULTS, ...parsed };
+	} catch {
+		return DEFAULTS;
+	}
+}
+
+function persist(value: UserPreferences): void {
+	if (!browser) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+	} catch {
+		/* localStorage quota or private-mode — ignore, in-memory only */
+	}
+}
+
+function createUserPreferencesStore() {
+	const { subscribe, set, update } = writable<UserPreferences>(load());
+
+	return {
+		subscribe,
+		set: (value: UserPreferences) => {
+			persist(value);
+			set(value);
+		},
+		/** Atomic update — passes current value, expects new value back. */
+		update: (updater: (current: UserPreferences) => UserPreferences) =>
+			update((current) => {
+				const next = updater(current);
+				persist(next);
+				return next;
+			}),
+		/** Convenience: set a single pref by key without mangling the rest. */
+		setPref: <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) =>
+			update((current) => {
+				const next = { ...current, [key]: value };
+				persist(next);
+				return next;
+			})
+	};
+}
+
+export const userPreferences = createUserPreferencesStore();

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -2771,13 +2771,13 @@
       "profile_photo_generic": "Profilfoto",
       "profile_initial_alt": "Profilinitialen von {name}",
       "contact_links_label": "Kontaktlinks",
-      "opens_new_tab": "{label} (öffnet in neuem Tab)",
-      "rail_sidebar_label": "Profil-Seitenleiste"
+      "opens_new_tab": "{label} (öffnet in neuem Tab)"
     },
     "nav": {
       "home": "Startseite",
       "back_to": "Zurück zu {page}",
-      "open_main_menu": "Hauptmenü öffnen"
+      "open_main_menu": "Hauptmenü öffnen",
+      "sections_label": "Abschnittsnavigation"
     },
     "password": {
       "title": "Passwortgeschützt",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1063,7 +1063,11 @@
       "demo": "Demo",
       "demo_on": "AN",
       "toggle_demo_mode": "Demo-Modus umschalten",
-      "opens_new_tab": "{label} (öffnet in neuem Tab)"
+      "opens_new_tab": "{label} (öffnet in neuem Tab)",
+      "live_preview_toggle": "Live-Vorschau umschalten",
+      "live_preview_label": "Vorschau",
+      "live_preview_on": "An",
+      "live_preview_off": "Aus"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "Einstellungen",
         "description": "Konto, Website, Integrationen und Entwicklertools."
       }
+    },
+    "site_preview": {
+      "heading": "Live-Vorschau",
+      "iframe_title": "Live-Vorschau Ihrer öffentlichen Seite",
+      "readonly_note": "Diese Vorschau ist schreibgeschützt und nicht per Tastatur bedienbar. Zum Ausblenden ausschalten.",
+      "ready_announce": "Live-Vorschau bereit",
+      "error_announce": "Live-Vorschau nicht verfügbar"
     }
   },
   "public": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "Akzentfarbe auf {hex} gesetzt",
       "announced_curated": "Akzentfarbe auf {name} gesetzt"
     },
+    "text_color_picker": {
+      "label": "Textfarbe",
+      "description": "Färbe Überschriften und Fließtext auf deiner öffentlichen Seite. Wir passen den Farbton automatisch an, damit er in hellem und dunklem Modus stets gut lesbar bleibt (WCAG AAA).",
+      "suggestions_label": "Vorgeschlagene Textfarben",
+      "suggestion_slate": "Schiefer",
+      "suggestion_graphite": "Graphit",
+      "suggestion_umber": "Umbra",
+      "suggestion_navy": "Marineblau",
+      "suggestion_forest": "Waldgrün",
+      "suggestion_plum": "Pflaume",
+      "custom_label": "Oder wähle eine eigene Hex-Farbe",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Sechs hexadezimale Zeichen (0-9, A-F), mit optionalem führenden #. Leer lassen für die Standardfarbe.",
+      "invalid": "Gib eine gültige Hex-Farbe ein (z. B. #1f2937)",
+      "reset": "Auf Standard zurücksetzen",
+      "preview_label": "Live-Vorschau (automatisch angepasst)",
+      "preview_light": "Heller Modus",
+      "preview_dark": "Dunkler Modus",
+      "preview_heading": "Überschrift",
+      "preview_body": "Hier steht ein Absatz Fließtext.",
+      "aaa_note": "Der angezeigte Farbton ist genau das, was auf deiner Seite erscheint. Er wird automatisch so begrenzt, dass er in jedem Modus einen Kontrast von 7:1 (WCAG AAA) zum Hintergrund erreicht.",
+      "announced": "Textfarbe auf {hex} gesetzt",
+      "announced_reset": "Textfarbe auf Standard zurückgesetzt",
+      "updated": "Textfarbe aktualisiert",
+      "error": "Textfarbe konnte nicht aktualisiert werden"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Facette bearbeiten",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -167,7 +167,9 @@
         "css_help_components": "Komponenten",
         "css_help_tip": "Tipp: Halten Sie CSS klein; vermeiden Sie das Ausblenden struktureller Elemente, die für Barrierefreiheit und Layout wichtig sind.",
         "font_pack_updated": "Typography updated",
-        "font_pack_error": "Failed to update typography"
+        "font_pack_error": "Failed to update typography",
+        "hero_layout_rail": "Seitenleiste",
+        "hero_layout_rail_desc": "Fixierte Seitenleiste links, Inhalt rechts"
       },
       "general": {
         "section_title": "Allgemein",
@@ -2769,7 +2771,8 @@
       "profile_photo_generic": "Profilfoto",
       "profile_initial_alt": "Profilinitialen von {name}",
       "contact_links_label": "Kontaktlinks",
-      "opens_new_tab": "{label} (öffnet in neuem Tab)"
+      "opens_new_tab": "{label} (öffnet in neuem Tab)",
+      "rail_sidebar_label": "Profil-Seitenleiste"
     },
     "nav": {
       "home": "Startseite",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -2771,13 +2771,13 @@
       "profile_photo_generic": "Visage",
       "profile_initial_alt": "Seal of {name}",
       "contact_links_label": "Paths of contact",
-      "opens_new_tab": "{label} (opens new window)",
-      "rail_sidebar_label": "Pillar of the wanderer"
+      "opens_new_tab": "{label} (opens new window)"
     },
     "nav": {
       "home": "Home",
       "back_to": "Return to {page}",
-      "open_main_menu": "Open main paths"
+      "open_main_menu": "Open main paths",
+      "sections_label": "Paths through the tale"
     },
     "password": {
       "title": "Warded Content",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "Accent color set to {hex}",
       "announced_curated": "Accent color set to {name}"
     },
+    "text_color_picker": {
+      "label": "Gwath i phith",
+      "description": "Maetho i tîw beleg a phith na i barth lîn. Cenim i gwath an i phith bain a thand (WCAG AAA) vi galad a vi dúath.",
+      "suggestions_label": "Gwaith i phith iestannen",
+      "suggestion_slate": "Gond Luin",
+      "suggestion_graphite": "Morn-glân",
+      "suggestion_umber": "Baran",
+      "suggestion_navy": "Luin-dûr",
+      "suggestion_forest": "Taur-laeg",
+      "suggestion_plum": "Gwaloth",
+      "custom_label": "Egor ceno gwath hej veleg",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Eneg tengw hex (0-9, A-F), na # ned-ohtar. Awartha an i gwath iaur.",
+      "invalid": "Anno gwath hex mae (sui #1f2937)",
+      "reset": "Danna an i gwath iaur",
+      "preview_label": "Tirith cuin (cennen)",
+      "preview_light": "Galad",
+      "preview_dark": "Dúath",
+      "preview_heading": "Têw beleg",
+      "preview_body": "Si nostach i phith o i barth.",
+      "aaa_note": "I gwath i cenich nan i gwath i thiâ nan i barth. Tortha cuin an i thand 7:1 (WCAG AAA) na i mbar vi pân lû.",
+      "announced": "Gwath i phith nan {hex}",
+      "announced_reset": "Gwath i phith danna an i gwath iaur",
+      "updated": "Gwath i phith cennen",
+      "error": "Ú-bell anno i gwath i phith"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Shape Facet",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -167,7 +167,9 @@
         "css_help_components": "Elements",
         "css_help_tip": "Wisdom: Keep weaving spare; avoid hiding structural elements that power accessibility and form.",
         "font_pack_updated": "Typography updated",
-        "font_pack_error": "Failed to update typography"
+        "font_pack_error": "Failed to update typography",
+        "hero_layout_rail": "Wayside",
+        "hero_layout_rail_desc": "Steadfast pillar to the left, tale to the right"
       },
       "general": {
         "section_title": "Common Matters",
@@ -2769,7 +2771,8 @@
       "profile_photo_generic": "Visage",
       "profile_initial_alt": "Seal of {name}",
       "contact_links_label": "Paths of contact",
-      "opens_new_tab": "{label} (opens new window)"
+      "opens_new_tab": "{label} (opens new window)",
+      "rail_sidebar_label": "Pillar of the wanderer"
     },
     "nav": {
       "home": "Home",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -1063,7 +1063,11 @@
       "demo": "Demo",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggle demonstration",
-      "opens_new_tab": "{label} (opens in new window)"
+      "opens_new_tab": "{label} (opens in new window)",
+      "live_preview_toggle": "Toggle the living glimpse",
+      "live_preview_label": "Glimpse",
+      "live_preview_on": "Lit",
+      "live_preview_off": "Dimmed"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "Panod",
         "description": "Estel, nost, gonathra a tegil curu."
       }
+    },
+    "site_preview": {
+      "heading": "Living glimpse",
+      "iframe_title": "A living glimpse of your public realm",
+      "readonly_note": "This glimpse is for the eyes only, not the hand. Dim it to hide it away.",
+      "ready_announce": "Living glimpse made ready",
+      "error_announce": "The living glimpse is veiled"
     }
   },
   "public": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1724,6 +1724,32 @@
       "announced_custom": "Accent color set to {hex}",
       "announced_curated": "Accent color set to {name}"
     },
+    "text_color_picker": {
+      "label": "Text color",
+      "description": "Tint headings and body text on your public page. We auto-adjust the shade so it always stays highly readable (WCAG AAA) in both light and dark mode.",
+      "suggestions_label": "Suggested text colors",
+      "suggestion_slate": "Slate",
+      "suggestion_graphite": "Graphite",
+      "suggestion_umber": "Umber",
+      "suggestion_navy": "Navy",
+      "suggestion_forest": "Forest",
+      "suggestion_plum": "Plum",
+      "custom_label": "Or pick a custom hex color",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Six hexadecimal characters (0-9, A-F), with optional leading #. Leave empty for the default ink.",
+      "invalid": "Enter a valid hex color (e.g. #1f2937)",
+      "reset": "Reset to default",
+      "preview_label": "Live preview (auto-adjusted)",
+      "preview_light": "Light mode",
+      "preview_dark": "Dark mode",
+      "preview_heading": "Heading text",
+      "preview_body": "Body paragraph text reads here.",
+      "aaa_note": "The shade shown is what renders on your page. It is automatically clamped to clear 7:1 contrast (WCAG AAA) against the background in each mode.",
+      "announced": "Text color set to {hex}",
+      "announced_reset": "Text color reset to default",
+      "updated": "Text color updated",
+      "error": "Failed to update text color"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Edit Facet",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1210,7 +1210,11 @@
       "demo": "Demo",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggle demo mode",
-      "opens_new_tab": "{label} (opens in new tab)"
+      "opens_new_tab": "{label} (opens in new tab)",
+      "live_preview_toggle": "Toggle live preview",
+      "live_preview_label": "Preview",
+      "live_preview_on": "On",
+      "live_preview_off": "Off"
     },
     "password_modal": {
       "title": "Change Password",
@@ -2754,6 +2758,13 @@
         "title": "Settings",
         "description": "Account, site, integrations, and developer tools."
       }
+    },
+    "site_preview": {
+      "heading": "Live preview",
+      "iframe_title": "Live preview of your public site",
+      "readonly_note": "This preview is read-only and not keyboard accessible. Toggle off to hide it.",
+      "ready_announce": "Live preview ready",
+      "error_announce": "Live preview unavailable"
     }
   },
   "public": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2771,13 +2771,13 @@
       "profile_photo_generic": "Profile photo",
       "profile_initial_alt": "{name}'s profile initial",
       "contact_links_label": "Contact links",
-      "opens_new_tab": "{label} (opens in new tab)",
-      "rail_sidebar_label": "Profile sidebar"
+      "opens_new_tab": "{label} (opens in new tab)"
     },
     "nav": {
       "home": "Home",
       "back_to": "Back to {page}",
-      "open_main_menu": "Open main menu"
+      "open_main_menu": "Open main menu",
+      "sections_label": "Section navigation"
     },
     "password": {
       "title": "Password Protected",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -167,7 +167,9 @@
         "css_help_description": "These selectors match the public site (not the admin UI). Start small and test on mobile.",
         "css_help_base": "Base",
         "css_help_components": "Components",
-        "css_help_tip": "Tip: Keep CSS small; avoid hiding structural elements that power accessibility and layout."
+        "css_help_tip": "Tip: Keep CSS small; avoid hiding structural elements that power accessibility and layout.",
+        "hero_layout_rail": "Rail",
+        "hero_layout_rail_desc": "Sticky sidebar on the left, content on the right"
       },
       "general": {
         "section_title": "General",
@@ -2769,7 +2771,8 @@
       "profile_photo_generic": "Profile photo",
       "profile_initial_alt": "{name}'s profile initial",
       "contact_links_label": "Contact links",
-      "opens_new_tab": "{label} (opens in new tab)"
+      "opens_new_tab": "{label} (opens in new tab)",
+      "rail_sidebar_label": "Profile sidebar"
     },
     "nav": {
       "home": "Home",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -167,7 +167,9 @@
         "css_help_components": "Components",
         "css_help_tip": "Tactical note: Keep code minimal; do not hide structural elements that power accessibility and layout.",
         "font_pack_updated": "Typography updated",
-        "font_pack_error": "Failed to update typography"
+        "font_pack_error": "Failed to update typography",
+        "hero_layout_rail": "Battle Rail",
+        "hero_layout_rail_desc": "Fixed war-banner at the left, conquest to the right"
       },
       "general": {
         "section_title": "General Operations",
@@ -2769,7 +2771,8 @@
       "profile_photo_generic": "Profile image",
       "profile_initial_alt": "{name}'s insignia",
       "contact_links_label": "Communication channels",
-      "opens_new_tab": "{label} (opens new window)"
+      "opens_new_tab": "{label} (opens new window)",
+      "rail_sidebar_label": "Warrior's flank banner"
     },
     "nav": {
       "home": "Home",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -2771,13 +2771,13 @@
       "profile_photo_generic": "Profile image",
       "profile_initial_alt": "{name}'s insignia",
       "contact_links_label": "Communication channels",
-      "opens_new_tab": "{label} (opens new window)",
-      "rail_sidebar_label": "Warrior's flank banner"
+      "opens_new_tab": "{label} (opens new window)"
     },
     "nav": {
       "home": "Home",
       "back_to": "Return to {page}",
-      "open_main_menu": "Open main command menu"
+      "open_main_menu": "Open main command menu",
+      "sections_label": "Battle section navigation"
     },
     "password": {
       "title": "Defended Access",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "Accent color set to {hex}",
       "announced_curated": "Accent color set to {name}"
     },
+    "text_color_picker": {
+      "label": "ngutlh rItlh",
+      "description": "publicHom Daq nargh ngutlh 'ej porgh ngutlh yIrItlhmoH. rItlh wIchoHmoH 'e' wIlaDlaHchugh reH (WCAG AAA) wovbe' 'ej wovqu'.",
+      "suggestions_label": "ngutlh rItlh chuvmey",
+      "suggestion_slate": "nagh SuD",
+      "suggestion_graphite": "qIj",
+      "suggestion_umber": "Doq qIj",
+      "suggestion_navy": "SuD'a'",
+      "suggestion_forest": "ngem SuD",
+      "suggestion_plum": "naH Doq",
+      "custom_label": "pagh hex rItlh DawIv",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "jav hex mIllogh (0-9, A-F), # tlhItlh DaH. rItlh motlh chovnatlhlu' chugh chImmoH.",
+      "invalid": "lugh hex rItlh yIghItlh (#1f2937 rur)",
+      "reset": "rItlh motlh Daq yIchegh",
+      "preview_label": "ral leghlu' (choHlu')",
+      "preview_light": "wovbe'",
+      "preview_dark": "wovqu'",
+      "preview_heading": "ngutlh nIvbogh",
+      "preview_body": "naDev porgh ngutlh laDlu'.",
+      "aaa_note": "rItlh leghlu'bogh 'oH publicHomDaq nargh'e'. reH 7:1 (WCAG AAA) Hutlhmey DuvDaq choHchu'lu' Hoch Daq.",
+      "announced": "{hex} ngutlh rItlh",
+      "announced_reset": "rItlh motlh Daq ngutlh rItlh chegh",
+      "updated": "ngutlh rItlh choHlu'",
+      "error": "ngutlh rItlh choHlaHbe'"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Modify Facet",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -1063,7 +1063,11 @@
       "demo": "Training",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggle training mode",
-      "opens_new_tab": "{label} (opens in new viewport)"
+      "opens_new_tab": "{label} (opens in new viewport)",
+      "live_preview_toggle": "Toggle live battle preview",
+      "live_preview_label": "Preview",
+      "live_preview_on": "On",
+      "live_preview_off": "Off"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "choH",
         "description": "SeH, qach, rar, je chenmoHwI' jan."
       }
+    },
+    "site_preview": {
+      "heading": "Live battle preview",
+      "iframe_title": "Live preview of your public site",
+      "readonly_note": "This preview is read-only and not keyboard accessible. Toggle off to hide it. Qapla'!",
+      "ready_announce": "Live preview ready! Qapla'!",
+      "error_announce": "Live preview unavailable. Dishonorable!"
     }
   },
   "public": {

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -167,7 +167,9 @@
         "css_help_components": "Componentz",
         "css_help_tip": "Tip: Keep CSS smol; avoid hidin struktural elementz dat powr aksessibility n layout.",
         "font_pack_updated": "Typography updated",
-        "font_pack_error": "Failed to update typography"
+        "font_pack_error": "Failed to update typography",
+        "hero_layout_rail": "Rail",
+        "hero_layout_rail_desc": "Sticky sidebar on teh left, stuffz on teh right"
       },
       "general": {
         "section_title": "Jeneral",
@@ -2769,7 +2771,8 @@
       "profile_photo_generic": "Profile foto",
       "profile_initial_alt": "{name}'z profile initial",
       "contact_links_label": "Contact linkz",
-      "opens_new_tab": "{label} (openz in new tab)"
+      "opens_new_tab": "{label} (openz in new tab)",
+      "rail_sidebar_label": "Profile sidebar"
     },
     "nav": {
       "home": "Hoem",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -1550,6 +1550,32 @@
       "announced_custom": "ACCENT COLOR SET 2 {hex}",
       "announced_curated": "ACCENT COLOR SET 2 {name}"
     },
+    "text_color_picker": {
+      "label": "Werdz Culah",
+      "description": "Maek ur big werdz an lil werdz on ur public payj haz culah. We fix teh shaed so it can reedz gud (WCAG AAA) in brite mode an dark mode.",
+      "suggestions_label": "Sugjestd werdz culahs",
+      "suggestion_slate": "Slaet",
+      "suggestion_graphite": "Pensil",
+      "suggestion_umber": "Brown",
+      "suggestion_navy": "Bloo",
+      "suggestion_forest": "Treez",
+      "suggestion_plum": "Plum",
+      "custom_label": "Or pik ur own hex culah",
+      "custom_placeholder": "#1f2937",
+      "custom_help": "Six hex letterz (0-9, A-F), wif optshunal # in frunt. Leev emptee for defalt ink.",
+      "invalid": "Givs a reel hex culah plz (liek #1f2937)",
+      "reset": "Bak to defalt",
+      "preview_label": "Liv peek (auto-fixd)",
+      "preview_light": "Brite mode",
+      "preview_dark": "Dark mode",
+      "preview_heading": "Big Werdz",
+      "preview_body": "Lil werdz go heer for reedin.",
+      "aaa_note": "Teh shaed u see iz wut showz on ur payj. We awtomatiklee skootch it til it haz 7:1 contrast (WCAG AAA) wif teh bakgrund in each mode.",
+      "announced": "Werdz culah iz now {hex}",
+      "announced_reset": "Werdz culah bak to defalt",
+      "updated": "Werdz culah chanjd",
+      "error": "Cudnt chanj werdz culah"
+    },
     "view_editor": {
       "page": {
         "title_edit": "Edit Facet",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -1063,7 +1063,11 @@
       "demo": "Demo",
       "demo_on": "ON",
       "toggle_demo_mode": "Toggl demo moed",
-      "opens_new_tab": "{label} (openz in noo windoe)"
+      "opens_new_tab": "{label} (openz in noo windoe)",
+      "live_preview_toggle": "Toggle liv preview",
+      "live_preview_label": "Lookz",
+      "live_preview_on": "On",
+      "live_preview_off": "Off"
     },
     "settings": {
       "favicon": {
@@ -2754,6 +2758,13 @@
         "title": "Settingz",
         "description": "Akkount, sait, hookupz, an nerd toolz."
       }
+    },
+    "site_preview": {
+      "heading": "Liv preview",
+      "iframe_title": "Liv lookz at ur publik sait",
+      "readonly_note": "Dis preview iz lookz-only, no keyboardz. Toggle off 2 hide it.",
+      "ready_announce": "Liv preview redy!",
+      "error_announce": "Liv preview no can has. Sad kitteh."
     }
   },
   "public": {

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -2771,13 +2771,13 @@
       "profile_photo_generic": "Profile foto",
       "profile_initial_alt": "{name}'z profile initial",
       "contact_links_label": "Contact linkz",
-      "opens_new_tab": "{label} (openz in new tab)",
-      "rail_sidebar_label": "Profile sidebar"
+      "opens_new_tab": "{label} (openz in new tab)"
     },
     "nav": {
       "home": "Hoem",
       "back_to": "Bak 2 {page}",
-      "open_main_menu": "Open main menu"
+      "open_main_menu": "Open main menu",
+      "sections_label": "Sekshun naviashun"
     },
     "password": {
       "title": "Passwurd Protektd",

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 	import Toast from '$components/shared/Toast.svelte';
 	import ConfirmDialog from '$components/shared/ConfirmDialog.svelte';
 	import { ACCENT_COLORS, DEFAULT_ACCENT_COLOR, type AccentColor, generatePaletteFromHex, hexToRgbChannels, buildPaletteRootBlock } from '$lib/colors';
-	import { getFontPack, DEFAULT_FONT_PACK, type FontPack } from '$lib/fonts';
+	import { getFontPack, type FontPack } from '$lib/fonts';
 	import { initI18n, setLocale, waitLocale } from '$lib/i18n';
 	import { isLoading as i18nLoading, t } from 'svelte-i18n';
 	import { initPlan, initPlanFromSSR, type PlanConfig } from '$lib/stores/plan';
@@ -193,19 +193,21 @@ function applyFlatAccent(color: string) {
   --font-code: '${pack.code}', ${pack.codeFallback};
 }`;
 
-		// Load Google Fonts for non-default packs
-		if (packName !== DEFAULT_FONT_PACK) {
-			if (!fontLinkEl) {
-				fontLinkEl = document.createElement('link');
-				fontLinkEl.id = 'dynamic-google-fonts';
-				fontLinkEl.rel = 'stylesheet';
-				document.head.appendChild(fontLinkEl);
-			}
-			fontLinkEl.href = pack.googleFontsUrl;
-		} else if (fontLinkEl) {
-			fontLinkEl.remove();
-			fontLinkEl = null;
+		// Ensure the resolved pack's Google Fonts are loaded, including the DEFAULT
+		// pack (soft-premium = Hanken Grotesk + Newsreader). app.html only statically
+		// loads the editorial fonts, and SSR (hooks.server.ts) injects the resolved
+		// pack's link on first paint; but this client applier re-runs on every SPA
+		// navigation. If the default pack special-cased *removing* the link, the
+		// default pack's fonts would drop on client nav and the page would fall back
+		// to Plus Jakarta. So we always (re)create/point the link at the resolved
+		// pack's URL, for the default pack too.
+		if (!fontLinkEl) {
+			fontLinkEl = document.createElement('link');
+			fontLinkEl.id = 'dynamic-google-fonts';
+			fontLinkEl.rel = 'stylesheet';
+			document.head.appendChild(fontLinkEl);
 		}
+		fontLinkEl.href = pack.googleFontsUrl;
 	}
 
 	async function loadAccentColor() {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -241,6 +241,15 @@
 	let navPinned = $state(false);
 	let sentinelEl: HTMLDivElement | null = $state(null);
 
+	// Rail layout: 2-column desktop with a sticky left sidebar. The hero
+	// renders as col 1 (the <aside>), page content flows in col 2. Non-rail
+	// layouts fall back to display:contents so they render byte-identically.
+	let effectiveHeroLayout = $derived(
+		(data.view?.hero_layout || data.profile?.hero_layout || 'standard') as
+			'standard' | 'centered' | 'split' | 'minimal' | 'stacked' | 'rail'
+	);
+	let useRailLayout = $derived(effectiveHeroLayout === 'rail');
+
 	// Apply view-specific accent color if default view has one
 	function applyAccentColor(colorName: AccentColor) {
 		if (!browser) return;
@@ -473,6 +482,26 @@
 		ssrNavItems={data.siteNav?.items}
 	/>
 
+	<!-- For rail layout, the below-hero SiteNav is lifted ABOVE the rail grid so
+	     it spans full width instead of getting trapped in the content column. -->
+	{#if useRailLayout}
+		<SiteNav
+			slot="below"
+			ctaUrl={data.profile?.cta_url || data.view?.cta_url || ''}
+			ctaButtonText={data.profile?.cta_button_text || data.view?.cta_button_text || 'Learn More'}
+			ctaText={data.profile?.cta_text || data.view?.cta_text || ''}
+			ctaEnabled={data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
+			ssrNavEnabled={data.siteNav?.enabled}
+			ssrNavMode={data.siteNav?.mode}
+			ssrNavPosition={data.siteNav?.position}
+			ssrNavItems={data.siteNav?.items}
+		/>
+	{/if}
+
+	<!-- Rail layout: 2-col grid wraps the hero (aside, col 1) + main flow
+	     (col 2). Other layouts fall back to display:contents (no structural
+	     change, so they render byte-identically to before). -->
+	<div class={useRailLayout ? 'md:grid md:grid-cols-[320px_minmax(0,1fr)] md:items-start' : 'contents'}>
 	<!-- Hero section with possible view overrides -->
 	<ProfileHero
 		profile={{
@@ -481,24 +510,28 @@
 			summary,
 			location
 		}}
-		layout={(data.view?.hero_layout || data.profile?.hero_layout || 'standard') as 'standard' | 'centered' | 'split' | 'minimal' | 'stacked'}
+		layout={effectiveHeroLayout}
 		spacing={(data.view?.hero_spacing || data.profile?.hero_spacing || '') as '' | 'compact' | 'default' | 'spacious'}
 		heroBgColor={data.view?.hero_bg_color || data.profile?.hero_bg_color || ''}
 		showAvatar={((data as unknown as { showAvatar?: boolean }).showAvatar) !== false}
 	/>
+	<div class={useRailLayout ? 'min-w-0' : 'contents'}>
 
-	<!-- Site Navigation (below hero) / CTA Banner - only renders when position='below' (default) -->
-	<SiteNav
-		slot="below"
-		ctaUrl={data.profile?.cta_url || data.view?.cta_url || ''}
-		ctaButtonText={data.profile?.cta_button_text || data.view?.cta_button_text || 'Learn More'}
-		ctaText={data.profile?.cta_text || data.view?.cta_text || ''}
-		ctaEnabled={data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
-		ssrNavEnabled={data.siteNav?.enabled}
-		ssrNavMode={data.siteNav?.mode}
-		ssrNavPosition={data.siteNav?.position}
-		ssrNavItems={data.siteNav?.items}
-	/>
+	<!-- Site Navigation (below hero) / CTA Banner - only renders here for
+	     non-rail layouts (rail lifts it above the grid). -->
+	{#if !useRailLayout}
+		<SiteNav
+			slot="below"
+			ctaUrl={data.profile?.cta_url || data.view?.cta_url || ''}
+			ctaButtonText={data.profile?.cta_button_text || data.view?.cta_button_text || 'Learn More'}
+			ctaText={data.profile?.cta_text || data.view?.cta_text || ''}
+			ctaEnabled={data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
+			ssrNavEnabled={data.siteNav?.enabled}
+			ssrNavMode={data.siteNav?.mode}
+			ssrNavPosition={data.siteNav?.position}
+			ssrNavItems={data.siteNav?.items}
+		/>
+	{/if}
 
 	<div
 		aria-hidden="true"
@@ -637,6 +670,8 @@
 			{/if}
 		{/if}
 	</main>
+	</div><!-- /content column (rail col 2) -->
+	</div><!-- /rail grid wrapper -->
 
 	<Footer profile={data.profile} />
 

--- a/frontend/src/routes/[slug=slug]/+page.svelte
+++ b/frontend/src/routes/[slug=slug]/+page.svelte
@@ -66,6 +66,15 @@
 	let navPinned = $state(false);
 	let sentinelEl: HTMLDivElement | null = $state(null);
 
+	// Rail layout: 2-column desktop with a sticky left sidebar. The hero
+	// renders as col 1 (the <aside>), page content flows in col 2. Non-rail
+	// layouts fall back to display:contents so they render byte-identically.
+	let effectiveHeroLayout = $derived(
+		(data.view?.hero_layout || data.profile?.hero_layout || 'standard') as
+			'standard' | 'centered' | 'split' | 'minimal' | 'stacked' | 'rail'
+	);
+	let useRailLayout = $derived(effectiveHeroLayout === 'rail');
+
 	// Apply view-specific accent color (or profile default)
 	function applyAccentColor(colorName: AccentColor) {
 		if (!browser) return;
@@ -369,6 +378,44 @@
 			/>
 		{/if}
 
+		<!-- For rail layout, the below-hero SiteNav / CTA banner is lifted ABOVE
+		     the rail grid so it spans full width instead of being trapped in
+		     the content column. -->
+		{#if useRailLayout}
+			{#if data.isPublicView}
+				<SiteNav
+					slot="below"
+					ctaUrl={data.view?.cta_url || ''}
+					ctaButtonText={data.view?.cta_button_text || 'Learn More'}
+					ctaText={data.view?.cta_text || ''}
+					ctaEnabled={data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
+					ssrNavEnabled={data.siteNav?.enabled}
+					ssrNavMode={data.siteNav?.mode}
+					ssrNavPosition={data.siteNav?.position}
+					ssrNavItems={data.siteNav?.items}
+				/>
+			{:else if data.view?.cta_text && data.view?.cta_url && data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
+				<!-- Fallback CTA for non-public views (no site nav) -->
+				<div class="bg-primary-600 text-white py-4">
+					<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
+						<span class="font-medium">{data.view.cta_text}</span>
+						<a
+							href={data.view.cta_url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn bg-white text-primary-600 hover:bg-stone-100"
+						>
+							{data.view.cta_button_text || 'Learn More'}
+						</a>
+					</div>
+				</div>
+			{/if}
+		{/if}
+
+		<!-- Rail layout: 2-col grid wraps the hero (aside, col 1) + main flow
+		     (col 2). Other layouts fall back to display:contents (no structural
+		     change, so they render byte-identically to before). -->
+		<div class={useRailLayout ? 'md:grid md:grid-cols-[320px_minmax(0,1fr)] md:items-start' : 'contents'}>
 		<!-- Modified hero with view overrides -->
 		<ProfileHero
 			profile={{
@@ -378,40 +425,44 @@
 				location: data.view?.hero_location || data.profile?.location,
 				hero_image_url: data.view?.hero_image_url || data.profile?.hero_image_url
 			}}
-			layout={(data.view?.hero_layout || data.profile?.hero_layout || 'standard') as 'standard' | 'centered' | 'split' | 'minimal' | 'stacked'}
+			layout={effectiveHeroLayout}
 			spacing={(data.view?.hero_spacing || data.profile?.hero_spacing || '') as '' | 'compact' | 'default' | 'spacious'}
 			heroBgColor={data.view?.hero_bg_color || data.profile?.hero_bg_color || ''}
 			showAvatar={((data as unknown as { showAvatar?: boolean }).showAvatar) !== false}
 		/>
+		<div class={useRailLayout ? 'min-w-0' : 'contents'}>
 
-		<!-- Site Navigation (below hero) / CTA banner - only on public views -->
-		{#if data.isPublicView}
-			<SiteNav
-				slot="below"
-				ctaUrl={data.view?.cta_url || ''}
-				ctaButtonText={data.view?.cta_button_text || 'Learn More'}
-				ctaText={data.view?.cta_text || ''}
-				ctaEnabled={data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
-				ssrNavEnabled={data.siteNav?.enabled}
-				ssrNavMode={data.siteNav?.mode}
-				ssrNavPosition={data.siteNav?.position}
-				ssrNavItems={data.siteNav?.items}
-			/>
-		{:else if data.view?.cta_text && data.view?.cta_url && data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
-			<!-- Fallback CTA for non-public views (no site nav) -->
-			<div class="bg-primary-600 text-white py-4">
-				<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-					<span class="font-medium">{data.view.cta_text}</span>
-					<a
-						href={data.view.cta_url}
-						target="_blank"
-						rel="noopener noreferrer"
-						class="btn bg-white text-primary-600 hover:bg-stone-100"
-					>
-						{data.view.cta_button_text || 'Learn More'}
-					</a>
+		<!-- Site Navigation (below hero) / CTA banner - only renders here for
+		     non-rail layouts (rail lifts it above the grid). -->
+		{#if !useRailLayout}
+			{#if data.isPublicView}
+				<SiteNav
+					slot="below"
+					ctaUrl={data.view?.cta_url || ''}
+					ctaButtonText={data.view?.cta_button_text || 'Learn More'}
+					ctaText={data.view?.cta_text || ''}
+					ctaEnabled={data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
+					ssrNavEnabled={data.siteNav?.enabled}
+					ssrNavMode={data.siteNav?.mode}
+					ssrNavPosition={data.siteNav?.position}
+					ssrNavItems={data.siteNav?.items}
+				/>
+			{:else if data.view?.cta_text && data.view?.cta_url && data.siteCtaEnabled !== false && data.view?.cta_enabled !== false}
+				<!-- Fallback CTA for non-public views (no site nav) -->
+				<div class="bg-primary-600 text-white py-4">
+					<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
+						<span class="font-medium">{data.view.cta_text}</span>
+						<a
+							href={data.view.cta_url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn bg-white text-primary-600 hover:bg-stone-100"
+						>
+							{data.view.cta_button_text || 'Learn More'}
+						</a>
+					</div>
 				</div>
-			</div>
+			{/if}
 		{/if}
 
 		<!-- Sentinel to detect when ProfileNav becomes sticky -->
@@ -534,6 +585,8 @@
 				{/each}
 			</div>
 		</main>
+		</div><!-- /content column (rail col 2) -->
+		</div><!-- /rail grid wrapper -->
 
 		<Footer profile={data.profile} />
 

--- a/frontend/src/routes/admin/+layout.svelte
+++ b/frontend/src/routes/admin/+layout.svelte
@@ -11,6 +11,8 @@
 	import { demoMode, initDemoMode, collection } from '$lib/stores/demo';
 	import AdminSidebar from '$components/admin/AdminSidebar.svelte';
 	import AdminHeader from '$components/admin/AdminHeader.svelte';
+	import LivePreview from '$components/admin/LivePreview.svelte';
+	import { userPreferences } from '$lib/stores/userPreferences';
 	import PasswordChangeModal from '$components/admin/PasswordChangeModal.svelte';
 	import TwoFactorModal from '$components/admin/TwoFactorModal.svelte';
 	import SetupWizard from '$components/admin/SetupWizard.svelte';
@@ -397,14 +399,20 @@
 
 			<AdminSidebar {isMobile} />
 
-			<!-- Main content: 
+			<!-- Main content:
 				- Mobile: full width (no margin)
 				- Desktop: margin-left based on sidebar state (preserves current behavior)
+				- When live preview is ON, allow main to shrink so the preview
+				  column gets reserved space at lg+. Below lg the preview is
+				  hidden via its own `lg:` gate so main stays full.
 			-->
 			<main
 				id="main-content"
 				class="flex-1 min-w-0 p-4 lg:p-6 mt-16 transition-all duration-200 overflow-x-clip w-full max-w-full
-					{isMobile ? '' : ($adminSidebarOpen ? 'lg:ml-64' : 'lg:ml-16')}"
+					{isMobile ? '' : ($adminSidebarOpen ? 'lg:ml-64' : 'lg:ml-16')}
+					{!isMobile && $userPreferences.livePreviewEnabled
+						? 'lg:max-w-[calc(50%-1rem)] xl:max-w-[calc(50%-1.5rem)]'
+						: ''}"
 			>
 				{#if showEncryptionWarning}
 					<div class="mb-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4" role="status">
@@ -431,6 +439,18 @@
 				{/if}
 				{@render children?.()}
 			</main>
+
+			<!-- Live site preview column.
+			     - Hidden via Tailwind `hidden lg:block` so mobile + tablet
+			       never render the iframe (no value on small screens; saves
+			       bandwidth + CPU on touch devices).
+			     - Mounted only when the toggle is ON. When OFF nothing renders
+			       (regression-safe). -->
+			{#if !isMobile && $userPreferences.livePreviewEnabled}
+				<div class="hidden lg:block flex-1 min-w-0 p-4 lg:p-6 mt-16">
+					<LivePreview />
+				</div>
+			{/if}
 		</div>
 
 			<SetupWizard />

--- a/frontend/src/routes/admin/homepage/+page.svelte
+++ b/frontend/src/routes/admin/homepage/+page.svelte
@@ -161,7 +161,8 @@ import { brandName } from '$lib/stores/plan';
 		{ id: 'centered', labelKey: 'admin.settings_page.appearance.hero_layout_centered' },
 		{ id: 'split', labelKey: 'admin.settings_page.appearance.hero_layout_split' },
 		{ id: 'minimal', labelKey: 'admin.settings_page.appearance.hero_layout_minimal' },
-		{ id: 'stacked', labelKey: 'admin.settings_page.appearance.hero_layout_stacked' }
+		{ id: 'stacked', labelKey: 'admin.settings_page.appearance.hero_layout_stacked' },
+		{ id: 'rail', labelKey: 'admin.settings_page.appearance.hero_layout_rail' }
 	];
 
 	const heroSpacingOptions = [

--- a/frontend/src/routes/admin/homepage/+page.svelte
+++ b/frontend/src/routes/admin/homepage/+page.svelte
@@ -15,6 +15,7 @@ import { brandName } from '$lib/stores/plan';
 	import MarkdownEditor from '$components/admin/MarkdownEditor.svelte';
 	import HomepageSectionManager from '$components/admin/HomepageSectionManager.svelte';
 	import AccentPicker from '$components/admin/AccentPicker.svelte';
+	import TextColorPicker from '$components/admin/TextColorPicker.svelte';
 	import AccordionSection from '$components/admin/forms/AccordionSection.svelte';
 	import { DEFAULT_ACCENT_COLOR, type AccentColor } from '$lib/colors';
 	import { FONT_PACKS, FONT_PACK_LIST, DEFAULT_FONT_PACK, type FontPack } from '$lib/fonts';
@@ -154,6 +155,7 @@ import { brandName } from '$lib/stores/plan';
 	let heroBgError = $state('');
 	let accentColor: AccentColor = $state(DEFAULT_ACCENT_COLOR);
 	let customHexColor: string = $state('');
+	let textColor: string = $state('');
 	let fontPack: FontPack = $state(DEFAULT_FONT_PACK);
 
 	const heroLayoutOptions = [
@@ -459,6 +461,7 @@ import { brandName } from '$lib/stores/plan';
 				heroBgColor = ((profile as unknown as { hero_bg_color?: string }).hero_bg_color) || '';
 				accentColor = ((profile as unknown as { accent_color?: string }).accent_color as AccentColor) || DEFAULT_ACCENT_COLOR;
 				customHexColor = (profile as unknown as { custom_hex_color?: string }).custom_hex_color || '';
+				textColor = (profile as unknown as { text_color?: string }).text_color || '';
 				fontPack = ((profile as unknown as { font_pack?: string }).font_pack as FontPack) || DEFAULT_FONT_PACK;
 
 				if (profile.avatar) {
@@ -512,6 +515,22 @@ import { brandName } from '$lib/stores/plan';
 		} catch (err) {
 			console.error('Failed to save custom hex color:', err);
 			toasts.add('error', $t('admin.settings_page.appearance.accent_color_error'));
+		}
+	}
+
+	// Text (font) color autosave. Empty string clears it back to the default ink.
+	// The derived AAA-clamped ink is computed SSR-side (deriveTextInk), so saving
+	// the raw hue is all that's needed; the public page re-derives on next load.
+	async function saveTextColor(hex: string) {
+		if (!profile) return;
+		try {
+			await collection('profile').update(profile.id as string, { text_color: hex });
+			textColor = hex;
+			toasts.add('success', $t('admin.text_color_picker.updated'));
+			window.dispatchEvent(new CustomEvent('text-color-changed', { detail: hex }));
+		} catch (err) {
+			console.error('Failed to save text color:', err);
+			toasts.add('error', $t('admin.text_color_picker.error'));
 		}
 	}
 
@@ -1157,6 +1176,12 @@ import { brandName } from '$lib/stores/plan';
 							onchange={(color) => saveAccentColor(color)}
 							onhexchange={(hex) => saveCustomHexColor(hex)}
 						/>
+						<div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+							<TextColorPicker
+								value={textColor}
+								onchange={(hex) => saveTextColor(hex)}
+							/>
+						</div>
 						<div class="pt-4 border-t border-gray-200 dark:border-gray-700">
 							<span class="block text-sm font-semibold text-gray-900 dark:text-white mb-1">{$t('admin.homepage.font_pack_title')}</span>
 							<p class="text-sm text-gray-600 dark:text-gray-400 mb-3">{$t('admin.homepage.font_pack_description')}</p>

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -1602,7 +1602,8 @@
 							{ id: 'centered', label: 'Centered' },
 							{ id: 'split', label: 'Split' },
 							{ id: 'minimal', label: 'Minimal' },
-							{ id: 'stacked', label: 'Stacked' }
+							{ id: 'stacked', label: 'Stacked' },
+							{ id: 'rail', label: 'Rail' }
 						] as layoutOption}
 							<button
 								type="button"
@@ -1813,6 +1814,7 @@
 						</div>
 						<ViewPreview
 							{profile}
+							{heroLayout}
 							{heroHeadline}
 							{heroSummary}
 							{ctaText}

--- a/frontend/src/routes/admin/views/new/+page.svelte
+++ b/frontend/src/routes/admin/views/new/+page.svelte
@@ -1032,7 +1032,8 @@
 							{ id: 'centered', label: 'Centered' },
 							{ id: 'split', label: 'Split' },
 							{ id: 'minimal', label: 'Minimal' },
-							{ id: 'stacked', label: 'Stacked' }
+							{ id: 'stacked', label: 'Stacked' },
+							{ id: 'rail', label: 'Rail' }
 						] as layoutOption}
 							<button
 								type="button"
@@ -1379,6 +1380,7 @@
 						</div>
 						<ViewPreview
 							{profile}
+							{heroLayout}
 							{heroHeadline}
 							{heroSummary}
 							{ctaText}

--- a/frontend/tests/accent-aaa-clamp.spec.ts
+++ b/frontend/tests/accent-aaa-clamp.spec.ts
@@ -48,6 +48,48 @@ test('generatePaletteFromHex clamps white-on-600 to AAA (7:1), preserving hue', 
 	}
 });
 
+// Relative luminance (WCAG) of a #rrggbb hex, used to assert a monotonic ramp.
+function relLuminance(hex: string) {
+	const h = hex.trim().replace('#', '');
+	const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+	const f = (c: number) => {
+		const cc = c / 255;
+		return cc <= 0.03928 ? cc / 12.92 : Math.pow((cc + 0.055) / 1.055, 2.4);
+	};
+	return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+test('palette ramp is monotonic from 600 to 950 even for pale accents whose 600 clamps deep', async ({ page }) => {
+	await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+	const palettes = await page.evaluate(async (modUrl) => {
+		const mod = (await import(/* @vite-ignore */ modUrl)) as {
+			generatePaletteFromHex: (hex: string) => Record<string, string>;
+		};
+		const hexes = [
+			'#ffe066', // pale yellow: clamp600 drives 600 well past the nominal 700 mix
+			'#22d3ee', // pale cyan
+			'#ffe600', // worst-case pale yellow
+			'#a3e635', // lime
+			'#c2410c', // Soft Premium default terracotta (must not regress)
+			'#1e3a8a' // deep blue (600 stays at nominal)
+		];
+		return hexes.map((h) => ({ h, scale: mod.generatePaletteFromHex(h) }));
+	}, COLORS_MOD);
+
+	for (const { h, scale } of palettes) {
+		const steps = ['500', '600', '700', '800', '900', '950'] as const;
+		const lums = steps.map((s) => relLuminance(scale[s]));
+		// Each darker step must be strictly darker (lower luminance) than the
+		// previous one (no inversion). Epsilon covers 8-bit rounding.
+		for (let i = 1; i < steps.length; i++) {
+			expect(
+				lums[i],
+				`${h}: ${steps[i]}=${scale[steps[i]]} (L=${lums[i].toFixed(4)}) must be darker than ${steps[i - 1]}=${scale[steps[i - 1]]} (L=${lums[i - 1].toFixed(4)})`
+			).toBeLessThan(lums[i - 1] + 1e-9);
+		}
+	}
+});
+
 test('clamp only deepens — a hue already dark enough is left at its nominal 600', async ({ page }) => {
 	await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
 	const { darkSix, paleSix } = await page.evaluate(async (modUrl) => {

--- a/frontend/tests/hero-rail-layout.spec.ts
+++ b/frontend/tests/hero-rail-layout.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { apiBaseURL } from './config';
+
+/**
+ * Rail hero layout end-to-end certification.
+ *
+ * The rail layout renders the hero as a sticky ~320px left <aside> sidebar and
+ * flows page content in the right column via a 2-column grid. This spec drives
+ * the real running stack:
+ *   - A PB superuser PATCHes profile.hero_layout = 'rail'
+ *   - The public page is loaded at a desktop viewport
+ *   - We assert the rail <aside> is present, sits in the left column (~320px),
+ *     and the page uses the 2-col grid
+ *   - We then reset to 'standard' and assert the rail <aside> is gone, proving
+ *     other layouts are unaffected.
+ *
+ * The suite is serial (playwright.config workers: 1); run with --workers=1.
+ */
+
+const PB_SUPERUSER = process.env.PB_SUPERUSER_EMAIL || 'admin@localhost.dev';
+const PB_SUPERUSER_PW = process.env.PB_SUPERUSER_PASSWORD || 'admin123';
+
+async function superuserToken(request: APIRequestContext): Promise<string> {
+	const res = await request.post(
+		`${apiBaseURL}/api/collections/_superusers/auth-with-password`,
+		{ data: { identity: PB_SUPERUSER, password: PB_SUPERUSER_PW } }
+	);
+	expect(res.ok(), 'PB superuser auth must succeed').toBeTruthy();
+	return (await res.json()).token as string;
+}
+
+async function profileId(request: APIRequestContext, token: string): Promise<string> {
+	const res = await request.get(`${apiBaseURL}/api/collections/profile/records?perPage=1`, {
+		headers: { Authorization: token }
+	});
+	expect(res.ok()).toBeTruthy();
+	const items = (await res.json()).items as Array<{ id: string }>;
+	expect(items.length, 'a profile record must exist').toBeGreaterThan(0);
+	return items[0].id;
+}
+
+async function setHeroLayout(
+	request: APIRequestContext,
+	token: string,
+	id: string,
+	layout: string
+): Promise<void> {
+	const res = await request.patch(`${apiBaseURL}/api/collections/profile/records/${id}`, {
+		headers: { Authorization: token },
+		data: { hero_layout: layout }
+	});
+	expect(
+		res.ok(),
+		`PATCH hero_layout=${layout} must succeed (migration must accept 'rail')`
+	).toBeTruthy();
+}
+
+test.describe('rail hero layout', () => {
+	let token: string;
+	let id: string;
+
+	test.beforeAll(async ({ request }) => {
+		token = await superuserToken(request);
+		id = await profileId(request, token);
+	});
+
+	test.afterAll(async ({ request }) => {
+		// Always reset to standard so the live instance / other specs are unaffected.
+		await setHeroLayout(request, token, id, 'standard');
+	});
+
+	test('rail renders a sticky ~320px left sidebar in a 2-col grid', async ({ request, page }) => {
+		await setHeroLayout(request, token, id, 'rail');
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/', { waitUntil: 'networkidle' });
+
+		// The rail sidebar is a <header class="rail-hero"> banner (not an <aside>),
+		// matching the other five hero layouts and carrying the page's <h1>.
+		const rail = page.locator('header.rail-hero');
+		await expect(rail, 'rail header renders for hero_layout=rail').toHaveCount(1);
+		await expect(rail).toBeVisible();
+
+		// The header must hug the left edge and be roughly the rail width (~320px).
+		const box = await rail.boundingBox();
+		expect(box, 'rail header has a layout box').not.toBeNull();
+		expect(box!.x, 'rail sidebar hugs the left edge').toBeLessThan(40);
+		expect(box!.width, 'rail sidebar is ~320px wide').toBeGreaterThan(240);
+		expect(box!.width, 'rail sidebar is ~320px wide').toBeLessThan(420);
+
+		// The hero's grid wrapper must use the 2-col rail grid template.
+		const gridTemplate = await rail.evaluate((el) => {
+			const wrapper = el.parentElement as HTMLElement | null;
+			return wrapper ? getComputedStyle(wrapper).gridTemplateColumns : '';
+		});
+		// Two resolved track widths => 2-column grid is active (rail col + content col).
+		const tracks = gridTemplate.trim().split(/\s+/).filter(Boolean);
+		expect(
+			tracks.length,
+			`rail wrapper uses a 2-col grid (got "${gridTemplate}")`
+		).toBe(2);
+
+		// Content must flow in the right column, to the right of the sidebar.
+		const main = page.locator('main#main-content');
+		await expect(main).toBeVisible();
+		const mainBox = await main.boundingBox();
+		expect(mainBox, 'main has a layout box').not.toBeNull();
+		expect(
+			mainBox!.x,
+			'main content sits to the right of the rail sidebar'
+		).toBeGreaterThan(box!.x + box!.width - 1);
+	});
+
+	test('switching back to standard removes the rail sidebar (other layouts unaffected)', async ({
+		request,
+		page
+	}) => {
+		await setHeroLayout(request, token, id, 'standard');
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/', { waitUntil: 'networkidle' });
+
+		// No rail sidebar for the standard layout.
+		await expect(page.locator('header.rail-hero'), 'no rail header for standard').toHaveCount(0);
+
+		// The standard hero still renders its <header>.
+		await expect(page.locator('header').first(), 'standard hero header renders').toBeVisible();
+	});
+});

--- a/frontend/tests/live-preview.spec.ts
+++ b/frontend/tests/live-preview.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Exercises the ported live-site preview: a header toggle (role=switch) that
+// opens a side column with a sandboxed iframe of the public homepage, with the
+// state persisted in localStorage. Desktop only (lg+).
+const BASE_URL =
+	process.env.PLAYWRIGHT_BASE_URL ?? process.env.VITE_POCKETBASE_URL ?? 'http://localhost:5173';
+const LOGIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const LOGIN_PASSWORD = process.env.ADMIN_PASSWORD ?? 'changeme123';
+
+async function login(page: Page) {
+	await page.goto(`${BASE_URL}/admin/login`);
+	await page.waitForSelector('input[type="email"]', { timeout: 10_000 });
+	await page.fill('input[type="email"]', LOGIN_EMAIL);
+	await page.fill('input[type="password"]', LOGIN_PASSWORD);
+	await page.click('button[type="submit"]');
+	await page.waitForURL((url) => /\/admin(\/|$)/.test(url.pathname) && !url.pathname.includes('/login'), {
+		timeout: 15_000
+	});
+}
+
+const toggle = (page: Page) => page.getByRole('switch', { name: 'Toggle live preview' });
+const previewFrame = (page: Page) => page.locator('iframe[title="Live preview of your public site"]');
+
+test.describe('Live site preview', () => {
+	test.beforeEach(async ({ page }) => {
+		await login(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		// Leave the preference off for the next test/file.
+		const t = toggle(page);
+		if ((await t.count()) > 0 && (await t.getAttribute('aria-checked')) === 'true') {
+			await t.click();
+		}
+	});
+
+	test('toggle is an accessible switch, off by default', async ({ page }) => {
+		const t = toggle(page);
+		await expect(t).toBeVisible();
+		await expect(t).toHaveAttribute('aria-checked', 'false');
+		// No preview iframe until enabled.
+		await expect(previewFrame(page)).toHaveCount(0);
+	});
+
+	test('enabling shows the sandboxed live-site iframe', async ({ page }) => {
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'true');
+		const frame = previewFrame(page);
+		await expect(frame).toBeVisible();
+		await expect(frame).toHaveAttribute('src', /\/\?preview=1/);
+		// Sealed from tab order (read-only pane).
+		await expect(frame).toHaveAttribute('tabindex', '-1');
+	});
+
+	test('preference persists across a reload (localStorage)', async ({ page }) => {
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'true');
+		await page.reload();
+		await page.waitForURL(/\/admin/);
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'true');
+		await expect(previewFrame(page)).toBeVisible();
+	});
+
+	test('disabling hides the preview column', async ({ page }) => {
+		await toggle(page).click();
+		await expect(previewFrame(page)).toBeVisible();
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute('aria-checked', 'false');
+		await expect(previewFrame(page)).toHaveCount(0);
+	});
+});

--- a/frontend/tests/soft-premium-fonts.spec.ts
+++ b/frontend/tests/soft-premium-fonts.spec.ts
@@ -75,4 +75,77 @@ test.describe('Soft Premium fonts (font selector governs)', () => {
 		const font = await bodyFont(page);
 		expect(font).toContain('hanken');
 	});
+
+	// Regression guard: applying the DEFAULT pack (soft-premium) on the client must
+	// KEEP the Google Fonts link. The live admin font picker drives applyFontPack via
+	// the 'font-pack-changed' window event; the regression special-cased the default
+	// pack and *removed* the dynamic link, so a creator who previews soft-premium (or
+	// switches back to it) lost Hanken/Newsreader and the body fell back to Plus
+	// Jakarta. We exercise the exact event the picker uses, then confirm a Hanken
+	// dynamic link is present and the resolved --font-body is Hanken. This is the
+	// discriminating assertion: the buggy code produced no soft-premium dynamic link.
+	const applyDefaultPackOnClient = (page: Page) =>
+		page.evaluate(
+			() =>
+				new Promise<void>((resolve) => {
+					window.dispatchEvent(new CustomEvent('font-pack-changed', { detail: 'soft-premium' }));
+					// let the layout's handler + Svelte effect flush
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+				})
+		);
+
+	const dynamicLinkState = (page: Page) =>
+		page.evaluate(() => {
+			const link = document.querySelector('link#dynamic-google-fonts') as HTMLLinkElement | null;
+			return {
+				dynamicHasHanken: !!link && /Hanken/i.test(link.href),
+				fontBody: getComputedStyle(document.body).fontFamily.toLowerCase(),
+				sameDoc: (window as unknown as Record<string, boolean>).__spaMarker === true
+			};
+		});
+
+	test('applying the default pack on the client keeps the Hanken link, and it survives SPA nav', async ({ page, request }) => {
+		const token = await adminToken(request);
+		await setFontPack(request, token, '');
+
+		await page.goto(`${BASE_URL}/`, { waitUntil: 'networkidle' });
+		// Tag the live document so we can prove the next navigation is client-side.
+		await page.evaluate(() => ((window as unknown as Record<string, boolean>).__spaMarker = true));
+
+		// Drive the real admin live-preview event for the DEFAULT pack.
+		await applyDefaultPackOnClient(page);
+
+		const applied = await dynamicLinkState(page);
+		expect(
+			applied.dynamicHasHanken,
+			'applying soft-premium on the client must create/keep #dynamic-google-fonts pointing at Hanken (regression removed it)'
+		).toBeTruthy();
+		expect(applied.fontBody).toContain('hanken');
+
+		// Now navigate client-side; the SvelteKit font $effect re-runs applyFontPack
+		// and must not drop the default pack's link.
+		const inAppHref = await page.evaluate(() => {
+			const a = Array.from(document.querySelectorAll('a[href]')).find((el) => {
+				const href = (el as HTMLAnchorElement).getAttribute('href') || '';
+				return href.startsWith('/') && !href.startsWith('//') && !href.startsWith('/#');
+			}) as HTMLAnchorElement | undefined;
+			return a ? a.getAttribute('href') : null;
+		});
+
+		if (inAppHref) {
+			await Promise.all([
+				page.waitForURL((url) => url.pathname === inAppHref, { timeout: 10_000 }),
+				page.click(`a[href="${inAppHref}"]`)
+			]);
+			// Re-apply (as the picker would on the new page) and assert persistence.
+			await applyDefaultPackOnClient(page);
+			const afterNav = await dynamicLinkState(page);
+			expect(afterNav.sameDoc, 'navigation should be client-side (SPA)').toBeTruthy();
+			expect(
+				afterNav.dynamicHasHanken,
+				'dynamic Hanken link must remain after SPA nav with the default pack'
+			).toBeTruthy();
+			expect(afterNav.fontBody).toContain('hanken');
+		}
+	});
 });

--- a/frontend/tests/text-color-aaa.spec.ts
+++ b/frontend/tests/text-color-aaa.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { apiBaseURL } from './config';
+
+/**
+ * AAA proof for the operator-settable text (font) color.
+ *
+ * The whole promise of the feature is: whatever hue the operator picks — even a
+ * deliberately terrible one (pale yellow, mid gray) — the ACTUAL rendered text
+ * on the public page clears WCAG AAA (7:1) against its background, in BOTH light
+ * and dark mode, BY CONSTRUCTION.
+ *
+ * This test drives the real bundled CSS + the real SSR injection (no mocks):
+ *  1. PATCH profile.text_color to a bad pick.
+ *  2. Load the public page.
+ *  3. Read the COMPUTED color of a heading AND a body paragraph and compute the
+ *     contrast ratio in-test against their COMPUTED background.
+ *  4. Repeat in dark mode.
+ *  5. Assert the default (no text_color) is unchanged, and that a known surface
+ *     element is NOT tinted (stays the neutral stone value).
+ *
+ * The PB superuser PATCHes the field; the public render re-derives the AAA clamp.
+ */
+
+const PB_SUPERUSER = process.env.PB_SUPERUSER_EMAIL || 'admin@localhost.dev';
+const PB_SUPERUSER_PW = process.env.PB_SUPERUSER_PASSWORD || 'admin123';
+
+// Two deliberately bad picks: pale yellow (worst case for dark-on-light) and a
+// mid gray (near the worst case for BOTH modes). Both must end up AAA.
+const BAD_PICKS = ['#ffe066', '#808080'];
+
+function srgbLuminance(r: number, g: number, b: number): number {
+	const f = (c: number) => {
+		const cc = c / 255;
+		return cc <= 0.03928 ? cc / 12.92 : Math.pow((cc + 0.055) / 1.055, 2.4);
+	};
+	return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+function parseRgb(s: string): [number, number, number] {
+	const m = s.match(/\d+(\.\d+)?/g);
+	if (!m || m.length < 3) throw new Error(`Cannot parse color: ${s}`);
+	return [Number(m[0]), Number(m[1]), Number(m[2])];
+}
+
+function contrast(c1: string, c2: string): number {
+	const l1 = srgbLuminance(...parseRgb(c1));
+	const l2 = srgbLuminance(...parseRgb(c2));
+	const hi = Math.max(l1, l2);
+	const lo = Math.min(l1, l2);
+	return (hi + 0.05) / (lo + 0.05);
+}
+
+async function superuserToken(request: APIRequestContext): Promise<string> {
+	const res = await request.post(
+		`${apiBaseURL}/api/collections/_superusers/auth-with-password`,
+		{ data: { identity: PB_SUPERUSER, password: PB_SUPERUSER_PW } }
+	);
+	expect(res.ok(), 'PB superuser auth must succeed').toBeTruthy();
+	return (await res.json()).token as string;
+}
+
+async function profileId(request: APIRequestContext, token: string): Promise<string> {
+	const res = await request.get(`${apiBaseURL}/api/collections/profile/records?perPage=1`, {
+		headers: { Authorization: token }
+	});
+	expect(res.ok()).toBeTruthy();
+	const items = (await res.json()).items as Array<{ id: string }>;
+	expect(items.length, 'a profile record must exist').toBeGreaterThan(0);
+	return items[0].id;
+}
+
+async function setTextColor(
+	request: APIRequestContext,
+	token: string,
+	id: string,
+	hex: string
+): Promise<void> {
+	const res = await request.patch(`${apiBaseURL}/api/collections/profile/records/${id}`, {
+		headers: { Authorization: token },
+		data: { text_color: hex }
+	});
+	expect(res.ok(), `PATCH text_color=${hex || '(empty)'} must succeed`).toBeTruthy();
+}
+
+/**
+ * Measure computed color + background for a heading and a body paragraph on the
+ * currently loaded public page, in the given theme. Appends a real product-class
+ * body paragraph into <main> so the assertion does not depend on seeded content,
+ * while still exercising the exact scoped CSS rule the product ships.
+ */
+async function measure(page: import('@playwright/test').Page, dark: boolean) {
+	return page.evaluate((isDark) => {
+		document.documentElement.classList.toggle('dark', isDark);
+
+		const bgOf = (el: Element | null): string => {
+			let e: Element | null = el;
+			while (e) {
+				const c = getComputedStyle(e).backgroundColor;
+				if (c && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent') return c;
+				e = e.parentElement;
+			}
+			return getComputedStyle(document.documentElement).backgroundColor;
+		};
+
+		// Heading: a real section/article heading (text-gray-900 / dark:text-white).
+		const heading = document.querySelector('article h3, h2.section-title, main h1');
+
+		// Body: append a product-class paragraph into <main> so we always have a
+		// body target on a real surface, styled by the real scoped CSS rules.
+		const main = document.querySelector('main') || document.body;
+		let para = document.getElementById('aaa-test-body') as HTMLParagraphElement | null;
+		if (!para) {
+			para = document.createElement('p');
+			para.id = 'aaa-test-body';
+			para.className = 'prose-custom text-gray-700 dark:text-gray-300';
+			para.textContent = 'Body paragraph text used for the AAA contrast assertion.';
+			const card = document.createElement('div');
+			card.className = 'card p-4';
+			card.appendChild(para);
+			main.appendChild(card);
+		}
+
+		// On-bg body: append a SECOND product-class paragraph directly to <main>
+		// (no .card wrapper) so it inherits the warm page --bg, which is the
+		// worst-case (lowest-contrast) surface for dark-on-light text. bgOf walks
+		// up past <main> (no background) to documentElement, which carries --bg.
+		let paraOnBg = document.getElementById('aaa-test-body-onbg') as HTMLParagraphElement | null;
+		if (!paraOnBg) {
+			paraOnBg = document.createElement('p');
+			paraOnBg.id = 'aaa-test-body-onbg';
+			paraOnBg.className = 'prose-custom text-gray-700 dark:text-gray-300';
+			paraOnBg.textContent = 'Body paragraph text on the warm page background for the AAA contrast assertion.';
+			main.appendChild(paraOnBg);
+		}
+
+		const surface = document.querySelector('.card, article');
+
+		return {
+			headingColor: heading ? getComputedStyle(heading).color : null,
+			headingBg: bgOf(heading),
+			bodyColor: getComputedStyle(para).color,
+			bodyBg: bgOf(para),
+			bodyOnBgColor: getComputedStyle(paraOnBg).color,
+			bodyOnBgBg: bgOf(paraOnBg),
+			surfaceBg: surface ? getComputedStyle(surface).backgroundColor : null,
+			textInk: getComputedStyle(document.documentElement).getPropertyValue('--text-ink').trim(),
+			hasAttr: document.documentElement.hasAttribute('data-text-ink')
+		};
+	}, dark);
+}
+
+test.describe('operator text color is AAA by construction', () => {
+	let token: string;
+	let id: string;
+
+	test.beforeAll(async ({ request }) => {
+		token = await superuserToken(request);
+		id = await profileId(request, token);
+	});
+
+	test.afterAll(async ({ request }) => {
+		// Always reset so the live instance / other specs see the default.
+		await setTextColor(request, token, id, '');
+	});
+
+	test('default (no text_color) leaves text + surfaces untinted', async ({ request, page }) => {
+		await setTextColor(request, token, id, '');
+		await page.goto('/', { waitUntil: 'networkidle' });
+
+		const light = await measure(page, false);
+		expect(light.hasAttr, 'no data-text-ink attribute when unset').toBeFalsy();
+		expect(light.textInk, '--text-ink unset by default').toBe('');
+		// Surface stays the neutral stone white (#ffffff) — not tinted.
+		expect(light.surfaceBg).toBe('rgb(255, 255, 255)');
+	});
+
+	for (const pick of BAD_PICKS) {
+		test(`bad pick ${pick}: heading + body clear 7:1 in light AND dark`, async ({
+			request,
+			page
+		}) => {
+			await setTextColor(request, token, id, pick);
+			await page.goto('/', { waitUntil: 'networkidle' });
+
+			// ---- Light mode ----
+			const light = await measure(page, false);
+			expect(light.hasAttr, 'data-text-ink present when color set').toBeTruthy();
+			expect(light.textInk, '--text-ink injected').toMatch(/^#[0-9a-fA-F]{6}$/);
+			expect(light.headingColor, 'heading present').not.toBeNull();
+
+			const lightHeading = contrast(light.headingColor!, light.headingBg);
+			const lightBody = contrast(light.bodyColor, light.bodyBg);
+			expect(
+				lightHeading,
+				`light heading ${light.headingColor} on ${light.headingBg} = ${lightHeading.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+			expect(
+				lightBody,
+				`light body ${light.bodyColor} on ${light.bodyBg} = ${lightBody.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+
+			// Worst-case surface: body text directly on the warm page --bg (#fbf8f4),
+			// not a white card. The clamp targets exactly this surface, so hold it to
+			// the strict 7.0 floor.
+			const lightBodyOnBg = contrast(light.bodyOnBgColor, light.bodyOnBgBg);
+			expect(
+				lightBodyOnBg,
+				`light body on page bg ${light.bodyOnBgColor} on ${light.bodyOnBgBg} = ${lightBodyOnBg.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(7.0);
+
+			// Surface must NOT be tinted — still neutral stone white.
+			expect(light.surfaceBg, 'surface stays neutral in light mode').toBe('rgb(255, 255, 255)');
+
+			// ---- Dark mode ----
+			const dark = await measure(page, true);
+			const darkHeading = contrast(dark.headingColor!, dark.headingBg);
+			const darkBody = contrast(dark.bodyColor, dark.bodyBg);
+			expect(
+				darkHeading,
+				`dark heading ${dark.headingColor} on ${dark.headingBg} = ${darkHeading.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+			expect(
+				darkBody,
+				`dark body ${dark.bodyColor} on ${dark.bodyBg} = ${darkBody.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(6.95);
+
+			// Worst-case surface in dark mode: body text directly on the page --bg
+			// (#1a1613), not a card. Hold it to the strict 7.0 floor.
+			const darkBodyOnBg = contrast(dark.bodyOnBgColor, dark.bodyOnBgBg);
+			expect(
+				darkBodyOnBg,
+				`dark body on page bg ${dark.bodyOnBgColor} on ${dark.bodyOnBgBg} = ${darkBodyOnBg.toFixed(2)}:1`
+			).toBeGreaterThanOrEqual(7.0);
+		});
+	}
+});


### PR DESCRIPTION
Combines four certified PRs (#471, #472, #473, #474) into one, plus a backend `font_pack` select migration. Replaces those four (closing them as superseded).

## Features
- **Live site preview** (#471): header `role=switch` toggle opens a sandboxed iframe of the public site that auto-reloads as you edit; localStorage-persisted; editor shrinks to ~50% at lg+.
- **Rail hero layout** (#472): 6th hero layout — sticky ~320px left sidebar (`<header>`/banner) in a 2-col grid; other 5 layouts byte-identical via `display:contents` fallback; `hero_layout` migration widened.
- **AAA text color** (#473): operator-settable text hue, auto-clamped per-mode (light/dark) to guarantee ≥7:1 (dedicated `--text-ink` token, doesn't bleed into surface/border grays). Measured 7.0–12.7:1.
- **Redesign regression fixes** (#474): default fonts persist across SPA nav; `font_pack` TS union + backend select include `soft-premium`; monotonic accent ramp (600 never darker than 700); `<body>` follows `--bg`.

## Certification (combined state, verified directly)
- `go build`/`go test` ✓ · svelte-check **0/0** · i18n **100%** (all 4 PRs' keys, 5 locales) · `npm run build` ✓
- Playwright **20/20** feature specs pass live (live-preview, hero-rail, text-color incl. bad-pick ≥7:1 proofs, soft-premium fonts incl. SPA-nav fix, tokens, accent clamp, typography)
- accessibility-lead signed off each feature individually during development
- Pre-existing (NOT introduced here, fail on main too): 3 `backport-qa` stale tests (assert pre-redesign UI locations) + 3 `media-management` (seed-dependent).