### PR TITLE
feat: testimonial lists — funnel testimonials to facets (#283)

### DIFF
--- a/backend/hooks/testimonials.go
+++ b/backend/hooks/testimonials.go
@@ -24,6 +24,7 @@ func RegisterTestimonialHooks(app *pocketbase.PocketBase, testimonial *services.
 				RecipientEmail string  `json:"recipient_email"`
 				ExpiresAt      *string `json:"expires_at"`
 				MaxUses        int     `json:"max_uses"`
+				List           string  `json:"list"`
 			}
 
 			if err := e.BindBody(&req); err != nil {
@@ -50,6 +51,7 @@ func RegisterTestimonialHooks(app *pocketbase.PocketBase, testimonial *services.
 			record.Set("custom_message", req.CustomMessage)
 			record.Set("recipient_name", req.RecipientName)
 			record.Set("recipient_email", req.RecipientEmail)
+			record.Set("list", req.List)
 			record.Set("is_active", true)
 			record.Set("use_count", 0)
 
@@ -79,6 +81,26 @@ func RegisterTestimonialHooks(app *pocketbase.PocketBase, testimonial *services.
 			})
 		}).Bind(apis.RequireAuth())
 
+		se.Router.GET("/api/testimonials/lists", func(e *core.RequestEvent) error {
+			// Distinct, non-empty list labels across requests and testimonials, so
+			// the admin can offer an autocomplete of lists already in use (#283).
+			seen := map[string]bool{}
+			lists := []string{}
+			for _, table := range []string{"testimonial_requests", "testimonials"} {
+				records, err := app.FindRecordsByFilter(table, "list != ''", "list", 500, 0)
+				if err != nil {
+					continue
+				}
+				for _, r := range records {
+					if l := r.GetString("list"); l != "" && !seen[l] {
+						seen[l] = true
+						lists = append(lists, l)
+					}
+				}
+			}
+			return e.JSON(http.StatusOK, map[string]interface{}{"lists": lists})
+		}).Bind(apis.RequireAuth())
+
 		se.Router.GET("/api/testimonials/requests", func(e *core.RequestEvent) error {
 			records, err := app.FindRecordsByFilter(
 				"testimonial_requests",
@@ -99,6 +121,7 @@ func RegisterTestimonialHooks(app *pocketbase.PocketBase, testimonial *services.
 					"custom_message":  r.GetString("custom_message"),
 					"recipient_name":  r.GetString("recipient_name"),
 					"recipient_email": r.GetString("recipient_email"),
+					"list":            r.GetString("list"),
 					"expires_at":      r.GetDateTime("expires_at"),
 					"max_uses":        r.GetInt("max_uses"),
 					"use_count":       r.GetInt("use_count"),
@@ -301,6 +324,9 @@ func RegisterTestimonialHooks(app *pocketbase.PocketBase, testimonial *services.
 
 			if requestRecord != nil {
 				record.Set("request_id", requestRecord.Id)
+				// Inherit the list the request was created under (#283), so approved
+				// testimonials surface automatically on facets pointed at that list.
+				record.Set("list", requestRecord.GetString("list"))
 
 				requestRecord.Set("use_count", requestRecord.GetInt("use_count")+1)
 				app.Save(requestRecord)

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -681,6 +681,26 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 					}
 				}
 
+				// Testimonials list filter (#283): if this view's testimonials section
+				// points at a list, auto-include approved testimonials from that list
+				// (parity with the homepage facet), rather than explicit per-item picks.
+				if sectionName == "testimonials" {
+					if listVal, ok := section["list"].(string); ok && listVal != "" {
+						recs, err := app.FindRecordsByFilter(
+							collectionName,
+							"status = 'approved' && (visibility = 'public' || visibility = '') && list = {:list}",
+							"-featured,-sort_order",
+							100,
+							0,
+							dbx.Params{"list": listVal},
+						)
+						if err == nil {
+							sectionData[sectionName] = serializeRecordsWithOverrides(app, recs, itemConfig, sectionName)
+						}
+						continue
+					}
+				}
+
 				// Only show items that are explicitly selected
 				// If no items are selected, the section is empty (nothing shown)
 				if ok && len(items) > 0 {

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -1293,13 +1293,21 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 			// Fetch testimonials - only approved and public/empty visibility appear on homepage
 			testimonialsEnabled, testimonialsSelectedItems, testimonialsConfigured := getSectionConfig(settings, "testimonials")
 			if testimonialsEnabled {
+				// Optional per-section list filter (#283): when a list is set, only
+				// approved testimonials collected under it are eligible. Empty => all.
+				testimonialsFilter := "status = 'approved' && (visibility = 'public' || visibility = '')"
+				var testimonialsParams dbx.Params
+				if list := getSectionList(settings, "testimonials"); list != "" {
+					testimonialsFilter += " && list = {:list}"
+					testimonialsParams = dbx.Params{"list": list}
+				}
 				testimonialRecords, err := app.FindRecordsByFilter(
 					getTableName(app, "testimonials"),
-					"status = 'approved' && (visibility = 'public' || visibility = '')",
+					testimonialsFilter,
 					"-featured,-sort_order",
 					100,
 					0,
-					nil,
+					testimonialsParams,
 				)
 				if err == nil {
 					testimonials := serializeRecords(testimonialRecords)

--- a/backend/hooks/view.go
+++ b/backend/hooks/view.go
@@ -1317,9 +1317,10 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 				// approved testimonials collected under it are eligible. Empty => all.
 				testimonialsFilter := "status = 'approved' && (visibility = 'public' || visibility = '')"
 				var testimonialsParams dbx.Params
-				if list := getSectionList(settings, "testimonials"); list != "" {
+				testimonialsList := getSectionList(settings, "testimonials")
+				if testimonialsList != "" {
 					testimonialsFilter += " && list = {:list}"
-					testimonialsParams = dbx.Params{"list": list}
+					testimonialsParams = dbx.Params{"list": testimonialsList}
 				}
 				testimonialRecords, err := app.FindRecordsByFilter(
 					getTableName(app, "testimonials"),
@@ -1331,7 +1332,14 @@ func RegisterViewHooks(app *pocketbase.PocketBase, crypto *services.CryptoServic
 				)
 				if err == nil {
 					testimonials := serializeRecords(testimonialRecords)
-					response["testimonials"] = filterBySelectedItemsWithDefault(testimonials, testimonialsSelectedItems, testimonialsConfigured)
+					// With a list set and no explicit picks, auto-show every approved
+					// testimonial from that list (#283: show automatically once approved).
+					// Once specific items are picked, those drive display (deselect-to-hide).
+					if testimonialsList != "" && len(testimonialsSelectedItems) == 0 {
+						response["testimonials"] = testimonials
+					} else {
+						response["testimonials"] = filterBySelectedItemsWithDefault(testimonials, testimonialsSelectedItems, testimonialsConfigured)
+					}
 				}
 			}
 

--- a/backend/hooks/view_helpers.go
+++ b/backend/hooks/view_helpers.go
@@ -543,3 +543,16 @@ func getSectionConfig(settings *services.SiteSettings, sectionKey string) (enabl
 
 	return config.Enabled, config.Items, true
 }
+
+// getSectionList returns the optional "list" filter configured for a section
+// (currently only testimonials). Empty string ⇒ no list filter (show all).
+func getSectionList(settings *services.SiteSettings, sectionKey string) string {
+	if settings == nil || settings.HomepageSections == nil {
+		return ""
+	}
+	config, exists := settings.HomepageSections[sectionKey]
+	if !exists {
+		return ""
+	}
+	return config.List
+}

--- a/backend/migrations/1779400000_add_testimonial_list.go
+++ b/backend/migrations/1779400000_add_testimonial_list.go
@@ -1,0 +1,54 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Adds a nullable `list` TextField to testimonial_requests and testimonials.
+//
+// A "list" is a lightweight, free-text grouping label (e.g. "Clients",
+// "Conference"). It is set on a testimonial_request when the operator generates
+// a request link, and copied onto the resulting testimonial when it is
+// submitted, so approved testimonials inherit the list they were collected
+// under. A facet's testimonials section can then point at a list and have
+// matching approved testimonials surface automatically (see GitHub #283).
+//
+// Empty `list` ⇒ today's behavior exactly: requests/testimonials carry no list,
+// and a section with no list filter shows everything as before. Existing
+// instances are unaffected until an operator starts using lists.
+func init() {
+	m.Register(func(app core.App) error {
+		for _, name := range []string{"testimonial_requests", "testimonials"} {
+			collection, err := app.FindCollectionByNameOrId(name)
+			if err != nil {
+				// Collection doesn't exist (shouldn't happen post-init); skip.
+				continue
+			}
+			if collection.Fields.GetByName("list") == nil {
+				collection.Fields.Add(&core.TextField{
+					Name: "list",
+					Max:  100,
+				})
+				if err := app.Save(collection); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}, func(app core.App) error {
+		for _, name := range []string{"testimonial_requests", "testimonials"} {
+			collection, err := app.FindCollectionByNameOrId(name)
+			if err != nil {
+				continue
+			}
+			if f := collection.Fields.GetByName("list"); f != nil {
+				collection.Fields.RemoveById(f.GetId())
+				if err := app.Save(collection); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/backend/services/settings.go
+++ b/backend/services/settings.go
@@ -141,6 +141,7 @@ type HomepageSectionConfig struct {
 	Width         string         `json:"width,omitempty"`         // Section width
 	CategoryOrder []string       `json:"categoryOrder,omitempty"` // For skills: custom category order
 	ItemConfig    map[string]any `json:"itemConfig,omitempty"`    // Per-item overrides
+	List          string         `json:"list,omitempty"`          // For testimonials: auto-include approved testimonials in this list
 }
 
 // SiteNavItem represents a navigation button configuration

--- a/frontend/src/components/admin/HomepageSectionManager.svelte
+++ b/frontend/src/components/admin/HomepageSectionManager.svelte
@@ -12,7 +12,7 @@
 	import { onMount, tick } from 'svelte';
 	import { flip } from 'svelte/animate';
 	import type { CustomContent } from '$lib/pocketbase';
-	import { VALID_LAYOUTS, getValidWidthsForLayout, isWidthValidForLayout, type SectionWidth } from '$lib/pocketbase';
+	import { pb, VALID_LAYOUTS, getValidWidthsForLayout, isWidthValidForLayout, type SectionWidth } from '$lib/pocketbase';
 	import AdminTagBadge from '$components/admin/AdminTagBadge.svelte';
 	import SkillsCategoryManager from '$components/admin/SkillsCategoryManager.svelte';
 	import ReorderAnnouncer from '$lib/components/admin/ReorderAnnouncer.svelte';
@@ -36,6 +36,7 @@
 			dndLoaded = true;
 			applySavedItemOrder();
 		}
+		loadTestimonialLists();
 	});
 
 	const flipDurationMs = 200;
@@ -72,6 +73,7 @@
 			disabledCategories?: string[];
 			categoryDisplayModes?: Record<string, string>;
 			featuredId?: string;
+			list?: string;
 		}>;
 		sectionOrder: Array<{ id: string; key: string }>;
 		sectionItems: Record<string, Array<{
@@ -184,6 +186,27 @@
 
 	function updateSectionWidth(sectionKey: string, width: string) {
 		sections[sectionKey].width = width;
+		updateSections();
+	}
+
+	// Distinct testimonial list labels in use, for the section list autocomplete (#283).
+	let existingLists = $state<string[]>([]);
+	async function loadTestimonialLists() {
+		try {
+			const res = await fetch('/api/testimonials/lists', {
+				headers: pb.authStore.isValid ? { Authorization: `Bearer ${pb.authStore.token}` } : undefined
+			});
+			if (res.ok) {
+				const data = await res.json();
+				existingLists = Array.isArray(data.lists) ? data.lists : [];
+			}
+		} catch {
+			/* non-fatal: autocomplete is a convenience */
+		}
+	}
+
+	function updateSectionList(sectionKey: string, list: string) {
+		sections[sectionKey].list = list.trim();
 		updateSections();
 	}
 
@@ -464,6 +487,32 @@
 					<!-- Section Items (expanded) -->
 					{#if sectionConfig.enabled && sectionConfig.expanded && publicItems.length > 0 && !isCustom}
 						<div class="p-3 border-t border-gray-200 dark:border-gray-700">
+							{#if sectionKey === 'testimonials'}
+								<div class="mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-100 dark:border-gray-700">
+									<label for="list-{sectionKey}" class="text-xs font-medium text-gray-500 uppercase mb-1 block">
+										{$t('admin.homepage.testimonial_list_label')}
+									</label>
+									<input
+										id="list-{sectionKey}"
+										type="text"
+										value={sectionConfig.list || ''}
+										list="testimonial-lists-{sectionKey}"
+										placeholder={$t('admin.homepage.testimonial_list_placeholder')}
+										aria-describedby="list-help-{sectionKey}"
+										class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+										onchange={(e) => updateSectionList(sectionKey, e.currentTarget.value)}
+										onclick={(e) => e.stopPropagation()}
+									/>
+									<datalist id="testimonial-lists-{sectionKey}">
+										{#each existingLists as l (l)}
+											<option value={l}></option>
+										{/each}
+									</datalist>
+									<p id="list-help-{sectionKey}" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+										{$t('admin.homepage.testimonial_list_help')}
+									</p>
+								</div>
+							{/if}
 							<!-- Mobile Layout/Width Controls -->
 							<div class="lg:hidden grid grid-cols-1 gap-3 mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-100 dark:border-gray-700">
 								{#if sectionConfig.enabled}

--- a/frontend/src/components/admin/view-editor/ViewSectionManager.svelte
+++ b/frontend/src/components/admin/view-editor/ViewSectionManager.svelte
@@ -8,6 +8,7 @@
 	import SkillsCategoryManager from '$components/admin/SkillsCategoryManager.svelte';
 	import ReorderAnnouncer from '$lib/components/admin/ReorderAnnouncer.svelte';
 	import {
+		pb,
 		OVERRIDABLE_FIELDS,
 		VALID_LAYOUTS,
 		VALID_WIDTHS,
@@ -28,15 +29,32 @@
 	// Shared screen-reader announcer for keyboard + drag reorder (DRY).
 	let reorderAnnouncer = $state<ReorderAnnouncer | undefined>(undefined);
 
+	// Distinct testimonial list labels in use, for the section list autocomplete (#283).
+	let existingLists = $state<string[]>([]);
+	async function loadTestimonialLists() {
+		try {
+			const res = await fetch('/api/testimonials/lists', {
+				headers: pb.authStore.isValid ? { Authorization: `Bearer ${pb.authStore.token}` } : undefined
+			});
+			if (res.ok) {
+				const data = await res.json();
+				existingLists = Array.isArray(data.lists) ? data.lists : [];
+			}
+		} catch {
+			/* non-fatal: autocomplete is a convenience */
+		}
+	}
+
 	// Load DnD functionality when in browser
 	onMount(async () => {
+		loadTestimonialLists();
 		if (browser) {
 			const { dndzone: dnd, TRIGGERS: trig, SHADOW_PLACEHOLDER_ITEM_ID: shadow } = await import('svelte-dnd-action');
 			dndzone = dnd;
 			TRIGGERS = trig;
 			SHADOW_PLACEHOLDER_ITEM_ID = shadow;
 			dndLoaded = true;
-			
+
 			// Apply saved item order after dndzone is loaded
 			// This ensures selected items appear at top in saved order
 			applySavedItemOrder();
@@ -255,6 +273,7 @@
 			disabledCategories?: string[];
 			categoryDisplayModes?: Record<string, string>;
 			featuredId?: string;
+			list?: string;
 		}>;
 		sectionOrder: Array<{ id: string; key: string }>;
 		sectionItems: Record<string, Array<{
@@ -912,6 +931,33 @@
 									</div>
 								{/each}
 							</div>
+							{/if}
+
+							{#if sectionKey === 'testimonials'}
+								<div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+									<label for="view-list-{sectionKey}" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+										{$t('admin.homepage.testimonial_list_label')}
+									</label>
+									<input
+										id="view-list-{sectionKey}"
+										type="text"
+										value={sectionConfig.list || ''}
+										list="view-testimonial-lists"
+										placeholder={$t('admin.homepage.testimonial_list_placeholder')}
+										aria-describedby="view-list-help"
+										class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+										onchange={(e) => {
+											sections['testimonials'].list = e.currentTarget.value.trim() || undefined;
+											updateSections();
+										}}
+									/>
+									<datalist id="view-testimonial-lists">
+										{#each existingLists as l (l)}<option value={l}></option>{/each}
+									</datalist>
+									<p id="view-list-help" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+										{$t('admin.homepage.testimonial_list_help')}
+									</p>
+								</div>
 							{/if}
 
 							{#if sectionKey === 'testimonials' && (sectionConfig.layout === 'featured' || sectionConfig.layout === 'carousel')}

--- a/frontend/src/components/admin/view-editor/ViewSectionManager.svelte
+++ b/frontend/src/components/admin/view-editor/ViewSectionManager.svelte
@@ -942,19 +942,19 @@
 										id="view-list-{sectionKey}"
 										type="text"
 										value={sectionConfig.list || ''}
-										list="view-testimonial-lists"
+										list="view-testimonial-lists-{sectionKey}"
 										placeholder={$t('admin.homepage.testimonial_list_placeholder')}
-										aria-describedby="view-list-help"
+										aria-describedby="view-list-help-{sectionKey}"
 										class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
 										onchange={(e) => {
 											sections['testimonials'].list = e.currentTarget.value.trim() || undefined;
 											updateSections();
 										}}
 									/>
-									<datalist id="view-testimonial-lists">
+									<datalist id="view-testimonial-lists-{sectionKey}">
 										{#each existingLists as l (l)}<option value={l}></option>{/each}
 									</datalist>
-									<p id="view-list-help" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+									<p id="view-list-help-{sectionKey}" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
 										{$t('admin.homepage.testimonial_list_help')}
 									</p>
 								</div>

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -458,6 +458,7 @@ export interface ViewSection {
 	disabledCategories?: string[]; // For skills section: categories to hide entirely
 	categoryDisplayModes?: Record<string, string>; // For skills section: per-category layout overrides
 	featuredId?: string; // For testimonials section: per-view featured testimonial
+	list?: string; // For testimonials section: auto-include approved testimonials from this list (#283)
 }
 
 // Valid width options with labels

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -2331,7 +2331,10 @@
       "custom_content_note": "<strong>Hinweis:</strong> Hier erscheinen nur benutzerdefinierte Inhalte, die als <strong>öffentlich</strong> und <strong>nicht im Entwurf</strong> markiert sind. Um die Sichtbarkeit zu ändern, gehe zu <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Benutzerdefinierte Inhalte</a>.",
       "section_width_title": "Abschnittsbreite",
       "section_layout_title": "Abschnittslayout",
-      "page_title": "Startseite"
+      "page_title": "Startseite",
+      "testimonial_list_label": "Testimonial-Liste",
+      "testimonial_list_placeholder": "z. B. Kunden",
+      "testimonial_list_help": "Zeigt freigegebene Testimonials aus dieser Liste. Leer lassen, um alle anzuzeigen."
     },
     "import": {
       "resume_dropzone_label": "Lebenslauf-Datei-Ablagebereich",

--- a/frontend/src/locales/elvish.json
+++ b/frontend/src/locales/elvish.json
@@ -2331,7 +2331,10 @@
       "custom_content_note": "<strong>Heed:</strong> Only wrought tales marked <strong>open to all</strong> and <strong>not yet a draft</strong> appear here. To change who may behold them, journey to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Wrought Tales</a>.",
       "section_width_title": "Breadth of the chapter",
       "section_layout_title": "Weave of the chapter",
-      "page_title": "Homepage"
+      "page_title": "Homepage",
+      "testimonial_list_label": "Pedthû o thelsignel",
+      "testimonial_list_placeholder": "ned, Mýl",
+      "testimonial_list_help": "Tiro i thelsignel o i thaud hin. Awartho an tirad pân."
     },
     "import": {
       "resume_dropzone_label": "Chronicle scroll waypoint",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2478,7 +2478,10 @@
       "custom_content_note": "<strong>Note:</strong> Only custom content marked as <strong>public</strong> and <strong>not in draft</strong> appears here. To change visibility, go to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Custom Content</a>.",
       "section_width_title": "Section width",
       "section_layout_title": "Section layout",
-      "page_title": "Homepage"
+      "page_title": "Homepage",
+      "testimonial_list_label": "Testimonial list",
+      "testimonial_list_placeholder": "e.g., Clients",
+      "testimonial_list_help": "Show approved testimonials collected under this list. Leave empty to show all."
     },
     "import": {
       "resume_dropzone_label": "Resume file drop zone",

--- a/frontend/src/locales/klingon.json
+++ b/frontend/src/locales/klingon.json
@@ -2331,7 +2331,10 @@
       "custom_content_note": "<strong>Attend:</strong> Only custom records marked <strong>public</strong> and <strong>not in draft</strong> stand here. To change who may see them, advance to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Custom Records</a>.",
       "section_width_title": "Division breadth",
       "section_layout_title": "Division formation",
-      "page_title": "Homepage"
+      "page_title": "Homepage",
+      "testimonial_list_label": "tlhIngan testimonial tetlh",
+      "testimonial_list_placeholder": "jagh:客 (customers)",
+      "testimonial_list_help": "tetlhvam Daq testimonials lutamlu'pu'bogh 'ang. pagh chugh Hoch 'ang."
     },
     "import": {
       "resume_dropzone_label": "Battle record upload zone",

--- a/frontend/src/locales/lolcat.json
+++ b/frontend/src/locales/lolcat.json
@@ -2331,7 +2331,10 @@
       "custom_content_note": "<strong>Note:</strong> Only custom stuffz markd <strong>public</strong> an <strong>not in draft</strong> showz here. To chanj who can haz, go to <a href=\"/admin/custom\" class=\"underline hover:no-underline\">Custom Content</a>.",
       "section_width_title": "Sekshun wideness",
       "section_layout_title": "Sekshun layout",
-      "page_title": "Homepaej"
+      "page_title": "Homepaej",
+      "testimonial_list_label": "Testimonyal lizt",
+      "testimonial_list_placeholder": "liek, Klientz",
+      "testimonial_list_help": "Showz approovd testimonyals frm dis lizt. Leevz empty 2 show all kthx."
     },
     "import": {
       "resume_dropzone_label": "Rezume file drop zone",

--- a/frontend/src/routes/admin/homepage/+page.svelte
+++ b/frontend/src/routes/admin/homepage/+page.svelte
@@ -115,6 +115,8 @@ import { brandName } from '$lib/stores/plan';
 		categoryOrder?: string[];
 		disabledCategories?: string[];
 		categoryDisplayModes?: Record<string, string>;
+		// Testimonials-specific: auto-include approved testimonials from this list (#283)
+		list?: string;
 	}> = $state({});
 
 	// Available items for each section
@@ -295,7 +297,8 @@ import { brandName } from '$lib/stores/plan';
 					// Skills-specific settings
 					categoryOrder: (config as any).categoryOrder || undefined,
 					disabledCategories: (config as any).disabledCategories || undefined,
-					categoryDisplayModes: (config as any).categoryDisplayModes || undefined
+					categoryDisplayModes: (config as any).categoryDisplayModes || undefined,
+					list: (config as any).list || undefined
 				};
 			}
 		}
@@ -619,6 +622,7 @@ import { brandName } from '$lib/stores/plan';
 				categoryOrder?: string[];
 				disabledCategories?: string[];
 				categoryDisplayModes?: Record<string, string>;
+				list?: string;
 			}> = {};
 			for (const [key, config] of Object.entries(sections)) {
 				homepageSections[key] = {
@@ -627,6 +631,10 @@ import { brandName } from '$lib/stores/plan';
 					layout: config.layout,
 					width: config.width
 				};
+				// Testimonials list filter (#283)
+				if (config.list) {
+					homepageSections[key].list = config.list;
+				}
 				// Include skills-specific settings if present
 				if (config.categoryOrder?.length) {
 					homepageSections[key].categoryOrder = config.categoryOrder;

--- a/frontend/src/routes/admin/testimonials/requests/+page.svelte
+++ b/frontend/src/routes/admin/testimonials/requests/+page.svelte
@@ -12,6 +12,7 @@
 		custom_message: string;
 		recipient_name: string;
 		recipient_email: string;
+		list: string;
 		expires_at: string;
 		max_uses: number;
 		use_count: number;
@@ -24,11 +25,14 @@
 	let showForm = $state(false);
 	let saving = $state(false);
 	let newToken = $state<string | null>(null);
+	// Distinct list labels already in use, for the list autocomplete (#283).
+	let existingLists = $state<string[]>([]);
 
 	let label = $state('');
 	let customMessage = $state('');
 	let recipientName = $state('');
 	let recipientEmail = $state('');
+	let listName = $state('');
 	let expiresAt = $state('');
 	let maxUses = $state(0);
 
@@ -38,7 +42,25 @@
 		showForm = false;
 	});
 
-	onMount(loadRequests);
+	onMount(() => {
+		loadRequests();
+		loadLists();
+	});
+
+	async function loadLists() {
+		try {
+			const headers = pb.authStore.isValid
+				? { Authorization: `Bearer ${pb.authStore.token}` }
+				: undefined;
+			const res = await fetch('/api/testimonials/lists', { headers });
+			if (res.ok) {
+				const data = await res.json();
+				existingLists = Array.isArray(data.lists) ? data.lists : [];
+			}
+		} catch {
+			/* non-fatal: autocomplete is a convenience */
+		}
+	}
 
 	async function loadRequests() {
 		loading = true;
@@ -75,6 +97,7 @@
 					custom_message: customMessage,
 					recipient_name: recipientName,
 					recipient_email: recipientEmail,
+					list: listName.trim(),
 					expires_at: expiresAt || null,
 					max_uses: maxUses
 				})
@@ -86,6 +109,7 @@
 				toasts.success('Request link created');
 				resetForm();
 				await loadRequests();
+				await loadLists();
 			} else {
 				toasts.error('Failed to create request link');
 			}
@@ -157,6 +181,7 @@
 		customMessage = '';
 		recipientName = '';
 		recipientEmail = '';
+		listName = '';
 		expiresAt = '';
 		maxUses = 0;
 	}
@@ -261,6 +286,29 @@
 						placeholder="e.g., Project X Clients"
 						class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
 					/>
+				</div>
+				<div>
+					<label for="listName" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+						List (auto-publish to a facet)
+					</label>
+					<input
+						id="listName"
+						type="text"
+						bind:value={listName}
+						list="existing-lists"
+						placeholder="e.g., Clients"
+						aria-describedby="listName-help"
+						class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+					/>
+					<datalist id="existing-lists">
+						{#each existingLists as l (l)}
+							<option value={l}></option>
+						{/each}
+					</datalist>
+					<p id="listName-help" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+						Testimonials from this link join this list. A facet's testimonials section set to the
+						same list publishes them automatically once approved.
+					</p>
 				</div>
 				<div>
 					<label for="customMessage" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/frontend/src/routes/admin/views/[id]/+page.svelte
+++ b/frontend/src/routes/admin/views/[id]/+page.svelte
@@ -129,6 +129,7 @@
 		disabledCategories?: string[];
 		categoryDisplayModes?: Record<string, string>;
 		featuredId?: string;
+		list?: string;
 	}> = $state({});
 
 	// Section order for drag-drop (array of section keys with unique ids for dndzone)
@@ -708,6 +709,7 @@
 					sections[vs.section].disabledCategories = vs.disabledCategories;
 					sections[vs.section].categoryDisplayModes = vs.categoryDisplayModes;
 					sections[vs.section].featuredId = vs.featuredId;
+					sections[vs.section].list = vs.list;
 				}
 			}
 		} else {
@@ -872,6 +874,9 @@
 						}
 					}
 					// Include testimonials section settings if set
+					if (key === 'testimonials' && sectionConfig?.list) {
+						sectionData.list = sectionConfig.list;
+					}
 					if (key === 'testimonials' && sectionConfig?.featuredId) {
 						sectionData.featuredId = sectionConfig.featuredId;
 					}

--- a/frontend/tests/testimonial-lists.spec.ts
+++ b/frontend/tests/testimonial-lists.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { apiBaseURL } from './config';
+import { loginAsAdmin } from './helpers';
+
+// #283 — testimonial lists: a request carries a free-text list; the submitted
+// testimonial inherits it; a facet's testimonials section pointed at that list
+// auto-publishes approved testimonials from it (and hides off-list ones), with
+// the empty-list path unchanged. API-level so it's deterministic under workers=1.
+
+const LIST = 'e2e-clients';
+const OTHER = 'e2e-other';
+
+async function createRequest(request: APIRequestContext, token: string, list: string) {
+	const res = await request.post(`${apiBaseURL}/api/testimonials/requests`, {
+		headers: { Authorization: token },
+		data: { label: `e2e ${list}`, list }
+	});
+	expect(res.ok()).toBeTruthy();
+	return (await res.json()).token as string;
+}
+
+async function submitAndApprove(
+	request: APIRequestContext,
+	token: string,
+	reqToken: string,
+	author: string
+) {
+	const sub = await request.post(`${apiBaseURL}/api/testimonials/submit`, {
+		data: { request_token: reqToken, content: `${author} says great.`, author_name: author }
+	});
+	expect(sub.ok()).toBeTruthy();
+	const id = (await sub.json()).id as string;
+	const ok = await request.post(`${apiBaseURL}/api/testimonials/${id}/approve`, {
+		headers: { Authorization: token }
+	});
+	expect(ok.ok()).toBeTruthy();
+	return id;
+}
+
+async function homepageAuthors(request: APIRequestContext): Promise<string[]> {
+	const res = await request.get(`${apiBaseURL}/api/homepage`);
+	expect(res.ok()).toBeTruthy();
+	const ts = (await res.json()).testimonials ?? [];
+	return ts.map((t: any) => t.author_name as string);
+}
+
+test.describe('Testimonial lists (#283)', () => {
+	let token = '';
+	let savedSections: unknown = null;
+
+	test.beforeAll(async ({ request }) => {
+		token = (await loginAsAdmin(request)).token;
+		// Snapshot site-settings so we can restore the section config afterwards.
+		const cur = await request.get(`${apiBaseURL}/api/site-settings`, {
+			headers: { Authorization: token }
+		});
+		if (cur.ok()) savedSections = (await cur.json()).homepage_sections ?? null;
+	});
+
+	test.afterAll(async ({ request }) => {
+		if (token) {
+			await request.put(`${apiBaseURL}/api/site-settings`, {
+				headers: { Authorization: token },
+				data: { homepage_sections: savedSections ?? {} }
+			});
+		}
+	});
+
+	test('submitted testimonial inherits the request list', async ({ request }) => {
+		const reqToken = await createRequest(request, token, LIST);
+		const sub = await request.post(`${apiBaseURL}/api/testimonials/submit`, {
+			data: { request_token: reqToken, content: 'Inherit check.', author_name: 'Inherit Tester' }
+		});
+		expect(sub.ok()).toBeTruthy();
+		const id = (await sub.json()).id as string;
+		const rec = await request.get(`${apiBaseURL}/api/collections/testimonials/records/${id}`, {
+			headers: { Authorization: token }
+		});
+		expect(rec.ok()).toBeTruthy();
+		expect((await rec.json()).list).toBe(LIST);
+	});
+
+	test('a facet list section auto-publishes approved list testimonials and hides off-list', async ({
+		request
+	}) => {
+		const r1 = await createRequest(request, token, LIST);
+		await submitAndApprove(request, token, r1, 'Ada Listmember');
+		const r2 = await createRequest(request, token, OTHER);
+		await submitAndApprove(request, token, r2, 'Bob Offlist');
+
+		// Point the homepage testimonials section at LIST (no explicit picks).
+		const put = await request.put(`${apiBaseURL}/api/site-settings`, {
+			headers: { Authorization: token },
+			data: {
+				homepage_enabled: true,
+				homepage_section_order: ['testimonials'],
+				homepage_sections: { testimonials: { enabled: true, items: [], list: LIST } }
+			}
+		});
+		expect(put.ok()).toBeTruthy();
+
+		const authors = await homepageAuthors(request);
+		expect(authors).toContain('Ada Listmember'); // auto-shown
+		expect(authors).not.toContain('Bob Offlist'); // off-list hidden
+	});
+
+	test('/api/testimonials/lists returns the distinct lists in use', async ({ request }) => {
+		const res = await request.get(`${apiBaseURL}/api/testimonials/lists`, {
+			headers: { Authorization: token }
+		});
+		expect(res.ok()).toBeTruthy();
+		const lists = (await res.json()).lists as string[];
+		expect(lists).toContain(LIST);
+		expect(lists).toContain(OTHER);
+	});
+});


### PR DESCRIPTION
Implements #283 (self-hosted). A request can be tagged with a free-text **list**; the submitted testimonial inherits it; a facet's testimonials section pointed at that list **auto-publishes** approved testimonials from it (off-list hidden), matching the issue's 'show automatically once approved, then deselect to hide' flow.

## What's included
**Backend**
- Migration: `list` field on `testimonial_requests` + `testimonials`.
- Request create accepts `list`; submission copies it onto the testimonial.
- `GET /api/testimonials/lists` — distinct lists in use (for autocomplete).
- `HomepageSectionConfig.List` + `getSectionList`; homepage facet auto-shows all approved testimonials from the list when no explicit picks (explicit picks → deselect-to-hide). Per-view (`[slug]`) facets get the same auto-include. **No list ⇒ existing behavior, byte-for-byte.**

**Admin UI** (mirrors the existing per-view `featuredId` pattern + datalist autocomplete)
- Request form: `List` input with autocomplete of lists in use.
- Homepage + per-view testimonials section: list selector.
- i18n: 3 keys × 5 locales.

## Certification
- `go build` ✓ · svelte-check **0/0** · i18n **100%**
- **accessibility-lead: PASS** (applied the one required fix — per-instance ids in ViewSectionManager; flagged a *pre-existing, app-wide* input-border 1.4.11 contrast issue to escalate separately at the design-token level — not introduced here).
- Live e2e (SEED_DATA=dev): list inheritance, auto-publish, off-list hidden, lists endpoint — **3/3**; public-api regression **4/4**.

Fixes #283