### PR TITLE
[codex] fix Ollama model sync

### DIFF
--- a/frontend/src/routes/admin/settings/integrations/+page.svelte
+++ b/frontend/src/routes/admin/settings/integrations/+page.svelte
@@ -20,7 +20,7 @@
 		type: 'openai' as 'openai' | 'anthropic' | 'ollama' | 'custom',
 		api_key: '',
 		base_url: '',
-		model: '',
+		model: 'gpt-4o-mini',
 		is_active: true,
 		is_default: false
 	});
@@ -44,6 +44,7 @@
 	let fetchedModels = $state<string[]>([]);
 	let fetchingModels = $state(false);
 	let modelFetchError = $state('');
+	let lastProviderType: typeof newProvider.type = 'openai';
 
 	// Computed: use fetched models if available, otherwise fallback
 	let modelOptions = $derived.by(() => {
@@ -105,17 +106,15 @@
 		}
 	}
 
-	// Reset model and fetch when provider type changes
+	// Reset model options only when provider type changes.
 	run(() => {
-		if (newProvider.type) {
-			const options = fallbackModelOptions[newProvider.type] || [];
-			if (!options.includes(newProvider.model)) {
-				newProvider.model = defaultModels[newProvider.type] || '';
-			}
-			// Reset fetched models when type changes
-			fetchedModels = [];
-			modelFetchError = '';
-		}
+		const type = newProvider.type;
+		if (type === lastProviderType) return;
+
+		lastProviderType = type;
+		newProvider.model = defaultModels[type] || '';
+		fetchedModels = [];
+		modelFetchError = '';
 	});
 
 	onMount(async () => {
@@ -158,7 +157,7 @@
 				type: 'openai',
 				api_key: '',
 				base_url: '',
-				model: '',
+				model: 'gpt-4o-mini',
 				is_active: true,
 				is_default: false
 			};


### PR DESCRIPTION
## Summary
- keep fetched model options available after clicking sync
- reset model options only when the provider type actually changes
- initialize the add-provider form with the OpenAI default model

## Root Cause
The integrations page reset `fetchedModels` inside a reactive block that also read `newProvider.model`. After the sync response selected or exposed an Ollama model outside the fallback list, that same block ran again and cleared the fetched list, so the UI fell back to the five hardcoded Ollama defaults.

## Validation
- `cd frontend && npm run check`