### PR TITLE
fix(ai): preserve content language on small Ollama models

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module facet
 go 1.25.0
 
 require (
+	github.com/abadojack/whatlanggo v1.0.1
 	github.com/fumiama/go-docx v0.0.0-20250506085032-0c30fd09304b
 	github.com/gen2brain/go-fitz v1.23.7
 	github.com/golang-jwt/jwt/v4 v4.5.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -18,6 +18,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1r
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
+github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/backend/hooks/ai.go
+++ b/backend/hooks/ai.go
@@ -482,10 +482,22 @@ func getProviderFromRecord(record *core.Record, crypto *services.CryptoService) 
 	}, nil
 }
 
+// promptLanguage detects the response language for a prompt from the user's
+// content, falling back to context values when the content is empty.
+func promptLanguage(content string, ctx map[string]string) string {
+	fallback := make([]string, 0, len(ctx))
+	for _, v := range ctx {
+		fallback = append(fallback, v)
+	}
+	return services.DetectContentLanguage(content, strings.Join(fallback, " "))
+}
+
 // buildImprovementPrompt creates a prompt for content improvement based on type and action
 func buildImprovementPrompt(contentType, content string, ctx map[string]string, action string) string {
 	var sb strings.Builder
 
+	lang := promptLanguage(content, ctx)
+	sb.WriteString(services.LanguagePromptDirective(lang))
 	sb.WriteString(`You are helping improve professional portfolio content.
 Be concise, professional, and factual. Do not invent information not provided.
 
@@ -559,6 +571,7 @@ IMPORTANT WRITING STYLE RULES:
 	}
 
 	sb.WriteString("\nRespond with only the improved content, no explanations.")
+	sb.WriteString(services.LanguagePromptReminder(lang))
 
 	return sb.String()
 }
@@ -576,6 +589,8 @@ func getMapKeys(m map[string]any) []string {
 func buildRewritePrompt(content, fieldType string, ctx map[string]string, tone string) string {
 	var sb strings.Builder
 
+	lang := promptLanguage(content, ctx)
+	sb.WriteString(services.LanguagePromptDirective(lang))
 	sb.WriteString(`You are a professional writing assistant helping to rewrite portfolio content.
 
 CRITICAL STYLE RULES - NEVER VIOLATE:
@@ -672,6 +687,7 @@ CRITICAL STYLE RULES - NEVER VIOLATE:
 
 	sb.WriteString(content)
 	sb.WriteString("\n\nReturn ONLY the rewritten content with no explanations, no preamble, no meta-commentary.")
+	sb.WriteString(services.LanguagePromptReminder(lang))
 
 	return sb.String()
 }
@@ -680,6 +696,8 @@ CRITICAL STYLE RULES - NEVER VIOLATE:
 func buildCritiquePrompt(content, fieldType string, ctx map[string]string) string {
 	var sb strings.Builder
 
+	lang := promptLanguage(content, ctx)
+	sb.WriteString(services.LanguagePromptDirective(lang))
 	sb.WriteString(`You are a professional writing coach providing inline feedback on portfolio content.
 
 Your task: Return the EXACT original text with constructive feedback inserted in [square brackets].
@@ -722,6 +740,9 @@ DO NOT:
 	sb.WriteString("Content to critique:\n\n")
 	sb.WriteString(content)
 	sb.WriteString("\n\nReturn the original text with inline [feedback in brackets].")
+	if lang != "" {
+		sb.WriteString(fmt.Sprintf(" Write all bracketed feedback in %s.", lang))
+	}
 
 	return sb.String()
 }

--- a/backend/hooks/ai_prompt_test.go
+++ b/backend/hooks/ai_prompt_test.go
@@ -33,3 +33,33 @@ func TestAIWritingPromptsPreserveSourceLanguage(t *testing.T) {
 		})
 	}
 }
+
+// Small models ignore the passive rules above, so non-English content must
+// additionally pin an explicit directive to the first and last lines.
+func TestAIWritingPromptsPinExplicitLanguageDirective(t *testing.T) {
+	german := "Ich entwickle zuverlässige Softwareplattformen für mittelständische Unternehmen und betreue deren Betrieb."
+
+	prompts := map[string]string{
+		"improve":  buildImprovementPrompt("description", german, nil, "improve"),
+		"rewrite":  buildRewritePrompt(german, "description", nil, "professional"),
+		"critique": buildCritiquePrompt(german, "description", nil),
+	}
+
+	for name, prompt := range prompts {
+		t.Run(name, func(t *testing.T) {
+			if !strings.HasPrefix(prompt, "CRITICAL LANGUAGE REQUIREMENT: The source content is written in German.") {
+				t.Fatalf("prompt must START with the German directive:\n%s", prompt[:200])
+			}
+			tail := prompt[len(prompt)-160:]
+			if !strings.Contains(tail, "German") {
+				t.Fatalf("prompt must END with a German reminder, got tail:\n%s", tail)
+			}
+		})
+	}
+
+	// English content: no directive, prompts unchanged.
+	english := buildImprovementPrompt("description", "I build reliable software platforms for mid-sized companies.", nil, "improve")
+	if strings.Contains(english, "CRITICAL LANGUAGE REQUIREMENT") {
+		t.Fatal("English content must not get a language directive")
+	}
+}

--- a/backend/services/ai.go
+++ b/backend/services/ai.go
@@ -119,6 +119,8 @@ func (a *AIService) ImproveContentWithTokens(ctx context.Context, provider *AIPr
 func (a *AIService) buildPrompt(req *EnrichmentRequest) string {
 	var sb strings.Builder
 
+	lang := DetectContentLanguage(req.Description, req.README, req.Title)
+	sb.WriteString(LanguagePromptDirective(lang))
 	sb.WriteString(`You are helping create a professional portfolio entry for a software project. Generate content that is:
 - Factual and based only on provided information
 - Professional and neutral in tone
@@ -180,6 +182,9 @@ Generate a JSON response with the following structure:
 }
 
 IMPORTANT: Only include information that can be derived from the provided data. Do not invent features, metrics, or claims.`)
+	if lang != "" {
+		sb.WriteString(fmt.Sprintf("\nWrite every JSON string value in %s. Keep the JSON keys in English.", lang))
+	}
 
 	return sb.String()
 }
@@ -371,6 +376,12 @@ func (a *AIService) callOllamaRaw(ctx context.Context, provider *AIProvider, pro
 		"model":  model,
 		"prompt": prompt,
 		"stream": false,
+		// Ollama's default context window (2048-4096 tokens depending on
+		// version) silently truncates longer prompts, dropping the
+		// instructions at the top. Resume and enrichment prompts exceed it.
+		"options": map[string]interface{}{
+			"num_ctx": 8192, // ponytail: covers all current prompt builders; raise if resume profiles outgrow it
+		},
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/backend/services/lang.go
+++ b/backend/services/lang.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/abadojack/whatlanggo"
+)
+
+// minDetectableChars guards against trigram detection misfiring on very short
+// strings (a three-word headline). Below this we fall back to the passive
+// prompt rules instead of risking a wrong explicit directive.
+const minDetectableChars = 12
+
+// DetectContentLanguage returns the English name of the language of the first
+// text with a reliable detection (e.g. "German"), or "" when that text is
+// English, empty, or too short/ambiguous to call.
+//
+// Texts are checked in priority order: the first reliable detection wins, so
+// pass the user's main content first and context fields after it. "" means
+// "no explicit language directive" — English prompts already produce English.
+func DetectContentLanguage(texts ...string) string {
+	for _, t := range texts {
+		t = strings.TrimSpace(t)
+		if len(t) < minDetectableChars {
+			continue
+		}
+		info := whatlanggo.Detect(t)
+		if !info.IsReliable() {
+			continue
+		}
+		if info.Lang == whatlanggo.Eng {
+			return ""
+		}
+		if name, ok := whatlanggo.Langs[info.Lang]; ok {
+			return name
+		}
+	}
+	return ""
+}
+
+// LanguagePromptDirective returns an explicit response-language instruction
+// for the top of an AI prompt, or "" when lang is empty.
+//
+// Small local models (llama3.2 3B via Ollama) ignore passive "detect and keep
+// the language" rules buried mid-prompt and mirror the prompt's dominant
+// language, English. They do follow an explicit named language pinned to the
+// first and last lines, which is why this exists alongside the passive rules.
+func LanguagePromptDirective(lang string) string {
+	if lang == "" {
+		return ""
+	}
+	return fmt.Sprintf("CRITICAL LANGUAGE REQUIREMENT: The source content is written in %s. Write your ENTIRE response in %s. Do NOT translate to English.\n\n", lang, lang)
+}
+
+// LanguagePromptReminder returns a closing-line reinforcement of the response
+// language, or "" when lang is empty. Append it to the prompt's final
+// instruction line: weak models weight the last line the most.
+func LanguagePromptReminder(lang string) string {
+	if lang == "" {
+		return ""
+	}
+	return fmt.Sprintf(" Respond ONLY in %s.", lang)
+}

--- a/backend/services/lang_test.go
+++ b/backend/services/lang_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectContentLanguage(t *testing.T) {
+	german := "Ich entwickle zuverlässige Softwareplattformen für mittelständische Unternehmen und betreue deren Betrieb."
+	english := "I build reliable software platforms for mid-sized companies and run their operations."
+
+	tests := []struct {
+		name  string
+		texts []string
+		want  string
+	}{
+		{"german content", []string{german}, "German"},
+		{"english content", []string{english}, ""},
+		{"empty", []string{""}, ""},
+		{"too short", []string{"Hallo Welt"}, ""},
+		{"content wins over context", []string{german, english}, "German"},
+		{"english content stops fallback", []string{english, german}, ""},
+		{"falls back to context when content empty", []string{"", german}, "German"},
+		{"french", []string{"Je développe des plateformes logicielles fiables pour les entreprises de taille moyenne."}, "French"},
+		{"spanish", []string{"Desarrollo plataformas de software confiables para empresas medianas y gestiono sus operaciones."}, "Spanish"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectContentLanguage(tt.texts...); got != tt.want {
+				t.Fatalf("DetectContentLanguage(%q) = %q, want %q", tt.texts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLanguagePromptHelpers(t *testing.T) {
+	if LanguagePromptDirective("") != "" || LanguagePromptReminder("") != "" {
+		t.Fatal("empty lang must produce empty directive and reminder")
+	}
+	d := LanguagePromptDirective("German")
+	if !strings.Contains(d, "German") || !strings.Contains(d, "ENTIRE response") {
+		t.Fatalf("directive malformed: %q", d)
+	}
+	if r := LanguagePromptReminder("German"); r != " Respond ONLY in German." {
+		t.Fatalf("reminder malformed: %q", r)
+	}
+}

--- a/backend/services/resume.go
+++ b/backend/services/resume.go
@@ -82,6 +82,13 @@ func (r *ResumeService) GenerateResume(
 func (r *ResumeService) buildResumePrompt(viewData *ViewData, config *GenerationConfig) string {
 	var sb strings.Builder
 
+	var profileSummary, profileHeadline string
+	if viewData.Profile != nil {
+		profileSummary, _ = viewData.Profile["summary"].(string)
+		profileHeadline, _ = viewData.Profile["headline"].(string)
+	}
+	lang := DetectContentLanguage(viewData.HeroSummary, profileSummary, viewData.HeroHeadline, profileHeadline)
+	sb.WriteString(LanguagePromptDirective(lang))
 	sb.WriteString(`You are an expert resume writer. Generate a professional resume in clean Markdown format.
 
 IMPORTANT WRITING STYLE RULES:
@@ -167,6 +174,9 @@ OUTPUT REQUIREMENTS:
 9. For Contact Info: list email, phone, location, LinkedIn, etc. as plain text on one line separated by pipes (|)
 
 Return ONLY the Markdown content for the resume.`)
+	if lang != "" {
+		sb.WriteString(fmt.Sprintf(" Write the entire resume, including section headers, in %s.", lang))
+	}
 
 	return sb.String()
 }

--- a/backend/services/resume_parser.go
+++ b/backend/services/resume_parser.go
@@ -336,7 +336,11 @@ func (rp *ResumeParser) ParseResume(ctx context.Context, provider *AIProvider, r
 
 // buildParsingPrompt creates the AI prompt for resume parsing
 func (rp *ResumeParser) buildParsingPrompt(resumeText string) string {
-	return fmt.Sprintf(`You are an expert resume parser. Extract structured data from the resume text below.
+	langNote := ""
+	if lang := DetectContentLanguage(resumeText); lang != "" {
+		langNote = fmt.Sprintf("CRITICAL: The resume is written in %s. Keep every extracted text value (summary, descriptions, bullets) in %s. Do NOT translate to English.\n\n", lang, lang)
+	}
+	return langNote + fmt.Sprintf(`You are an expert resume parser. Extract structured data from the resume text below.
 
 Resume text:
 """


### PR DESCRIPTION
## Summary

Fixes German (and any non-English) content being translated to English by AI features when using small Ollama models (llama3.2) — reported by a self-hosted user after #483.

## Root cause

#483 added passive rules ("detect the primary language... keep the response in that language") buried mid-prompt. Anthropic/OpenAI models follow them; llama3.2 (3B) mirrors the prompt's dominant language — English — and translates. Only Anthropic was tested, so the bug shipped. Detection was delegated to the model; it belongs in code.

Second latent bug: no `num_ctx` was set for Ollama. The default (2048–4096) silently truncates long prompts from the top, dropping all instructions on the resume/enrich paths.

## Fix

- `services/lang.go`: `DetectContentLanguage` — deterministic Go-side detection (whatlanggo, pure Go, no data files). Returns "" for English/short/ambiguous content, so English users see zero prompt change.
- Explicit named-language directive pinned to the **first and last line** of every AI prompt ("Write your ENTIRE response in German" / "Respond ONLY in German") — small models weight first/last lines far more than mid-prompt rules.
- Applied to all six AI paths: improve, rewrite, critique, project enrich (had no language rules), resume generation (had none), resume upload parsing (had none).
- Ollama requests now set `options.num_ctx: 8192`.

## Verification (real model A/B)

Ran the exact shipped prompt vs the fixed prompt against **llama3.2:3b** (the reporter's model) via Ollama, German portfolio content, production settings:

| Run | Old prompt (#483) | New prompt |
|-----|-------------------|------------|
| 1 | English | German |
| 2 | English | German |
| 3 | English | German |

Old prompt also invented fake metrics ("over 20 clients, 99.5% uptime") while translating.

## Tests

- `services/lang_test.go`: detection (German/French/Spanish/English/short/empty/priority-order) + directive helpers
- `hooks/ai_prompt_test.go`: German content → directive present as first line and reminder in the tail; English content → prompts unchanged
- Full `hooks` + `services` suites pass; `go build ./...` clean

## Notes

- Known gap: "generate" with empty content and only a short context word (e.g. lone "Softwareentwickler") is below the detection floor → falls back to passive rules.
- Same fix ported to the cloud repo (facetcloud PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
