### PR TITLE
fix(preview): allow same-origin iframes in CSP frame-src

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -16,8 +16,6 @@
         # admin live-preview pane can embed this instance's own public site.
         # (DENY blocked even same-origin frames, breaking the preview.)
         X-Frame-Options "SAMEORIGIN"
-        # Modern equivalent; 'self' = only this origin may frame us.
-        Content-Security-Policy "frame-ancestors 'self'"
 
         # Control referrer information - safe default per OWASP
         Referrer-Policy "strict-origin-when-cross-origin"
@@ -34,7 +32,7 @@
         # Content Security Policy (enforcing)
         # Restricts script/style/frame sources to mitigate XSS.
         # 'unsafe-inline' kept for scripts/styles due to Svelte's inline injection pattern.
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.loom.com https://w.soundcloud.com https://open.spotify.com https://codepen.io https://www.figma.com; connect-src 'self'; media-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.loom.com https://w.soundcloud.com https://open.spotify.com https://codepen.io https://www.figma.com; connect-src 'self'; media-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'"
 
         # INTENTIONALLY OMITTED:
         # - X-XSS-Protection: Deprecated since 2023, can cause vulnerabilities


### PR DESCRIPTION
## Bug (still occurring after #476)
Live-preview pane shows **"This content is blocked"** on production (`facet.theansible.co`).

## Real cause
The enforcing CSP (`docker/Caddyfile`) had `frame-src https://www.youtube.com … https://www.figma.com` — the oEmbed providers — but **no `'self'`**. So the admin page is forbidden from embedding an iframe of its own public site (`src=/?preview=1`). `X-Frame-Options` was already `SAMEORIGIN`; #476 fixed framing-of-the-page but not the parent's `frame-src`.

## Fix
- `frame-src 'self' …providers` — allows the same-origin preview iframe.
- Fold `frame-ancestors 'self'` into the single CSP header (removed the duplicate CSP #476 added). `X-Frame-Options: SAMEORIGIN` kept as legacy fallback. Cross-origin framing still blocked.

## Verify
Header-only; **takes effect on next prod redeploy** (Caddy reload). Confirmed against live headers: prod CSP `frame-src` was missing `'self'`.