### PR TITLE
fix(preview): allow same-origin framing so live preview renders (X-Frame-Options)

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -12,8 +12,12 @@
         # Prevent MIME type sniffing (universal, no risk)
         X-Content-Type-Options "nosniff"
 
-        # Prevent clickjacking (will migrate to CSP frame-ancestors in Phase 5B)
-        X-Frame-Options "DENY"
+        # Prevent cross-origin clickjacking, but allow SAMEORIGIN framing so the
+        # admin live-preview pane can embed this instance's own public site.
+        # (DENY blocked even same-origin frames, breaking the preview.)
+        X-Frame-Options "SAMEORIGIN"
+        # Modern equivalent; 'self' = only this origin may frame us.
+        Content-Security-Policy "frame-ancestors 'self'"
 
         # Control referrer information - safe default per OWASP
         Referrer-Policy "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Bug
The live-preview pane showed the browser error **"This content is blocked. Contact the site owner to fix the issue."**

## Cause
`docker/Caddyfile` set `X-Frame-Options "DENY"`, which blocks **all** framing — including the same-origin admin→public-site iframe the live preview uses. This only manifests in production (behind Caddy); the dev server has no Caddy, which is why the Playwright suite (run against dev) didn't catch it.

## Fix
`X-Frame-Options: SAMEORIGIN` + `Content-Security-Policy: frame-ancestors 'self'`. Same-origin framing (the preview) is allowed; cross-origin clickjacking remains blocked.

## Verification note
Header change only — verify by loading the live-preview toggle on a Caddy-fronted (production/docker-compose prod) instance; the iframe should now render the public site instead of the block error.