### PR TITLE
[codex] localize formatted month names

### DIFF
--- a/frontend/src/components/admin/view-editor/ViewSectionManager.svelte
+++ b/frontend/src/components/admin/view-editor/ViewSectionManager.svelte
@@ -18,7 +18,7 @@
 		type SectionWidth,
 		type ItemConfig
 	} from '$lib/pocketbase';
-	import { t } from 'svelte-i18n';
+	import { locale, t } from 'svelte-i18n';
 
 	// Import DnD safely - only in browser
 	let dndzone: any = $state((node: HTMLElement, params?: any) => ({ destroy: () => {} }));
@@ -177,7 +177,7 @@
 		try {
 			const date = new Date(dateStr);
 			if (isNaN(date.getTime())) return dateStr;
-			return new Intl.DateTimeFormat('en', { month: 'short', year: 'numeric' }).format(date);
+			return new Intl.DateTimeFormat($locale || 'en', { month: 'short', year: 'numeric' }).format(date);
 		} catch {
 			return dateStr;
 		}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,5 +1,7 @@
 import { marked } from 'marked';
 import DOMPurify from 'isomorphic-dompurify';
+import { get } from 'svelte/store';
+import { locale } from 'svelte-i18n';
 
 type EmbedMatch = {
 	provider: string;
@@ -67,16 +69,21 @@ DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
 	}
 });
 
+function currentLocale(): string {
+	return get(locale) || 'en';
+}
+
 export function formatDate(dateString: string | undefined, options?: Intl.DateTimeFormatOptions): string {
 	if (!dateString) return '';
 	if (/^\d{4}$/.test(dateString)) return dateString;
+	const formatOptions = options || { month: 'short', year: 'numeric' };
 	if (/^\d{4}-\d{2}$/.test(dateString)) {
 		const [year, month] = dateString.split('-');
 		const date = new Date(parseInt(year), parseInt(month) - 1);
-		return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+		return date.toLocaleDateString(currentLocale(), formatOptions);
 	}
 	const date = new Date(dateString);
-	return date.toLocaleDateString('en-US', options || { month: 'short', year: 'numeric' });
+	return date.toLocaleDateString(currentLocale(), formatOptions);
 }
 
 export function formatDateRange(startDate?: string, endDate?: string, presentText: string = 'Present'): string {


### PR DESCRIPTION
## Summary
- make shared `formatDate` use the active `svelte-i18n` locale instead of hardcoded `en-US`
- localize the experience/education date preview in the view section manager
- leave existing date formats intact while letting `Intl` supply localized month names

## Root Cause
Experience and education date ranges were already translating the "Present" label, but the month formatter was hardcoded to English. German pages therefore still rendered month names like `Mar` and `Dec`.

## Validation
- `cd frontend && npm run check`